### PR TITLE
build script should not return 0 when it fails

### DIFF
--- a/build.py
+++ b/build.py
@@ -232,6 +232,7 @@ def build_kmod():
         cmd('make -C core/kmod')
     except SystemExit:
         print >> sys.stderr, '*** module build has failed.'
+        raise
 
 def build_all():
     setup_dpdk()


### PR DESCRIPTION
This minor fix is useful for continuous integration.