### PR TITLE
Add support for DPDK virtual PMDs

### DIFF
--- a/core/drivers/pmd.c
+++ b/core/drivers/pmd.c
@@ -63,8 +63,8 @@ static int pmd_init_driver(struct driver *driver)
 		memset(&dev_info, 0, sizeof(dev_info));
 		rte_eth_dev_info_get(i, &dev_info);
 
-		log_info("DPDK port_id %d (%s)   RXQ %hu TXQ %hu  ", 
-				i, 
+		log_info("DPDK port_id %d (%s)   RXQ %hu TXQ %hu  ",
+				i,
 				dev_info.driver_name,
 				dev_info.max_rx_queues,
 				dev_info.max_tx_queues);
@@ -85,7 +85,7 @@ static int pmd_init_driver(struct driver *driver)
 	return 0;
 }
 
-static struct snobj *find_dpdk_port(struct snobj *conf, 
+static struct snobj *find_dpdk_port(struct snobj *conf,
 		dpdk_port_t *ret_port_id)
 {
 	struct snobj *t;
@@ -101,7 +101,7 @@ static struct snobj *find_dpdk_port(struct snobj *conf,
 		if (port_id < 0 || port_id >= RTE_MAX_ETHPORTS)
 			return snobj_err(EINVAL, "Invalid port id %d",
 					port_id);
-		
+
 		if (!rte_eth_devices[port_id].attached)
 			return snobj_err(ENODEV, "Port id %d is not available",
 					port_id);
@@ -123,7 +123,7 @@ pci_format_err:
 					"dddd:bb:dd.ff or bb:dd.ff");
 		}
 
-		if (eal_parse_pci_DomBDF(bdf, &addr) != 0 && 
+		if (eal_parse_pci_DomBDF(bdf, &addr) != 0 &&
 				eal_parse_pci_BDF(bdf, &addr) != 0)
 			goto pci_format_err;
 
@@ -134,7 +134,7 @@ pci_format_err:
 			if (!rte_eth_devices[i].pci_dev)
 				continue;
 
-			if (rte_eal_compare_pci_addr(&addr, 
+			if (rte_eal_compare_pci_addr(&addr,
 					&rte_eth_devices[i].pci_dev->addr))
 				continue;
 
@@ -161,8 +161,18 @@ pci_format_err:
 		}
 	}
 
+	if (port_id == DPDK_PORT_UNKNOWN &&
+			(t = snobj_eval(conf, "vdev")) != NULL) {
+		const char *name = snobj_str_get(t);
+		int ret = rte_eth_dev_attach(name, &port_id);
+
+		if (ret < 0)
+			return snobj_err(ENODEV, "Cannot attach to virtual" \
+					"device %s", name);
+	}
+
 	if (port_id == DPDK_PORT_UNKNOWN)
-		return snobj_err(EINVAL, "Either 'port_id' or 'pci' field " \
+		return snobj_err(EINVAL, "'port_id', 'pci', or 'vdev' field " \
 				"must be specified");
 
 	*ret_port_id = port_id;
@@ -187,7 +197,7 @@ static struct snobj *pmd_init_port(struct port *p, struct snobj *conf)
 	int num_rxq = p->num_queues[PACKET_DIR_INC];
 
 	struct snobj *err;
-	
+
 	int ret;
 
 	int i;
@@ -209,12 +219,12 @@ static struct snobj *pmd_init_port(struct port *p, struct snobj *conf)
 
 	eth_txconf = dev_info.default_txconf;
 	eth_txconf.txq_flags = ETH_TXQ_FLAGS_NOVLANOFFL |
-			ETH_TXQ_FLAGS_NOMULTSEGS * (1 - SN_TSO_SG) | 
+			ETH_TXQ_FLAGS_NOMULTSEGS * (1 - SN_TSO_SG) |
 			ETH_TXQ_FLAGS_NOXSUMS * (1 - SN_HW_TXCSUM);
 
 	ret = rte_eth_dev_configure(port_id,
 				    num_rxq, num_txq, &eth_conf);
-	if (ret != 0) 
+	if (ret != 0)
 		return snobj_err(-ret, "rte_eth_dev_configure() failed");
 
 	rte_eth_promiscuous_enable(port_id);
@@ -226,12 +236,12 @@ static struct snobj *pmd_init_port(struct port *p, struct snobj *conf)
 		if (sid < 0 || sid > RTE_MAX_NUMA_NODES)
 			sid = 0;
 
-		ret = rte_eth_rx_queue_setup(port_id, i, 
+		ret = rte_eth_rx_queue_setup(port_id, i,
 					     p->queue_size[PACKET_DIR_INC],
 					     sid, &eth_rxconf,
 					     get_pframe_pool_socket(sid));
-		if (ret != 0) 
-			return snobj_err(-ret, 
+		if (ret != 0)
+			return snobj_err(-ret,
 					"rte_eth_rx_queue_setup() failed");
 	}
 
@@ -241,14 +251,14 @@ static struct snobj *pmd_init_port(struct port *p, struct snobj *conf)
 		ret = rte_eth_tx_queue_setup(port_id, i,
 					     p->queue_size[PACKET_DIR_OUT],
 					     sid, &eth_txconf);
-		if (ret != 0) 
+		if (ret != 0)
 			return snobj_err(-ret,
 					"rte_eth_tx_queue_setup() failed");
 	}
 
 #if 0
 	ret = rte_eth_dev_flow_ctrl_get(port_id, &fc_conf);
-	if (ret != 0) 
+	if (ret != 0)
 		return snobj_err(-ret, "rte_eth_dev_flow_ctrl_get() failed");
 
 	log_info("port %d high %u low %u ptime %hu send_xon %hu mode %u cfwd %hhu autoneg %hhu\n",
@@ -259,7 +269,7 @@ static struct snobj *pmd_init_port(struct port *p, struct snobj *conf)
 #endif
 
 	ret = rte_eth_dev_start(port_id);
-	if (ret != 0) 
+	if (ret != 0)
 		return snobj_err(-ret, "rte_eth_dev_start() failed");
 
 	priv->dpdk_port_id = port_id;
@@ -304,9 +314,9 @@ static void pmd_collect_stats(struct port *p, int reset)
 	       "tx_pause_xon %lu rx_pause_xon %lu "
 	       "tx_pause_xoff %lu rx_pause_xoff %lu\n",
 			priv->dpdk_port_id,
-			stats.ipackets, stats.opackets, 
+			stats.ipackets, stats.opackets,
 			stats.ibytes, stats.obytes,
-			stats.imissed, stats.ibadcrc, stats.ibadlen, 
+			stats.imissed, stats.ibadcrc, stats.ibadlen,
 			stats.ierrors, stats.oerrors, stats.imcasts,
 			stats.rx_nombuf, stats.fdirmatch, stats.fdirmiss,
 			stats.tx_pause_xon, stats.rx_pause_xon,
@@ -317,15 +327,15 @@ static void pmd_collect_stats(struct port *p, int reset)
 
 	dir = PACKET_DIR_INC;
 	for (qid = 0; qid < p->num_queues[dir]; qid++) {
-		p->queue_stats[dir][qid].packets = stats.q_ipackets[qid]; 
-		p->queue_stats[dir][qid].bytes   = stats.q_ibytes[qid]; 
-		p->queue_stats[dir][qid].dropped = stats.q_errors[qid]; 
+		p->queue_stats[dir][qid].packets = stats.q_ipackets[qid];
+		p->queue_stats[dir][qid].bytes   = stats.q_ibytes[qid];
+		p->queue_stats[dir][qid].dropped = stats.q_errors[qid];
 	}
 
 	dir = PACKET_DIR_OUT;
 	for (qid = 0; qid < p->num_queues[dir]; qid++) {
-		p->queue_stats[dir][qid].packets = stats.q_opackets[qid]; 
-		p->queue_stats[dir][qid].bytes   = stats.q_obytes[qid]; 
+		p->queue_stats[dir][qid].packets = stats.q_opackets[qid];
+		p->queue_stats[dir][qid].bytes   = stats.q_obytes[qid];
 	}
 }
 
@@ -333,7 +343,7 @@ static int pmd_recv_pkts(struct port *p, queue_t qid, snb_array_t pkts, int cnt)
 {
 	struct pmd_priv *priv = get_port_priv(p);
 
-	return rte_eth_rx_burst(priv->dpdk_port_id, qid, 
+	return rte_eth_rx_burst(priv->dpdk_port_id, qid,
 			(struct rte_mbuf **)pkts, cnt);
 }
 
@@ -341,7 +351,7 @@ static int pmd_send_pkts(struct port *p, queue_t qid, snb_array_t pkts, int cnt)
 {
 	struct pmd_priv *priv = get_port_priv(p);
 
-	int sent = rte_eth_tx_burst(priv->dpdk_port_id, qid, 
+	int sent = rte_eth_tx_burst(priv->dpdk_port_id, qid,
 			(struct rte_mbuf **)pkts, cnt);
 
 	p->port_stats[PACKET_DIR_OUT].dropped += (cnt - sent);


### PR DESCRIPTION
Example usage from bessctl:

add port PMD eth_bond0 \
    vdev='eth_bond0,mode=0,socket_id=0,slave=0000:03:00.0,slave=0000:03:00.1'

add port PMD eth_ring0 \
    vdev='eth_ring0,nodeaction=r0:0:CREATE'