### PR TITLE
Improve htable_bench output

### DIFF
--- a/core/utils/htable_bench.cc
+++ b/core/utils/htable_bench.cc
@@ -86,37 +86,55 @@ class BessFixture : public benchmark::Fixture {
 BENCHMARK_DEFINE_F(BessFixture, BessGet)(benchmark::State& state) {
   HTableBase *t = static_cast<HTableBase *>(arg_);
 
-  while (state.KeepRunning()) {
+  while (true) {
+    const size_t n = state.range(0);
     rng.SetSeed(0);
-    for (int i = 0; i < state.range(0); i++) {
+
+    for (size_t i = 0; i < n; i++) {
       uint32_t key = rng.Get();
       value_t *val;
 
       val = (value_t *)t->Get(&key);
       assert(val && *val == derive_val(key));
+
+      if (!state.KeepRunning()) {
+        state.SetItemsProcessed(state.iterations());
+        return;
+      }
     }
   }
 }
 
-BENCHMARK_REGISTER_F(BessFixture, BessGet)->RangeMultiplier(4)->Range(4, 4<<20);
+BENCHMARK_REGISTER_F(BessFixture, BessGet)
+    ->RangeMultiplier(4)
+    ->Range(4, 4 << 20);
 
 // Benchmarks the Get() method in HTable, which is inlined.
 BENCHMARK_DEFINE_F(BessFixture, BessInlinedGet)(benchmark::State& state) {
   HTable<uint32_t, value_t, inlined_keycmp, inlined_hash> *t =
       (HTable<uint32_t, value_t, inlined_keycmp, inlined_hash> *)arg_;
 
-  while (state.KeepRunning()) {
+  while (true) {
+    const size_t n = state.range(0);
     rng.SetSeed(0);
-    for (int i = 0; i < state.range(0); i++) {
+
+    for (size_t i = 0; i < n; i++) {
       uint32_t key = rng.Get();
       value_t *val;
 
       val = (value_t *)t->Get(&key);
       assert(val && *val == derive_val(key));
+
+      if (!state.KeepRunning()) {
+        state.SetItemsProcessed(state.iterations());
+        return;
+      }
     }
   }
 }
 
-BENCHMARK_REGISTER_F(BessFixture, BessInlinedGet)->RangeMultiplier(4)->Range(4, 4<<20);
+BENCHMARK_REGISTER_F(BessFixture, BessInlinedGet)
+    ->RangeMultiplier(4)
+    ->Range(4, 4 << 20);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
- Print out items/s measurement
- Reduce libbenchmark overhead
- Show # of operations, not # of loop iterations

Before:
```
Benchmark                                 Time           CPU Iterations
-----------------------------------------------------------------------
BessFixture/BessGet/4                    55 ns         55 ns   12919383
BessFixture/BessGet/16                  221 ns        221 ns    3183977
BessFixture/BessGet/64                  869 ns        869 ns     787016
BessFixture/BessGet/256                4045 ns       4045 ns     172809
BessFixture/BessGet/1024              18599 ns      18598 ns      38020
BessFixture/BessGet/4k                88456 ns      88452 ns       7767
BessFixture/BessGet/16k              410316 ns     410294 ns       1717
BessFixture/BessGet/64k             1867132 ns    1867025 ns        372
BessFixture/BessGet/256k            8465542 ns    8464801 ns         83
BessFixture/BessGet/1024k          37614708 ns   37613021 ns         19
BessFixture/BessGet/4M            311848071 ns  311821987 ns          2
BessFixture/BessInlinedGet/4             12 ns         12 ns   57567445
BessFixture/BessInlinedGet/16            56 ns         56 ns   12534705
BessFixture/BessInlinedGet/64           188 ns        188 ns    3728018
BessFixture/BessInlinedGet/256          753 ns        753 ns     941174
BessFixture/BessInlinedGet/1024        3049 ns       3048 ns     229160
BessFixture/BessInlinedGet/4k         32724 ns      32722 ns      21437
BessFixture/BessInlinedGet/16k       210571 ns     210561 ns       3335
BessFixture/BessInlinedGet/64k       935430 ns     935375 ns        749
BessFixture/BessInlinedGet/256k     3931766 ns    3931489 ns        178
BessFixture/BessInlinedGet/1024k   19126517 ns   19125327 ns         36
BessFixture/BessInlinedGet/4M     120839269 ns  120830044 ns          6
```

After:
```
Benchmark                                 Time           CPU Iterations
-----------------------------------------------------------------------
BessFixture/BessGet/4                    14 ns         14 ns   48601637   70.2994M items/s
BessFixture/BessGet/16                   14 ns         14 ns   50540625   68.7609M items/s
BessFixture/BessGet/64                   14 ns         14 ns   51201762   70.3821M items/s
BessFixture/BessGet/256                  16 ns         16 ns   44421665   60.2655M items/s
BessFixture/BessGet/1024                 18 ns         18 ns   37760110   51.6556M items/s
BessFixture/BessGet/4k                   22 ns         22 ns   32130403    42.721M items/s
BessFixture/BessGet/16k                  26 ns         26 ns   27624308   37.2368M items/s
BessFixture/BessGet/64k                  29 ns         29 ns   24268172   33.0974M items/s
BessFixture/BessGet/256k                 32 ns         32 ns   21646936   29.5083M items/s
BessFixture/BessGet/1024k                37 ns         37 ns   18744430     25.92M items/s
BessFixture/BessGet/4M                   75 ns         75 ns    8758345   12.7431M items/s
BessFixture/BessInlinedGet/4              4 ns          4 ns  178474210   243.156M items/s
BessFixture/BessInlinedGet/16             5 ns          5 ns  148216962   202.099M items/s
BessFixture/BessInlinedGet/64             4 ns          4 ns  167609541   217.959M items/s
BessFixture/BessInlinedGet/256            4 ns          4 ns  164916620   230.309M items/s
BessFixture/BessInlinedGet/1024           4 ns          4 ns  164390748   224.532M items/s
BessFixture/BessInlinedGet/4k            10 ns         10 ns   68487332   93.1635M items/s
BessFixture/BessInlinedGet/16k           15 ns         15 ns   46478973   63.3617M items/s
BessFixture/BessInlinedGet/64k           17 ns         17 ns   41296390   55.8423M items/s
BessFixture/BessInlinedGet/256k          20 ns         20 ns   35640899   48.5433M items/s
BessFixture/BessInlinedGet/1024k         23 ns         23 ns   30354931   41.4373M items/s
BessFixture/BessInlinedGet/4M            35 ns         35 ns   19849144   26.9052M items/s
```