### PR TITLE
pmd: Add ability to query link-status

### DIFF
--- a/bessctl/conf/samples/vport.bess
+++ b/bessctl/conf/samples/vport.bess
@@ -6,3 +6,8 @@ p = PMDPort(port_id=0)
 
 PortInc(port=p) -> PortOut(port=v)
 PortInc(port=v) -> PortOut(port=p)
+
+link_state = bess.get_port_link(p.name)
+# http://dpdk.org/doc/api/rte__ethdev_8h_source.html
+# Values for link_state
+print "Current Link State for Physical port is %s" % link_state

--- a/bessctl/port.py
+++ b/bessctl/port.py
@@ -23,3 +23,5 @@ class Port(object):
 
     def get_port_stats(self):
         return self.bess.get_port_stats(self.name)
+    def get_port_link(self):
+        return self.bess.get_port_link(self.name)

--- a/core/driver.h
+++ b/core/driver.h
@@ -23,6 +23,7 @@ ct_assert(MAX_QUEUES_PER_DIR < QUEUE_UNKNOWN);
 struct port;
 struct port_stats;
 struct snobj;
+struct link_status;
 
 typedef int (*pkt_io_func_t)(struct port *, queue_t, snb_array_t, int);
 
@@ -64,6 +65,9 @@ struct driver {
 
 	/* Optional: collect internal (HW) stats, if available */
 	void (*collect_stats)(struct port *p, int reset);
+
+	/* Optional: collect link (HW) stats (speed/duplex/link status) */
+	void (*get_link_status)(struct port *p);
 
 	/* Optional: port-specific query interface */
 	struct snobj *(*query)(struct port *p, struct snobj *q);

--- a/core/drivers/pmd.c
+++ b/core/drivers/pmd.c
@@ -377,6 +377,14 @@ static int pmd_send_pkts(struct port *p, queue_t qid, snb_array_t pkts, int cnt)
 	return sent;
 }
 
+static void pmd_link_status(struct port *p)
+{
+	struct pmd_priv *priv = get_port_priv(p);
+
+	rte_eth_link_get_nowait(priv->dpdk_port_id,
+		(struct rte_eth_link *)&p->link_status);
+}
+
 static const struct driver pmd = {
 	.name 		= "PMDPort",
 	.help		= "DPDK poll mode driver",
@@ -392,6 +400,7 @@ static const struct driver pmd = {
 	.collect_stats	= pmd_collect_stats,
 	.recv_pkts 	= pmd_recv_pkts,
 	.send_pkts 	= pmd_send_pkts,
+	.get_link_status = pmd_link_status,
 };
 
 ADD_DRIVER(pmd)

--- a/core/port.c
+++ b/core/port.c
@@ -242,6 +242,12 @@ int destroy_port(struct port *p)
 	return 0;
 }
 
+void get_port_link_status(struct port *p)
+{
+	if (p->driver->get_link_status)
+		p->driver->get_link_status(p);
+}
+
 void get_port_stats(struct port *p, port_stats_t *stats)
 {
 	if (p->driver->collect_stats)

--- a/core/port.h
+++ b/core/port.h
@@ -29,6 +29,17 @@ struct packet_stats {
 	uint64_t bytes;		/* doesn't include Ethernet overhead */
 };
 
+/* link_status maintains all link status details like speed/duplex/link.
+ * It is intentionally a copy of the DPDK struct rte_eth_link
+ * to avoid pointless translations. Q - Why not keeep rte_eth_link ?
+ * A - Don't want to tie it to DPDK */
+struct link_status {
+	uint32_t link_speed;
+	uint16_t link_duplex  : 1;
+	uint16_t link_autoneg : 1;
+	uint16_t link_status  : 1;
+};
+
 typedef struct packet_stats port_stats_t[PACKET_DIRS];
 
 struct module;
@@ -50,7 +61,9 @@ struct port {
 	struct packet_stats queue_stats[PACKET_DIRS][MAX_QUEUES_PER_DIR];
 	
 	/* for stats that do NOT belong to any queues */
-	port_stats_t port_stats;	
+	port_stats_t port_stats;
+
+	struct link_status link_status;
 
 	void *priv[0];	
 };
@@ -71,6 +84,7 @@ struct port *create_port(const char *name,
 int destroy_port(struct port *p);
 
 void get_port_stats(struct port *p, port_stats_t *stats);
+void get_port_link_status(struct port *p);
 
 void get_queue_stats(struct port *p, packet_dir_t dir, queue_t qid, 
 		struct packet_stats *stats);

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -166,6 +166,9 @@ class BESS(object):
     def get_port_stats(self, port):
         return self._request_bess('get_port_stats', port)
 
+    def get_port_link(self, port):
+        return self._request_bess('get_port_link', port)
+
     def list_mclasses(self):
         return self._request_bess('list_mclasses')
 


### PR DESCRIPTION
RFC patch

Currently there is no way to query for link
status like speed/duplex/link up/down for a physical
NIC controlled via bess. This ability is crucial to
for control plane protocols who need to take action if
link state changes.

This patch adds a ability to to access this setting via
a DPDK api and then adds plumbing all the way upto python
layer.

// Sample output
Current Link State for Physical port is {'duplex': 1, 'status': 1,
'autoneg': 0, 'speed': 10000}
// End

Signed-off-by: Chaitanya Lala <clala@arista.com>