### PR TITLE
Modularize driver port

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -44,7 +44,7 @@ endif
 
 -include extra.mk
 
-SRCS = $(filter-out time_test.cc, $(wildcard *.cc utils/*.cc modules/*.cc drivers/*.cc oldtests/*.cc))
+SRCS = $(filter-out $(wildcard *_test.cc), $(wildcard *.cc utils/*.cc modules/*.cc drivers/*.cc oldtests/*.cc))
 OBJS = $(patsubst %.cc,%.o, $(filter %.cc, $(SRCS)))
 HEADERS = $(wildcard *.h utils/*.h modules/*.h drivers/*.h oldtests/*.h)
 EXEC = bessd
@@ -115,7 +115,7 @@ cscope:
 	@rm -f cscope.files
 
 # Test rules
-TESTS = time_test
+TESTS = time_test port_test
 
 tests: $(TESTS)
 
@@ -145,6 +145,13 @@ time_test.o : time_test.cc time.h $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c time_test.cc
 
 time_test : time.o time_test.o gtest_main.a
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -pthread $^ -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -pthread $^ -o $@ $(LDFLAGS) $(LIBS)
+
+# Port test build rules.
+port_test.o : port_test.cc port.h $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c port_test.cc
+
+port_test : port.o port_test.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -pthread $^ -o $@ $(LDFLAGS) $(LIBS)
 
 endif

--- a/core/common.h
+++ b/core/common.h
@@ -101,4 +101,25 @@ static inline void memcpy_sloppy(void *__restrict__ dst,
   }
 }
 
+// Put this in the declarations for a class to be uncopyable.
+#define DISALLOW_COPY(TypeName) \
+  TypeName(const TypeName&) = delete
+// Put this in the declarations for a class to be unassignable.
+#define DISALLOW_ASSIGN(TypeName) \
+  void operator=(const TypeName&) = delete
+// A macro to disallow the copy constructor and operator= functions.
+// This should be used in the private: declarations for a class.
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  TypeName(const TypeName&) = delete;      \
+  void operator=(const TypeName&) = delete
+// A macro to disallow all the implicit constructors, namely the
+// default constructor, copy constructor and operator= functions.
+//
+// This should be used in the private: declarations for a class
+// that wants to prevent anyone from instantiating it. This is
+// especially useful for classes containing only static methods.
+#define DISALLOW_IMPLICIT_CONSTRUCTORS(TypeName) \
+  TypeName() = delete;                           \
+  DISALLOW_COPY_AND_ASSIGN(TypeName)
+
 #endif

--- a/core/common.h
+++ b/core/common.h
@@ -122,4 +122,16 @@ static inline void memcpy_sloppy(void *__restrict__ dst,
   TypeName() = delete;                           \
   DISALLOW_COPY_AND_ASSIGN(TypeName)
 
+// Used to explicitly mark the return value of a function as unused. If you are
+// really sure you don't want to do anything with the return value of a function
+// that has been marked WARN_UNUSED_RESULT, wrap it with this. Example:
+//
+//   std::unique_ptr<MyType> my_var = ...;
+//   if (TakeOwnership(my_var.get()) == SUCCESS)
+//     ignore_result(my_var.release());
+//
+template<typename T>
+inline void ignore_result(const T&) {
+}
+
 #endif

--- a/core/drivers/pcap.cc
+++ b/core/drivers/pcap.cc
@@ -3,6 +3,7 @@
 
 #include <glog/logging.h>
 
+#include "../log.h"
 #include "../port.h"
 #include "../utils/pcap.h"
 
@@ -25,7 +26,6 @@ static void pcap_gather_data(unsigned char *data, struct rte_mbuf *mbuf) {
 /* Experimental. Needs more tests */
 class PCAPPort : public Port {
  public:
-  static void InitDriver(){};
   virtual struct snobj *Init(struct snobj *arg);
   virtual void DeInit();
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -2,6 +2,7 @@
 #include <rte_ethdev.h>
 #include <rte_errno.h>
 
+#include "../log.h"
 #include "../port.h"
 
 typedef uint8_t dpdk_port_t;
@@ -10,7 +11,7 @@ typedef uint8_t dpdk_port_t;
 
 class PMDPort : public Port {
  public:
-  static void InitDriver();
+  virtual void InitDriver();
   virtual struct snobj *Init(struct snobj *arg);
   virtual void DeInit();
 

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -8,6 +8,7 @@
 #include <thread>
 #include <unistd.h>
 
+#include "../log.h"
 #include "../port.h"
 
 #define NOT_CONNECTED -1
@@ -23,8 +24,6 @@
 
 class UnixSocketPort : public Port {
  public:
-  static void InitDriver(){};
-
   virtual struct snobj *Init(struct snobj *arg);
   virtual void DeInit();
 
@@ -112,7 +111,7 @@ struct snobj *UnixSocketPort::Init(struct snobj *conf) {
     snprintf(addr_.sun_path, sizeof(addr_.sun_path), "%s", path);
   } else
     snprintf(addr_.sun_path, sizeof(addr_.sun_path), "%s/bess_unix_%s",
-             P_tmpdir, Name().c_str());
+             P_tmpdir, name().c_str());
 
   /* This doesn't include the trailing null character */
   addrlen = sizeof(addr_.sun_family) + strlen(addr_.sun_path);

--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -10,6 +10,7 @@
 #include <rte_config.h>
 #include <rte_malloc.h>
 
+#include "../log.h"
 #include "../kmod/sn_common.h"
 #include "../port.h"
 
@@ -173,7 +174,7 @@ static struct snobj *docker_container_pid(char *cid, int *container_pid) {
 
 class VPort : public Port {
  public:
-  static void InitDriver();
+  virtual void InitDriver();
 
   struct snobj *Init(struct snobj *conf);
   void DeInit();
@@ -504,7 +505,7 @@ struct snobj *VPort::Init(struct snobj *conf) {
   container_pid_ = 0;
 
   ifname = snobj_eval_str(conf, "ifname");
-  if (!ifname) ifname = Name().c_str();
+  if (!ifname) ifname = name().c_str();
 
   if (strlen(ifname) >= IFNAMSIZ) {
     err = snobj_err(EINVAL,

--- a/core/drivers/vport_zc.cc
+++ b/core/drivers/vport_zc.cc
@@ -8,6 +8,7 @@
 #include <rte_config.h>
 #include <rte_malloc.h>
 
+#include "../log.h"
 #include "../kmod/llring.h"
 #include "../port.h"
 
@@ -53,8 +54,6 @@ struct vport_bar {
 
 class ZeroCopyVPort : public Port {
  public:
-  static void InitDriver(){};
-
   struct snobj *Init(struct snobj *arg);
   void DeInit();
 
@@ -100,7 +99,7 @@ struct snobj *ZeroCopyVPort::Init(struct snobj *arg) {
   assert(bar != NULL);
   bar_ = bar;
 
-  strncpy(bar->name, Name().c_str(), PORT_NAME_LEN);
+  strncpy(bar->name, name().c_str(), PORT_NAME_LEN);
   bar->num_inc_q = num_inc_q;
   bar->num_out_q = num_out_q;
 
@@ -141,7 +140,7 @@ struct snobj *ZeroCopyVPort::Init(struct snobj *arg) {
 
   for (i = 0; i < num_out_q; i++) {
     snprintf(file_name, PORT_NAME_LEN + 256, "%s/%s/%s.rx%d", P_tmpdir,
-             VPORT_DIR_PREFIX, Name().c_str(), i);
+             VPORT_DIR_PREFIX, name().c_str(), i);
 
     mkfifo(file_name, 0666);
 
@@ -149,7 +148,7 @@ struct snobj *ZeroCopyVPort::Init(struct snobj *arg) {
   }
 
   snprintf(file_name, PORT_NAME_LEN + 256, "%s/%s/%s", P_tmpdir,
-           VPORT_DIR_PREFIX, Name().c_str());
+           VPORT_DIR_PREFIX, name().c_str());
   log_info("Writing port information to %s\n", file_name);
   fp = fopen(file_name, "w");
   fwrite(&bar_address, 8, 1, fp);
@@ -165,14 +164,14 @@ void ZeroCopyVPort::DeInit() {
 
   for (int i = 0; i < num_out_q; i++) {
     snprintf(file_name, PORT_NAME_LEN + 256, "%s/%s/%s.rx%d", P_tmpdir,
-             VPORT_DIR_PREFIX, Name().c_str(), i);
+             VPORT_DIR_PREFIX, name().c_str(), i);
 
     unlink(file_name);
     close(out_irq_fd_[i]);
   }
 
   snprintf(file_name, PORT_NAME_LEN + 256, "%s/%s/%s", P_tmpdir,
-           VPORT_DIR_PREFIX, Name().c_str());
+           VPORT_DIR_PREFIX, name().c_str());
   unlink(file_name);
 
   rte_free(bar_);

--- a/core/main.cc
+++ b/core/main.cc
@@ -328,6 +328,15 @@ static void set_resource_limit() {
   }
 }
 
+void init_drivers() {
+  for (auto &pair : PortBuilder::all_port_builders()) {
+    if (!const_cast<PortBuilder &>(pair.second).InitPortClass()) {
+      LOG(WARNING) << "Initializing driver (port class) "
+                   << pair.second.class_name() << " failed.";
+    }
+  }
+}
+
 int main(int argc, char *argv[]) {
   int signal_fd = -1;
 

--- a/core/port.cc
+++ b/core/port.cc
@@ -14,8 +14,6 @@
 #include "mem_alloc.h"
 #include "port.h"
 
-std::map<std::string, PortBuilder> PortBuilder::all_port_builders_;
-
 std::map<std::string, Port*> PortBuilder::all_ports_;
 
 Port *PortBuilder::CreatePort(const std::string &name) const {
@@ -85,7 +83,7 @@ bool PortBuilder::RegisterPortClass(std::function<Port *()> port_generator,
                                     const std::string &class_name,
                                     const std::string &name_template,
                                     const std::string &help_text) {
-  all_port_builders_.emplace(
+  all_port_builders_holder().emplace(
       std::piecewise_construct,
       std::forward_as_tuple(class_name),
       std::forward_as_tuple(port_generator, class_name, name_template, help_text));
@@ -93,7 +91,19 @@ bool PortBuilder::RegisterPortClass(std::function<Port *()> port_generator,
 }
 
 const std::map<std::string, PortBuilder> &PortBuilder::all_port_builders() {
-  return all_port_builders_;
+  return all_port_builders_holder();
+}
+
+std::map<std::string, PortBuilder> &PortBuilder::all_port_builders_holder(bool reset) {
+  // Maps from class names to port builders.  Tracks all port classes (via their
+  // PortBuilders).
+  static std::map<std::string, PortBuilder> all_port_builders;
+
+  if (reset) {
+    all_port_builders.clear();
+  }
+
+  return all_port_builders;
 }
 
 const std::map<std::string, Port*> &PortBuilder::all_ports() {

--- a/core/port.cc
+++ b/core/port.cc
@@ -14,6 +14,10 @@
 #include "mem_alloc.h"
 #include "port.h"
 
+std::map<std::string, PortBuilder> PortBuilder::all_port_builders_;
+
+std::map<std::string, Port*> PortBuilder::all_ports_;
+
 Port *PortBuilder::CreatePort(const std::string &name) const {
   Port *p = port_generator_();
   p->set_name(name);
@@ -86,6 +90,14 @@ bool PortBuilder::RegisterPortClass(std::function<Port *()> port_generator,
       std::forward_as_tuple(class_name),
       std::forward_as_tuple(port_generator, class_name, name_template, help_text));
   return true;
+}
+
+const std::map<std::string, PortBuilder> &PortBuilder::all_port_builders() {
+  return all_port_builders_;
+}
+
+const std::map<std::string, Port*> &PortBuilder::all_ports() {
+  return all_ports_;
 }
 
 void Port::GetPortStats(port_stats_t *stats) {

--- a/core/port.cc
+++ b/core/port.cc
@@ -3,43 +3,44 @@
 #include <errno.h>
 #include <stdio.h>
 
+#include <initializer_list>
+#include <memory>
 #include <sstream>
 
 #include <rte_config.h>
-#include <rte_ether.h>
 
 #include <glog/logging.h>
 
 #include "mem_alloc.h"
-#include "namespace.h"
 #include "port.h"
 
-Port::~Port() {}
-
-size_t list_ports(const Port **p_arr, size_t arr_size, size_t offset) {
-  size_t ret = 0;
-  size_t iter_cnt = 0;
-
-  struct ns_iter iter;
-
-  ns_init_iterator(&iter, NS_TYPE_PORT);
-  while (1) {
-    Port *port = (Port *)ns_next(&iter);
-    if (!port) break;
-
-    if (iter_cnt++ < offset) continue;
-
-    if (ret >= arr_size) break;
-
-    p_arr[ret++] = port;
-  }
-  ns_release_iterator(&iter);
-
-  return ret;
+Port *PortBuilder::CreatePort(const std::string &name) const {
+  Port *p = port_generator_();
+  p->set_name(name);
+  p->set_port_builder(this);
+  return p;
 }
 
-static std::string set_default_name(const std::string &driver_name,
-                                    const std::string &default_template) {
+bool PortBuilder::AddPort(Port *p) {
+  return all_ports_.insert({p->name(), p}).second;
+}
+
+int PortBuilder::DestroyPort(Port *p) {
+  for (packet_dir_t dir : {PACKET_DIR_INC, PACKET_DIR_OUT}) {
+    for (queue_t i = 0; i < p->num_queues[dir]; i++) {
+      if (p->users[dir][i]) return -EBUSY;
+    }
+  }
+
+  all_ports_.erase(p->name());
+  p->Deinit();
+  delete p;
+
+  return 0;
+}
+
+std::string PortBuilder::GenerateDefaultPortName(const std::string &driver_name,
+                                                 const std::string &default_template) {
   std::string name_template;
 
   if (default_template == "") {
@@ -61,214 +62,50 @@ static std::string set_default_name(const std::string &driver_name,
     ss << name_template << i;
     std::string name = ss.str();
 
-    if (!find_port(name.c_str())) return name;  // found an unallocated name!
+    if (!all_ports_.count(name)) return name;  // found an unallocated name!
   }
 
   promise_unreachable();
 }
 
-#if 0
-static void set_default_name(Port *p)
-{
-	char *fmt;
+bool PortBuilder::InitPortClass() {
+  if (initialized_) return false;
 
-	int i;
-
-	if (p->driver->def_port_name) {
-		fmt = (char *)alloca(strlen(p->driver->def_port_name) + 16);
-		strcpy(fmt, p->driver->def_port_name);
-	} else {
-		const char *def = p->driver->name;
-		const char *t;
-
-		char *s;
-
-		fmt = (char *)alloca(strlen(def) + 16);
-		s = fmt;
-
-		/* CamelCase -> camel_case */
-		for (t = def; *t != '\0'; t++) {
-			if (t != def && islower(*(t - 1)) && isupper(*t))
-				*s++ = '_';
-
-			*s++ = tolower(*t);
-		}
-
-		*s = '\0';
-	}
-
-	/* lower_case -> lower_case%d */
-	strcat(fmt, "%d");
-
-	for (i = 0; ; i++) {
-		int ret;
-
-		ret = snprintf(p->name, PORT_NAME_LEN, fmt, i);
-		assert(ret < PORT_NAME_LEN);
-
-		if (!find_port(p->name))
-			break;	/* found an unallocated name! */
-	}
-}
-#endif
-
-Port *find_port(const char *name) {
-  return (Port *)ns_lookup(NS_TYPE_PORT, name);
+  std::unique_ptr<Port> p(port_generator_());
+  p->InitDriver();
+  initialized_ = true;
+  return true;
 }
 
-static int register_port(Port *p) {
-  int ret;
-
-  ret = ns_insert(NS_TYPE_PORT, p->Name().c_str(), (void *)p);
-  if (ret < 0) {
-    return ret;
-  }
-
-  return 0;
+bool PortBuilder::RegisterPortClass(std::function<Port *()> port_generator,
+                                    const std::string &class_name,
+                                    const std::string &name_template,
+                                    const std::string &help_text) {
+  all_port_builders_.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(class_name),
+      std::forward_as_tuple(port_generator, class_name, name_template, help_text));
+  return true;
 }
 
-/* returns a pointer to the created port.
- * if error, returns NULL and *perr is set */
-Port *create_port(const char *name, const Driver *driver, struct snobj *arg,
-                  struct snobj **perr) {
-  Port *p = NULL;
-  int ret;
+void Port::GetPortStats(port_stats_t *stats) {
+  CollectStats(false);
 
-  queue_t num_inc_q = 1;
-  queue_t num_out_q = 1;
-  size_t size_inc_q = driver->DefaultQueueSize(PACKET_DIR_INC);
-  size_t size_out_q = driver->DefaultQueueSize(PACKET_DIR_OUT);
-
-  uint8_t mac_addr[ETH_ALEN];
-
-  *perr = NULL;
-
-  if (snobj_eval_exists(arg, "num_inc_q"))
-    num_inc_q = snobj_eval_uint(arg, "num_inc_q");
-
-  if (snobj_eval_exists(arg, "num_out_q"))
-    num_out_q = snobj_eval_uint(arg, "num_out_q");
-
-  if (snobj_eval_exists(arg, "size_inc_q"))
-    size_inc_q = snobj_eval_uint(arg, "size_inc_q");
-
-  if (snobj_eval_exists(arg, "size_out_q"))
-    size_out_q = snobj_eval_uint(arg, "size_out_q");
-
-  if (snobj_eval_exists(arg, "mac_addr")) {
-    char *v = snobj_eval_str(arg, "mac_addr");
-
-    ret = sscanf(v, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx", &mac_addr[0],
-                 &mac_addr[1], &mac_addr[2], &mac_addr[3], &mac_addr[4],
-                 &mac_addr[5]);
-
-    if (ret != 6) {
-      *perr = snobj_err(EINVAL,
-                        "MAC address should be "
-                        "formatted as a string "
-                        "xx:xx:xx:xx:xx:xx");
-      return NULL;
-    }
-  } else
-    eth_random_addr(mac_addr);
-
-  if (num_inc_q > MAX_QUEUES_PER_DIR || num_out_q > MAX_QUEUES_PER_DIR) {
-    *perr = snobj_err(EINVAL, "Invalid number of queues");
-    return NULL;
-  }
-
-  if (size_inc_q < 0 || size_inc_q > MAX_QUEUE_SIZE || size_out_q < 0 ||
-      size_out_q > MAX_QUEUE_SIZE) {
-    *perr = snobj_err(EINVAL, "Invalid queue size");
-    return NULL;
-  }
-
-  std::string port_name;
-
-  if (name) {
-    if (find_port(name)) {
-      *perr = snobj_err(EEXIST, "Port '%s' already exists", name);
-      return NULL;
-    }
-
-    port_name = name;
-  } else {
-    port_name = set_default_name(driver->Name(), driver->NameTemplate());
-  }
-
-  p = driver->CreatePort(port_name);
-
-  //	p->driver = driver;
-
-  memcpy(p->mac_addr, mac_addr, ETH_ALEN);
-  p->num_queues[PACKET_DIR_INC] = num_inc_q;
-  p->num_queues[PACKET_DIR_OUT] = num_out_q;
-
-  p->queue_size[PACKET_DIR_INC] = size_inc_q;
-  p->queue_size[PACKET_DIR_OUT] = size_out_q;
-
-  *perr = p->Init(arg);
-  if (*perr != NULL) {
-    delete p;
-    return NULL;
-  }
-
-  ret = register_port(p);
-  if (ret != 0) {
-    *perr = snobj_errno(-ret);
-    delete p;
-    return NULL;
-  }
-
-  return p;
-}
-
-#include <initializer_list>
-
-/* -errno if not successful */
-int destroy_port(Port *p) {
-  int ret;
+  memcpy(stats, &port_stats, sizeof(port_stats_t));
 
   for (packet_dir_t dir : {PACKET_DIR_INC, PACKET_DIR_OUT}) {
-    for (queue_t i = 0; i < p->num_queues[dir]; i++)
-      if (p->users[dir][i]) return -EBUSY;
-  }
+    for (queue_t qid = 0; qid < num_queues[dir]; qid++) {
+      const struct packet_stats *qs = &queue_stats[dir][qid];
 
-  ret = ns_remove(p->Name().c_str());
-  if (ret < 0) return ret;
-
-  p->Deinit();
-  delete p;
-
-  return 0;
-}
-
-void get_port_stats(Port *p, port_stats_t *stats) {
-  p->CollectStats(false);
-
-  memcpy(stats, &p->port_stats, sizeof(port_stats_t));
-
-  for (packet_dir_t dir : {PACKET_DIR_INC, PACKET_DIR_OUT}) {
-    for (queue_t qid = 0; qid < p->num_queues[dir]; qid++) {
-      const struct packet_stats *queue_stats;
-
-      queue_stats = &p->queue_stats[dir][qid];
-
-      (*stats)[dir].packets += queue_stats->packets;
-      (*stats)[dir].dropped += queue_stats->dropped;
-      (*stats)[dir].bytes += queue_stats->bytes;
+      (*stats)[dir].packets += qs->packets;
+      (*stats)[dir].dropped += qs->dropped;
+      (*stats)[dir].bytes += qs->bytes;
     }
   }
 }
 
-/* XXX: Do we need this? Currently not being used anywhere */
-void get_queue_stats(Port *p, packet_dir_t dir, queue_t qid,
-                     struct packet_stats *stats) {
-  memcpy(stats, &p->queue_stats[dir][qid], sizeof(*stats));
-}
-
-int acquire_queues(Port *p, const struct module *m, packet_dir_t dir,
-                   const queue_t *queues, int num_queues) {
+int Port::AcquireQueues(const struct module *m, packet_dir_t dir,
+                        const queue_t *queues, int num) {
   queue_t qid;
   int i;
 
@@ -278,43 +115,43 @@ int acquire_queues(Port *p, const struct module *m, packet_dir_t dir,
   }
 
   if (queues == NULL) {
-    for (qid = 0; qid < p->num_queues[dir]; qid++) {
+    for (qid = 0; qid < num_queues[dir]; qid++) {
       const struct module *user;
 
-      user = p->users[dir][qid];
+      user = users[dir][qid];
 
       /* the queue is already being used by someone else? */
       if (user && user != m) return -EBUSY;
     }
 
-    for (qid = 0; qid < p->num_queues[dir]; qid++) p->users[dir][qid] = m;
+    for (qid = 0; qid < num_queues[dir]; qid++) users[dir][qid] = m;
 
     return 0;
   }
 
-  for (i = 0; i < num_queues; i++) {
+  for (i = 0; i < num; i++) {
     const struct module *user;
 
     qid = queues[i];
 
-    if (qid >= p->num_queues[dir]) return -EINVAL;
+    if (qid >= num_queues[dir]) return -EINVAL;
 
-    user = p->users[dir][qid];
+    user = users[dir][qid];
 
     /* the queue is already being used by someone else? */
     if (user && user != m) return -EBUSY;
   }
 
-  for (i = 0; i < num_queues; i++) {
+  for (i = 0; i < num; i++) {
     qid = queues[i];
-    p->users[dir][qid] = m;
+    users[dir][qid] = m;
   }
 
   return 0;
 }
 
-void release_queues(Port *p, const struct module *m, packet_dir_t dir,
-                    const queue_t *queues, int num_queues) {
+void Port::ReleaseQueues(const struct module *m, packet_dir_t dir,
+                         const queue_t *queues, int num) {
   queue_t qid;
   int i;
 
@@ -324,56 +161,25 @@ void release_queues(Port *p, const struct module *m, packet_dir_t dir,
   }
 
   if (queues == NULL) {
-    for (qid = 0; qid < p->num_queues[dir]; qid++) {
-      if (p->users[dir][qid] == m) p->users[dir][qid] = NULL;
+    for (qid = 0; qid < num_queues[dir]; qid++) {
+      if (users[dir][qid] == m) users[dir][qid] = NULL;
     }
 
     return;
   }
 
-  for (i = 0; i < num_queues; i++) {
+  for (i = 0; i < num; i++) {
     qid = queues[i];
-    if (qid >= p->num_queues[dir]) continue;
+    if (qid >= num_queues[dir]) continue;
 
-    if (p->users[dir][qid] == m) p->users[dir][qid] = NULL;
+    if (users[dir][qid] == m) users[dir][qid] = NULL;
   }
 }
 
-size_t list_drivers(const Driver **p_arr, size_t arr_size, size_t offset) {
-  size_t ret = 0;
-  size_t iter_cnt = 0;
+/* XXX: Do we need this? Currently not being used anywhere */
+// void get_queue_stats(Port *p, packet_dir_t dir, queue_t qid,
+//                      struct packet_stats *stats) {
+//   memcpy(stats, &p->queue_stats[dir][qid], sizeof(*stats));
+// }
 
-  struct ns_iter iter;
 
-  ns_init_iterator(&iter, NS_TYPE_DRIVER);
-  while (1) {
-    Driver *driver = (Driver *)ns_next(&iter);
-    if (!driver) break;
-
-    if (iter_cnt++ < offset) continue;
-
-    if (ret >= arr_size) break;
-
-    p_arr[ret++] = driver;
-  }
-  ns_release_iterator(&iter);
-
-  return ret;
-}
-
-const Driver *find_driver(const char *name) {
-  return (Driver *)ns_lookup(NS_TYPE_DRIVER, name);
-}
-
-void init_drivers() {
-  struct ns_iter iter;
-
-  ns_init_iterator(&iter, NS_TYPE_DRIVER);
-  while (1) {
-    Driver *driver = (Driver *)ns_next(&iter);
-    if (!driver) break;
-
-    driver->Init();
-  }
-  ns_release_iterator(&iter);
-}

--- a/core/port.h
+++ b/core/port.h
@@ -3,8 +3,13 @@
 
 #include <stdint.h>
 
+#include <functional>
+#include <memory>
+#include <unordered_map>
+
+#include <glog/logging.h>
+
 #include "common.h"
-#include "log.h"
 #include "snobj.h"
 #include "snbuf.h"
 
@@ -42,96 +47,79 @@ struct packet_stats {
 
 typedef struct packet_stats port_stats_t[PACKET_DIRS];
 
-#if 0
-struct module;
-
-Port {
-	char *name;
-
-	const Driver *driver;
-
-	/* which modules are using this port?
-	 * TODO: more robust gate keeping */
-	const struct module *users[PACKET_DIRS][MAX_QUEUES_PER_DIR];
-
-	char mac_addr[ETH_ALEN];
-
-	queue_t num_queues[PACKET_DIRS];
-	int queue_size[PACKET_DIRS];
-
-	struct packet_stats queue_stats[PACKET_DIRS][MAX_QUEUES_PER_DIR];
-
-	/* for stats that do NOT belong to any queues */
-	port_stats_t port_stats;
-
-	void *priv[0];
-};
-
-static inline void *get_port_priv(Port *p)
-{
-	return (void *)(p + 1);
-}
-#endif
-
 class Port;
 
-class Driver {
+// A class to generate new Port objects of specific types.  Each instance can
+// generate Port objects of a specific class and specification.  Represents a
+// "driver" of that port.
+class PortBuilder {
  public:
-  Driver(const std::string &driver_name, const std::string &name_template,
-         const std::string &help)
-      : name_(driver_name), name_template_(name_template), help_(help) {
-    int ret = ns_insert(NS_TYPE_DRIVER, driver_name.c_str(),
-                        static_cast<void *>(this));
-    if (ret < 0) {
-      log_err("ns_insert() failure for driver '%s'\n", driver_name.c_str());
-    }
+  PortBuilder(std::function<Port *()> port_generator,
+              const std::string &class_name,
+              const std::string &name_template,
+              const std::string &help_text) :
+      port_generator_(port_generator),
+      class_name_(class_name),
+      name_template_(name_template),
+      help_text_(help_text),
+      initialized_(false) {}
+
+  // Returns a new Port object of the type represented by this PortBuilder
+  // instance (of type class_name) with the Port instance's name set to the
+  // given name.
+  Port *CreatePort(const std::string &name) const;
+
+  // Adds the given Port to the global Port collection.  Returns true upon
+  // success.
+  static bool AddPort(Port *p);
+
+  // Returns 0 upon success, -errno upon failure.
+  static int DestroyPort(Port *p);
+
+  // Generates a name for a new port given the driver name and its template.
+  static std::string GenerateDefaultPortName(const std::string &driver_name,
+                                             const std::string &default_template);
+
+  // Invokes one-time initialization of the corresponding port class.  Returns
+  // true upon success.
+  bool InitPortClass();
+
+  // Should be called via ADD_DRIVER (once per driver file) to register the
+  // existence of this driver.  Always returns true;
+  static bool RegisterPortClass(std::function<Port *()> port_generator,
+                                const std::string &class_name,
+                                const std::string &name_template,
+                                const std::string &help_text);
+
+  static const std::unordered_map<std::string, PortBuilder> &all_port_builders() {
+    return all_port_builders_;
   }
 
-  static void InitDriver(){};
-
-  virtual Port *CreatePort(const std::string &name) const = 0;
-  virtual void Init() {}
-
-  std::string Name() const { return name_; }
-  std::string NameTemplate() const { return name_template_; }
-  std::string Help() const { return help_; }
-
-  virtual size_t DefaultQueueSize(packet_dir_t dir) const = 0;
-  virtual uint32_t GetFlags() const = 0;
+  static const std::unordered_map<std::string, Port*> &all_ports() {
+    return all_ports_;
+  }
+  
+  const std::string &class_name() const { return class_name_; };
+  const std::string &name_template() const { return name_template_; };
+  const std::string &help_text() const { return help_text_; };
 
  private:
-  std::string name_;
-  std::string name_template_;
-  std::string help_;
+  // A function that emits a new Port object of the type class_name.  Sets the
+  // port's name to the given string argument.
+  std::function<Port *()> port_generator_; 
 
-  size_t def_size_inc_q;
-  size_t def_size_out_q;
-};
+  // Maps from class names to port builders.  Tracks all port classes (via their
+  // PortBuilders).
+  static std::unordered_map<std::string, PortBuilder> all_port_builders_;
 
-template <typename T>
-class DriverRegister : public Driver {
- public:
-  DriverRegister(const std::string &class_name,
-                 const std::string &name_template, const std::string &help)
-      : Driver(class_name, name_template, help){};
+  // Tracks all port instances.
+  static std::unordered_map<std::string, Port*> all_ports_;
 
-  virtual void InitDriver() { T::InitDriver(); }
+  std::string class_name_;     // The name of this Port class.
+  std::string name_template_;  // The port default name prefix.
+  std::string help_text_;      // Help text about this port type.
 
-  virtual Port *CreatePort(const std::string &name) const {
-    T *m = new T;
-    m->name_ = name;
-    m->driver_ = this;
-    return m;
-  }
-
-  virtual size_t DefaultQueueSize(packet_dir_t dir) const {
-    if (dir == PACKET_DIR_INC)
-      return T::kDefaultIncQueueSize;
-    else
-      return T::kDefaultOutQueueSize;
-  }
-
-  virtual uint32_t GetFlags() const { return T::kFlags; }
+  bool initialized_;  // Has this port class been initialized via InitPortClass()?
 };
 
 class Port {
@@ -143,37 +131,60 @@ class Port {
   virtual struct snobj *Init(struct snobj *arg) { return nullptr; }
   virtual void Deinit() {}
 
+  // For one-time initialization of the port's "driver" (optional).
+  virtual void InitDriver() {}
+
   virtual void CollectStats(bool reset) {}
 
   virtual int RecvPackets(queue_t qid, snb_array_t pkts, int cnt) { return 0; }
 
   virtual int SendPackets(queue_t qid, snb_array_t pkts, int cnt) { return 0; }
 
+  // For custom incoming / outgoing queue sizes (optional).
+  virtual size_t DefaultIncQueueSize() const { return kDefaultIncQueueSize; }
+  virtual size_t DefaultOutQueueSize() const { return kDefaultOutQueueSize; }
+
+  virtual size_t GetFlags() const { return kFlags; }
+
+  // -------------------------------------------------------------------------
+
+ public:
+  friend class PortBuilder;
+
+  // Fills in pointed-to structure with this port's stats.
+  void GetPortStats(port_stats_t *stats);
+
+  /* queues == NULL if _all_ queues are being acquired/released */
+  int AcquireQueues(const struct module *m, packet_dir_t dir,
+                    const queue_t *queues, int num);
+
+  void ReleaseQueues(const struct module *m, packet_dir_t dir,
+                     const queue_t *queues, int num);
+
+  const std::string &name() const { return name_; };
+
+  const PortBuilder *port_builder() const { return port_builder_; }
+
+  struct snobj *RunCommand(const std::string &user_cmd, struct snobj *arg);
+
+ private:
+  // Private methods, for use by PortBuilder.
+  void set_name(const std::string &name) { name_ = name; }
+  void set_port_builder(const PortBuilder *port_builder) {
+    port_builder_ = port_builder;
+  }
+
+  std::string name_; // The name of this port instance.
+
+  // Class-wide spec of this type of port.  Non-owning.
+  const PortBuilder *port_builder_;
+
   static const size_t kDefaultIncQueueSize = 256;
   static const size_t kDefaultOutQueueSize = 256;
 
   static const uint32_t kFlags = 0;
 
-  // -------------------------------------------------------------------------
-
- public:
-  const Driver *GetDriver() const { return driver_; };
-  std::string Name() const { return name_; };
-
-  struct snobj *RunCommand(const std::string &user_cmd, struct snobj *arg);
-
- private:
-  // non-copyable and non-movable by default
-  Port(Port &) = delete;
-  Port &operator=(Port &) = delete;
-  Port(Port &&) = delete;
-  Port &operator=(Port &&) = delete;
-
-  std::string name_;
-  const Driver *driver_;
-
-  template <typename T>
-  friend class DriverRegister;
+  DISALLOW_COPY_AND_ASSIGN(Port);
 
   // FIXME: porting in progress ----------------------------
  public:
@@ -192,34 +203,8 @@ class Port {
   port_stats_t port_stats;
 };
 
-size_t list_drivers(const Driver **p_arr, size_t arr_size, size_t offset);
-
-const Driver *find_driver(const char *name);
-
-int add_driver(const Driver *driver);
-
-void init_drivers();
-
-size_t list_ports(const Port **p_arr, size_t arr_size, size_t offset);
-Port *find_port(const char *name);
-
-Port *create_port(const char *name, const Driver *driver, struct snobj *arg,
-                  struct snobj **perr);
-
-int destroy_port(Port *p);
-
-void get_port_stats(Port *p, port_stats_t *stats);
-
-void get_queue_stats(Port *p, packet_dir_t dir, queue_t qid,
-                     struct packet_stats *stats);
-
-/* quques == NULL if _all_ queues are being acquired/released */
-int acquire_queues(Port *p, const struct module *m, packet_dir_t dir,
-                   const queue_t *queues, int num_queues);
-void release_queues(Port *p, const struct module *m, packet_dir_t dir,
-                    const queue_t *queues, int num_queues);
 
 #define ADD_DRIVER(_DRIVER, _NAME_TEMPLATE, _HELP) \
-  DriverRegister<_DRIVER> __driver__##_DRIVER(#_DRIVER, _NAME_TEMPLATE, _HELP);
+  bool __driver__##_DRIVER = PortBuilder::RegisterPortClass(std::function<Port *()>([]() { return new _DRIVER (); }), #_DRIVER, _NAME_TEMPLATE, _HELP);
 
 #endif

--- a/core/port.h
+++ b/core/port.h
@@ -5,7 +5,7 @@
 
 #include <functional>
 #include <memory>
-#include <unordered_map>
+#include <map>
 
 #include <glog/logging.h>
 
@@ -91,13 +91,9 @@ class PortBuilder {
                                 const std::string &name_template,
                                 const std::string &help_text);
 
-  static const std::unordered_map<std::string, PortBuilder> &all_port_builders() {
-    return all_port_builders_;
-  }
+  static const std::map<std::string, PortBuilder> &all_port_builders();
 
-  static const std::unordered_map<std::string, Port*> &all_ports() {
-    return all_ports_;
-  }
+  static const std::map<std::string, Port*> &all_ports();
   
   const std::string &class_name() const { return class_name_; };
   const std::string &name_template() const { return name_template_; };
@@ -110,10 +106,10 @@ class PortBuilder {
 
   // Maps from class names to port builders.  Tracks all port classes (via their
   // PortBuilders).
-  static std::unordered_map<std::string, PortBuilder> all_port_builders_;
+  static std::map<std::string, PortBuilder> all_port_builders_;
 
   // Tracks all port instances.
-  static std::unordered_map<std::string, Port*> all_ports_;
+  static std::map<std::string, Port*> all_ports_;
 
   std::string class_name_;     // The name of this Port class.
   std::string name_template_;  // The port default name prefix.
@@ -126,7 +122,7 @@ class Port {
   // overide this section to create a new module -----------------------------
  public:
   Port() = default;
-  virtual ~Port() = 0;
+  virtual ~Port() {};
 
   virtual struct snobj *Init(struct snobj *arg) { return nullptr; }
   virtual void Deinit() {}
@@ -203,7 +199,8 @@ class Port {
   port_stats_t port_stats;
 };
 
-
+// TODO(barath): Change the structure of this, because we can't rely on static
+//               initialization order.
 #define ADD_DRIVER(_DRIVER, _NAME_TEMPLATE, _HELP) \
   bool __driver__##_DRIVER = PortBuilder::RegisterPortClass(std::function<Port *()>([]() { return new _DRIVER (); }), #_DRIVER, _NAME_TEMPLATE, _HELP);
 

--- a/core/port.h
+++ b/core/port.h
@@ -100,8 +100,7 @@ class PortBuilder {
   const std::string &help_text() const { return help_text_; };
 
  private:
-  // A function that emits a new Port object of the type class_name.  Sets the
-  // port's name to the given string argument.
+  // A function that emits a new Port object of the type class_name.
   std::function<Port *()> port_generator_; 
 
   // Maps from class names to port builders.  Tracks all port classes (via their

--- a/core/port.h
+++ b/core/port.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include <glog/logging.h>
+#include <gtest/gtest_prod.h>
 
 #include "common.h"
 #include "snobj.h"
@@ -56,6 +57,9 @@ class PortTest;
 class PortBuilder {
  public:
   friend class PortTest;
+  FRIEND_TEST(PortBuilderTest, RegisterPortClassDirectCall);
+  FRIEND_TEST(PortBuilderTest, RegisterPortClassMacroCall);
+
 
   PortBuilder(std::function<Port *()> port_generator,
               const std::string &class_name,
@@ -72,8 +76,8 @@ class PortBuilder {
   // given name.
   Port *CreatePort(const std::string &name) const;
 
-  // Adds the given Port to the global Port collection.  Returns true upon
-  // success.
+  // Adds the given Port to the global Port collection.  Takes ownership of the
+  // pointer.  Returns true upon success.
   static bool AddPort(Port *p);
 
   // Returns 0 upon success, -errno upon failure.

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -1,0 +1,61 @@
+// Unit tests for port and portbuilder routines.
+
+#include "port.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+class DummyPort : public Port {
+  virtual void InitDriver() {
+    initialized = true;
+  }
+
+  bool initialized = false;
+};
+
+class PortTest : public ::testing::Test {
+ protected:
+   virtual void SetUp() {
+     p = new DummyPort();
+   }
+
+   virtual void TearDown() {
+     delete p;
+
+     PortBuilder::all_port_builders_holder(true);
+   }
+
+   DummyPort *p;
+};
+
+TEST_F(PortTest, RegisterPortClassDirectCall) {
+  ASSERT_TRUE(PortBuilder::all_port_builders().empty());
+
+  PortBuilder::RegisterPortClass([]() { return new DummyPort(); }, "DummyPort", "dummy_port", "dummy help");
+
+  ASSERT_EQ(1, PortBuilder::all_port_builders().size());
+  ASSERT_EQ(1, PortBuilder::all_port_builders().count("DummyPort"));
+
+  const PortBuilder &b = PortBuilder::all_port_builders().find("DummyPort")->second;
+  EXPECT_EQ("DummyPort", b.class_name());
+  EXPECT_EQ("dummy_port", b.name_template());
+  EXPECT_EQ("dummy help", b.help_text());
+}
+
+TEST_F(PortTest, RegisterPortClassMacroCall) {
+  ASSERT_TRUE(PortBuilder::all_port_builders().empty());
+
+  ADD_DRIVER(DummyPort, "dummy_port", "dummy help");
+  ASSERT_TRUE(__driver__DummyPort);
+
+  ASSERT_EQ(1, PortBuilder::all_port_builders().size());
+  ASSERT_EQ(1, PortBuilder::all_port_builders().count("DummyPort"));
+
+  const PortBuilder &b = PortBuilder::all_port_builders().find("DummyPort")->second;
+  EXPECT_EQ("DummyPort", b.class_name());
+  EXPECT_EQ("dummy_port", b.name_template());
+  EXPECT_EQ("dummy help", b.help_text());
+}
+
+

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -7,29 +7,137 @@
 #include <gtest/gtest.h>
 
 class DummyPort : public Port {
+ public:
+  DummyPort() : Port(), deinited_(nullptr) {}
+
   virtual void InitDriver() {
-    initialized = true;
+    initialized_ = true;
   }
 
-  bool initialized = false;
+  virtual void Deinit() {
+    if (deinited_) *deinited_ = true;
+  }
+
+  void set_deinited(bool *val) {
+    deinited_ = val;
+  }
+
+  static void set_initialized(bool val) {
+    initialized_ = val;
+  }
+
+  static bool initialized() {
+    return initialized_;
+  }
+
+ private:
+  bool *deinited_;
+
+  static bool initialized_;
 };
 
+bool DummyPort::initialized_ = false;
+
+// A basic test framework for ports.  Sets up a single dummy PortBuilder that
+// builds Ports of type DummyPort.
 class PortTest : public ::testing::Test {
  protected:
    virtual void SetUp() {
-     p = new DummyPort();
+     DummyPort::set_initialized(false);
+
+     ASSERT_TRUE(PortBuilder::all_port_builders().empty());
+
+     ADD_DRIVER(DummyPort, "dummy_port", "dummy help");
+     ASSERT_TRUE(__driver__DummyPort);
+
+     ASSERT_EQ(1, PortBuilder::all_port_builders().size());
+     ASSERT_EQ(1, PortBuilder::all_port_builders().count("DummyPort"));
+     dummy_port_builder = &PortBuilder::all_port_builders().find("DummyPort")->second;
+     EXPECT_EQ("DummyPort", dummy_port_builder->class_name());
+     EXPECT_EQ("dummy_port", dummy_port_builder->name_template());
+     EXPECT_EQ("dummy help", dummy_port_builder->help_text());
    }
 
    virtual void TearDown() {
-     delete p;
-
      PortBuilder::all_port_builders_holder(true);
+     PortBuilder::all_ports_.clear();
    }
 
-   DummyPort *p;
+   const PortBuilder *dummy_port_builder;
 };
 
-TEST_F(PortTest, RegisterPortClassDirectCall) {
+// Checks that when we create a port via the established PortBuilder, the right
+// Port object is returned.
+TEST_F(PortTest, CreatePort) {
+  std::unique_ptr<Port> p(dummy_port_builder->CreatePort("port1"));
+  ASSERT_NE(nullptr, p.get());
+
+  EXPECT_EQ("port1", p->name());
+  EXPECT_EQ(dummy_port_builder, p->port_builder());
+}
+
+// Checks that adding a port puts it into the global port collection.
+TEST_F(PortTest, AddPort) {
+  std::unique_ptr<Port> p(dummy_port_builder->CreatePort("port1"));
+  ASSERT_NE(nullptr, p.get());
+
+  ASSERT_TRUE(PortBuilder::all_ports().empty());
+  PortBuilder::AddPort(p.get());
+  ASSERT_EQ(1, PortBuilder::all_ports().size());
+
+  const auto &it = PortBuilder::all_ports().find("port1");
+  ASSERT_NE(it, PortBuilder::all_ports().end());
+
+  const Port *p_fetched = it->second;
+  EXPECT_EQ("port1", p_fetched->name());
+  EXPECT_EQ(dummy_port_builder, p_fetched->port_builder());
+}
+
+// Checks that adding a port puts it into the global port collection.
+TEST_F(PortTest, DestroyPort) {
+  Port *p = dummy_port_builder->CreatePort("port1");
+  ASSERT_NE(nullptr, p);
+
+  ASSERT_TRUE(PortBuilder::all_ports().empty());
+  PortBuilder::AddPort(p);
+  ASSERT_EQ(1, PortBuilder::all_ports().size());
+
+  const auto &it = PortBuilder::all_ports().find("port1");
+  ASSERT_NE(it, PortBuilder::all_ports().end());
+
+  Port *p_fetched = it->second;
+  EXPECT_EQ("port1", p_fetched->name());
+  EXPECT_EQ(dummy_port_builder, p_fetched->port_builder());
+
+  // Now destroy the port.
+  bool deinited = false;
+  static_cast<DummyPort *>(p_fetched)->set_deinited(&deinited);
+  ASSERT_FALSE(deinited);
+  PortBuilder::DestroyPort(p_fetched);
+  ASSERT_TRUE(deinited);
+}
+
+// Checks that the default port name generator produces names that match the
+// naming scheme.
+TEST_F(PortTest, GenerateDefaultPortName) {
+  // TODO(barath): Sangjin -- I don't quite know the naming scheme that is
+  //               used right now, so we can add this test later.
+}
+
+// Checks that a port's driver is initialized when the port class is
+// initialized.
+TEST_F(PortTest, InitPortClass) {
+  ASSERT_FALSE(DummyPort::initialized());
+
+  PortBuilder *builder = const_cast<PortBuilder *>(dummy_port_builder);
+  EXPECT_TRUE(builder->InitPortClass());
+  EXPECT_TRUE(DummyPort::initialized());
+  EXPECT_FALSE(builder->InitPortClass());
+}
+
+// Checks that when we register a portclass, the global table of PortBuilders
+// contains it.
+TEST(PortBuilderTest, RegisterPortClassDirectCall) {
   ASSERT_TRUE(PortBuilder::all_port_builders().empty());
 
   PortBuilder::RegisterPortClass([]() { return new DummyPort(); }, "DummyPort", "dummy_port", "dummy help");
@@ -41,9 +149,13 @@ TEST_F(PortTest, RegisterPortClassDirectCall) {
   EXPECT_EQ("DummyPort", b.class_name());
   EXPECT_EQ("dummy_port", b.name_template());
   EXPECT_EQ("dummy help", b.help_text());
+
+  PortBuilder::all_port_builders_holder(true);
 }
 
-TEST_F(PortTest, RegisterPortClassMacroCall) {
+// Checks that when we register a portclass via the ADD_DRIVER macro, the global
+// table of PortBuilders contains it.
+TEST(PortBuilderTest, RegisterPortClassMacroCall) {
   ASSERT_TRUE(PortBuilder::all_port_builders().empty());
 
   ADD_DRIVER(DummyPort, "dummy_port", "dummy help");
@@ -56,6 +168,7 @@ TEST_F(PortTest, RegisterPortClassMacroCall) {
   EXPECT_EQ("DummyPort", b.class_name());
   EXPECT_EQ("dummy_port", b.name_template());
   EXPECT_EQ("dummy help", b.help_text());
-}
 
+  PortBuilder::all_port_builders_holder(true);
+}
 


### PR DESCRIPTION
Eliminates use of namespace for port / driver and restructures port and related classes / methods:
* Adds PortBuilder to construct Port objects and to hold Ports and port classes (represented by PortBuilder "drivers")
* Eliminates Driver, DriverRegister, etc.
* Eliminates custom datastructure calls for getting ports, drivers, etc.

Includes nearly-complete unit test coverage for Port and PortBuilder.