### PR TITLE
Fix nvport library and examples work with changes

### DIFF
--- a/bessctl/conf/samples/sms.bess
+++ b/bessctl/conf/samples/sms.bess
@@ -1,4 +1,4 @@
-p = Port(driver = 'NativeVport')
+p = Port(driver = 'ZeroCopyVPort')
 
 Source() -> Timestamp() -> PortOut(port=p)
 PortInc(port=p) -> Measure() -> Sink()

--- a/bessctl/conf/samples/sms.bess
+++ b/bessctl/conf/samples/sms.bess
@@ -1,4 +1,4 @@
 p = Port(driver = 'NativeVport')
 
-Source() -> TimeStamp() -> PortOut(port=p)
+Source() -> Timestamp() -> PortOut(port=p)
 PortInc(port=p) -> Measure() -> Sink()

--- a/core/drivers/vport_zc.c
+++ b/core/drivers/vport_zc.c
@@ -212,7 +212,8 @@ vport_recv_pkts(struct port *p, queue_t qid, snb_array_t pkts, int cnt)
 }
 
 static const struct driver vport = {
-	.name 		= "NativeVport",
+	.name 		= "ZeroCopyVPort",
+	.def_port_name	= "zcvport",
 	.priv_size	= sizeof(struct vport_priv),
 	.init_port 	= vport_init_port,
 	.recv_pkts 	= vport_recv_pkts,

--- a/core/nvport/Makefile
+++ b/core/nvport/Makefile
@@ -1,18 +1,34 @@
-ifneq ($(wildcard $(RTE_SDK)/$(RTE_TARGET)*),)
-	DPDK_INC_DIR = $(RTE_SDK)/$(RTE_TARGET)/include
-	DPDK_LIB_DIR = $(RTE_SDK)/$(RTE_TARGET)/lib
-else
-	DPDK_INC_DIR = $(RTE_SDK)/build/include
-	DPDK_LIB_DIR = $(RTE_SDK)/build/lib
+CC = gcc
+DPDK_LIB = dpdk
+
+ifndef RTE_SDK
+    RTE_SDK = $(abspath ../../deps/dpdk-2.2.0)
 endif
 
-DPDK_LIBS = -L$(DPDK_LIB_DIR)
-DPDK_LIBS += -lintel_dpdk
+ifndef RTE_TARGET
+    RTE_TARGET = x86_64-native-linuxapp-gcc
+endif
 
-LIBS = -ldl -lpthread -lm
+ifneq ($(wildcard $(RTE_SDK)/$(RTE_TARGET)/*),)
+    DPDK_INC_DIR = $(RTE_SDK)/$(RTE_TARGET)/include
+    DPDK_LIB_DIR = $(RTE_SDK)/$(RTE_TARGET)/lib
+else ifneq ($(wildcard $(RTE_SDK)/build/*),)
+    # if the user didn't do "make install" for DPDK
+    DPDK_INC_DIR = $(RTE_SDK)/build/include
+    DPDK_LIB_DIR = $(RTE_SDK)/build/lib
+else
+    $(error DPDK is not available. \
+            Make sure $(abspath $(RTE_SDK)) is available and built)
+endif
+
+LIBS += -ldl -lpthread -lm
+LIBS += -L$(DPDK_LIB_DIR) -Wl,--whole-archive -l$(DPDK_LIB) \
+	-Wl,--no-whole-archive -lm -lpthread -ldl -lpcap
 
 CC = gcc
-CFLAGS = -std=gnu99 -Wall -Werror -march=native -Wno-unused-function -Wno-unused-but-set-variable -I../sndrv -fPIC -g3 -O3 
+CFLAGS += -std=gnu99 -Wall -Werror -march=native \
+	  -Wno-unused-function -Wno-unused-but-set-variable \
+	  -I../kmod -fPIC -g3 -O3 
 
 all: libsn.so libsn.a
 
@@ -20,7 +36,7 @@ clean:
 	rm -f *.o *.a *.so
 
 sn.o: sn.c sn.h
-	$(CC) $(CFLAGS) -I$(DPDK_INC_DIR) -c $< -o $@ 
+	$(CC) $(CFLAGS) -I$(DPDK_INC_DIR) -c $< -o $@ $(LIBS) 
 
 libsn.a: sn.o
 	ar rcs $@ $^

--- a/core/nvport/native_apps/Makefile
+++ b/core/nvport/native_apps/Makefile
@@ -1,20 +1,34 @@
-ifneq ($(wildcard $(RTE_SDK)/$(RTE_TARGET)*),)
-	DPDK_INC_DIR = $(RTE_SDK)/$(RTE_TARGET)/include
-	DPDK_LIB_DIR = $(RTE_SDK)/$(RTE_TARGET)/lib
-else
-	DPDK_INC_DIR = $(RTE_SDK)/build/include
-	DPDK_LIB_DIR = $(RTE_SDK)/build/lib
+DPDK_LIB = dpdk
+
+ifndef RTE_SDK
+    RTE_SDK = $(abspath ../../../deps/dpdk-2.2.0)
 endif
 
-DPDK_LIBS = -L$(DPDK_LIB_DIR)
-DPDK_LIBS += -lintel_dpdk
+ifndef RTE_TARGET
+    RTE_TARGET = x86_64-native-linuxapp-gcc
+endif
+
+ifneq ($(wildcard $(RTE_SDK)/$(RTE_TARGET)/*),)
+    DPDK_INC_DIR = $(RTE_SDK)/$(RTE_TARGET)/include
+    DPDK_LIB_DIR = $(RTE_SDK)/$(RTE_TARGET)/lib
+else ifneq ($(wildcard $(RTE_SDK)/build/*),)
+    # if the user didn't do "make install" for DPDK
+    DPDK_INC_DIR = $(RTE_SDK)/build/include
+    DPDK_LIB_DIR = $(RTE_SDK)/build/lib
+else
+    $(error DPDK is not available. \
+            Make sure $(abspath $(RTE_SDK)) is available and built)
+endif
 
 LIBS = -ldl -lpthread -lm
+LIBS += -L$(DPDK_LIB_DIR) -Wl,--whole-archive -l$(DPDK_LIB) \
+	-Wl,--no-whole-archive -lz -lm -lpthread -ldl -lpcap
 
-SN_LIBS = -L../ -lsn
+SN_LIBS = -L../ -lsn -Wl,-rpath ../
 
 CC = gcc
-CFLAGS = -std=gnu99 -Wall -Werror -march=native -Wno-unused-function -Wno-unused-but-set-variable -I../sndrv -I../ -fPIC -g3 -O3 
+CFLAGS = -std=gnu99 -Wall -Werror -march=native -Wno-unused-function \
+	 -Wno-unused-but-set-variable -I../sndrv -I../ -fPIC -g3 -O3 
 
 all: sample sink source fastforward sourcesink alloc_test iso_test 
 clean:
@@ -24,40 +38,40 @@ sample.o: sample.c
 	$(CC) $(CFLAGS) -c $< -o $@ $(CFLAGS) -I$(DPDK_INC_DIR) 
 
 sample: sample.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)
 
 sourcesink.o: sourcesink.c
 	$(CC) $(CFLAGS) -c $< -o $@ $(CFLAGS) -I$(DPDK_INC_DIR)
 
 sourcesink: sourcesink.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)
 
 sink.o: sink.c 
 	$(CC) $(CFLAGS) -c $< -o $@ -I$(DPDK_INC_DIR)
 
 sink: sink.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)
 
 source.o: source.c 
 	$(CC) $(CFLAGS) -c $< -o $@ -I$(DPDK_INC_DIR)
 
 source: source.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)
 
 fastforward.o: fastforward.c 
 	$(CC) $(CFLAGS) -c $< -o $@ -I$(DPDK_INC_DIR)
 
 fastforward: fastforward.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)
 
 alloc_test.o: alloc_test.c 
 	$(CC) $(CFLAGS) -c $< -o $@ -I$(DPDK_INC_DIR)
 
 alloc_test: alloc_test.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)
 
 iso_test.o: iso_test.c 
 	$(CC) $(CFLAGS) -c $< -o $@ -I$(DPDK_INC_DIR)
 
 iso_test: iso_test.o 
-	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) $(DPDK_LIBS) -Wl,--no-whole-archive $(LIBS)
+	$(CC) $< -o $@ -L. -Wl,--whole-archive $(SN_LIBS) -Wl,--no-whole-archive $(LIBS)

--- a/core/nvport/sn.c
+++ b/core/nvport/sn.c
@@ -15,7 +15,7 @@
 #include <rte_ether.h>
 #include <rte_byteorder.h>
 
-#include "../sndrv/sn_common.h"
+#include "../kmod/sn_common.h"
 
 #include "sn.h"
 

--- a/core/nvport/sn.h
+++ b/core/nvport/sn.h
@@ -6,9 +6,9 @@
 #include <rte_config.h>
 #include <rte_mbuf.h>
 
-#include "../sndrv/sn_common.h"
-#include "../sndrv/llring.h"
-#include "../softnic/snbuf.h"
+#include "../kmod/sn_common.h"
+#include "../kmod/llring.h"
+#include "../snbuf.h"
 
 #define IFNAMSIZ	16
 #define ETH_ALEN	6
@@ -216,7 +216,7 @@ static inline void __sn_snb_alloc_bulk(snb_array_t snbs, int cnt)
 		*((__m128 *)&snb->mbuf.packet_type) = _mm_setzero_ps();
 #else
 		rte_mbuf_refcnt_set(&snb->mbuf, 1);
-		rte_pktmbuf_reset(&snbs->mbuf);
+		rte_pktmbuf_reset(&snb->mbuf);
 #endif
 	}
 }


### PR DESCRIPTION
This also gets rid of the need to place libsn in /usr/lib and no longer depends
on having a dynamically linked dpdk build