### PR TITLE
Introduce big endian types and EthHeader

### DIFF
--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "../utils/endian.h"
 #include "../utils/format.h"
 
 // XXX: this is repeated in many modules. get rid of them when converting .h to
@@ -55,7 +56,7 @@ pb_error_t ExactMatch::AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
     f->mask = ((uint64_t)1 << (f->size * 8)) - 1;
   } else {
     if (uint64_to_bin((uint8_t *)&f->mask, f->size, field.mask(),
-                      is_be_system() | force_be))
+                      bess::utils::is_be_system() | force_be))
       return pb_error(EINVAL, "idx %d: not a correct %d-byte mask", idx,
                       f->size);
   }
@@ -334,7 +335,7 @@ pb_error_t ExactMatch::GatherKey(const RepeatedField<uint64_t> &fields,
     uint64_t f_obj = fields.Get(i);
 
     if (uint64_to_bin((uint8_t *)&f, field_size, f_obj,
-                      force_be | is_be_system())) {
+                      bess::utils::is_be_system() | force_be)) {
       return pb_error(EINVAL, "idx %d: not a correct %d-byte value", i,
                       field_size);
     }

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -1,5 +1,6 @@
 #include "wildcard_match.h"
 
+#include "../utils/endian.h"
 #include "../utils/format.h"
 
 /* k1 = k2 & mask */
@@ -380,11 +381,12 @@ pb_error_t WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
     int force_be = (fields_[i].attr_id < 0);
 
     if (uint64_to_bin(reinterpret_cast<uint8_t *>(&v), field_size,
-                      arg.values(i), force_be || is_be_system())) {
+                      arg.values(i), force_be || bess::utils::is_be_system())) {
       return pb_error(EINVAL, "idx %lu: not a correct %d-byte value", i,
                       field_size);
     } else if (uint64_to_bin(reinterpret_cast<uint8_t *>(&m), field_size,
-                             arg.masks(i), force_be || is_be_system())) {
+                             arg.masks(i),
+                             force_be || bess::utils::is_be_system())) {
       return pb_error(EINVAL, "idx %lu: not a correct %d-byte mask", i,
                       field_size);
     }

--- a/core/snobj.cc
+++ b/core/snobj.cc
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 
+#include "utils/endian.h"
 #include "utils/format.h"
 
 #define DEF_LIST_SLOTS 4
@@ -345,7 +346,7 @@ int snobj_binvalue_get(struct snobj *m, uint32_t size, void *dst,
 
     case TYPE_INT:
       return uint64_to_bin((uint8_t *)dst, size, snobj_uint_get(m),
-                           is_be_system() || force_be);
+                           bess::utils::is_be_system() || force_be);
 
     default:
       return -EINVAL;

--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -79,14 +79,6 @@ static inline int is_err_or_null(const void *ptr) {
   return !ptr || is_err(ptr);
 }
 
-static inline int is_be_system() {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  return 1;
-#else
-  return 0;
-#endif
-}
-
 #define __cacheline_aligned __attribute__((aligned(64)))
 
 /* For x86_64. DMA operations are not safe with these macros */

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -1,5 +1,5 @@
-#ifndef BESS_UTILS_ENDIAN_H
-#define BESS_UTILS_ENDIAN_H
+#ifndef BESS_UTILS_ENDIAN_H_
+#define BESS_UTILS_ENDIAN_H_
 
 #include <cstdint>
 
@@ -73,4 +73,4 @@ static_assert(sizeof(be64_t) == 8, "be64_t is not 8 bytes");
 }  // namespace utils
 }  // namespace bess
 
-#endif  // BESS_UTILS_ENDIAN_H
+#endif  // BESS_UTILS_ENDIAN_H_

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -1,0 +1,76 @@
+#ifndef BESS_UTILS_ENDIAN_H
+#define BESS_UTILS_ENDIAN_H
+
+#include <cstdint>
+
+namespace bess {
+namespace utils {
+
+constexpr bool is_be_system() {
+  return (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__);
+}
+
+template <typename T>
+class EndianBase {
+ public:
+  static constexpr T swap(const T &v);
+};
+
+template <>
+class EndianBase<uint16_t> {
+ public:
+  static constexpr uint16_t swap(const uint16_t &v) {
+    return __builtin_bswap16(v);
+  }
+};
+
+template <>
+class EndianBase<uint32_t> {
+ public:
+  static constexpr uint32_t swap(const uint32_t &v) {
+    return __builtin_bswap32(v);
+  }
+};
+
+template <>
+class EndianBase<uint64_t> {
+ public:
+  static constexpr uint64_t swap(const uint64_t &v) {
+    return __builtin_bswap64(v);
+  }
+};
+
+template <typename T>
+class [[gnu::packed]] BigEndian : public EndianBase<T> {
+ public:
+  BigEndian() = default;
+  BigEndian(const T &value) : value_(value) {}
+
+  constexpr T to_cpu() {
+    return is_be_system() ? value_ : EndianBase<T>::swap(value_);
+  }
+
+  static constexpr T to_cpu(const T &v) {
+    return is_be_system() ? v : EndianBase<T>::swap(v);
+  }
+
+ protected:
+  T value_;
+};
+
+using be16_t = BigEndian<uint16_t>;
+using be32_t = BigEndian<uint32_t>;
+using be64_t = BigEndian<uint64_t>;
+
+static_assert(std::is_pod<be16_t>::value, "not a POD type");
+static_assert(std::is_pod<be32_t>::value, "not a POD type");
+static_assert(std::is_pod<be64_t>::value, "not a POD type");
+
+static_assert(sizeof(be16_t) == 2, "be16_t is not 2 bytes");
+static_assert(sizeof(be32_t) == 4, "be32_t is not 4 bytes");
+static_assert(sizeof(be64_t) == 8, "be64_t is not 8 bytes");
+
+}  // namespace utils
+}  // namespace bess
+
+#endif  // BESS_UTILS_ENDIAN_H

--- a/core/utils/ether.cc
+++ b/core/utils/ether.cc
@@ -1,0 +1,46 @@
+#include "ether.h"
+
+#include <cstring>
+#include <sstream>
+
+#include "endian.h"
+#include "format.h"
+#include "time.h"
+
+namespace bess {
+namespace utils {
+
+using Address = EthHeader::Address;
+
+Address::Address(const std::string &str) {
+  if (!FromString(str)) {
+    memset(bytes, 0, sizeof(bytes));
+  };
+}
+
+bool Address::FromString(const std::string &str) {
+  int ret = Parse(str, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx", &bytes[0],
+                   &bytes[1], &bytes[2], &bytes[3], &bytes[4], &bytes[5]);
+  return (ret == Address::kSize);
+}
+
+std::string Address::ToString() const {
+  return Format("%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", bytes[0], bytes[1],
+                bytes[2], bytes[3], bytes[4], bytes[5]);
+}
+
+void Address::Randomize() {
+  uint64_t tsc = rdtsc();
+
+  if (is_be_system()) {
+    memcpy(bytes, reinterpret_cast<char *>(&tsc) + 2, sizeof(bytes));
+  } else {
+    memcpy(bytes, &tsc, sizeof(bytes));
+  }
+
+  bytes[0] &= 0xfe;  // not broadcast/multicast
+  bytes[1] |= 0x02;  // locally administered
+}
+
+}  // namespace utils
+}  // namespace bess

--- a/core/utils/ether.h
+++ b/core/utils/ether.h
@@ -1,5 +1,5 @@
-#ifndef BESS_UTILS_ETHER_H
-#define BESS_UTILS_ETHER_H
+#ifndef BESS_UTILS_ETHER_H_
+#define BESS_UTILS_ETHER_H_
 
 #include <cstdint>
 #include <string>
@@ -55,9 +55,9 @@ struct [[gnu::packed]] EthHeader {
 
 static_assert(std::is_pod<EthHeader>::value, "not a POD type");
 static_assert(std::is_pod<EthHeader::Address>::value, "not a POD type");
-static_assert(sizeof(EthHeader) == 14, "struct Ethernet is incorrect");
+static_assert(sizeof(EthHeader) == 14, "struct EthHeader is incorrect");
 
 }  // namespace utils
 }  // namespace bess
 
-#endif  // BESS_UTILS_ETHER_H
+#endif  // BESS_UTILS_ETHER_H_

--- a/core/utils/ether.h
+++ b/core/utils/ether.h
@@ -1,0 +1,63 @@
+#ifndef BESS_UTILS_ETHER_H
+#define BESS_UTILS_ETHER_H
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+#include "endian.h"
+
+namespace bess {
+namespace utils {
+
+struct [[gnu::packed]] EthHeader {
+  struct [[gnu::packed]] Address {
+    Address() = default;
+    Address(const std::string &str);
+
+    static const size_t kSize = 6;
+
+    // Parses str in "aA:Bb:00:11:22:33" format and saves the address in parsed
+    // Returns false if the format is incorrect.
+    //   (in that case, the content of parsed is undefined.)
+    bool FromString(const std::string &str);
+
+    // Returns "aA:Bb:00:11:22:33"
+    std::string ToString() const;
+
+    void Randomize();
+
+    bool operator == (const Address &o) const {
+      for (size_t i = 0; i < kSize; i++) {
+        if (bytes[i] != o.bytes[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    bool operator !=(const Address &o) const {
+      for (size_t i = 0; i < kSize; i++) {
+        if (bytes[i] != o.bytes[i]) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    char bytes[kSize];
+  };
+
+  Address dst_addr;
+  Address src_addr;
+  be16_t ether_type;
+};
+
+static_assert(std::is_pod<EthHeader>::value, "not a POD type");
+static_assert(std::is_pod<EthHeader::Address>::value, "not a POD type");
+static_assert(sizeof(EthHeader) == 14, "struct Ethernet is incorrect");
+
+}  // namespace utils
+}  // namespace bess
+
+#endif  // BESS_UTILS_ETHER_H

--- a/core/utils/ether_test.cc
+++ b/core/utils/ether_test.cc
@@ -1,0 +1,63 @@
+#include "ether.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using MacAddr = bess::utils::EthHeader::Address;
+
+TEST(EthHeaderTest, AddressInStr) {
+  MacAddr a;
+
+  EXPECT_FALSE(a.FromString("0g:12:34:56:78:90"));
+  EXPECT_FALSE(a.FromString("0f:12:34:56:78:"));
+  EXPECT_FALSE(a.FromString("00:12:34:56:7::90"));
+
+  EXPECT_TRUE(a.FromString("a:b:c:d:e:f"));
+  EXPECT_STREQ("0a:0b:0c:0d:0e:0f", a.ToString().c_str());
+
+  EXPECT_TRUE(a.FromString("00:00:00:00:00:00"));
+  EXPECT_STREQ("00:00:00:00:00:00", a.ToString().c_str());
+
+  EXPECT_TRUE(a.FromString("12:f:34:56:78:90"));
+  EXPECT_STREQ("12:0f:34:56:78:90", a.ToString().c_str());
+
+  MacAddr b("12:0F:34:56:78:90");
+  EXPECT_STREQ(b.ToString().c_str(), a.ToString().c_str());
+}
+
+TEST(EthHeaderTest, AddrEquality) {
+  MacAddr a("a0:17:03:20:b8:9");
+  MacAddr b("A0:17:3:20:B8:09");
+  MacAddr c("a0:18:3:20:b8:09");
+
+  EXPECT_EQ(a, a);
+  EXPECT_EQ(b, b);
+  EXPECT_EQ(c, c);
+
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(b, a);
+  EXPECT_NE(a, c);
+  EXPECT_NE(c, a);
+  EXPECT_NE(b, c);
+  EXPECT_NE(c, b);
+}
+
+TEST(EthHeaderTest, RandomAddr) {
+  MacAddr a;
+  MacAddr b;
+  MacAddr c("a0:18:3:20:b8:09");
+
+  a.Randomize();
+  b.Randomize();
+  c.Randomize();
+
+  EXPECT_NE(a, b);
+  EXPECT_NE(a, c);
+  EXPECT_NE(b, c);
+
+  MacAddr d("a0:18:3:20:b8:09");
+  EXPECT_NE(c, d);
+}
+
+}  // namespace (unnamed)

--- a/core/utils/format.cc
+++ b/core/utils/format.cc
@@ -6,14 +6,6 @@
 namespace bess {
 namespace utils {
 
-std::string Format(const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  const std::string s = FormatVarg(fmt, ap);
-  va_end(ap);
-  return s;
-}
-
 std::string FormatVarg(const char *fmt, va_list ap) {
   char *ptr = nullptr;
   int len = vasprintf(&ptr, fmt, ap);
@@ -22,6 +14,26 @@ std::string FormatVarg(const char *fmt, va_list ap) {
 
   std::string ret(ptr, len);
   free(ptr);
+  return ret;
+}
+
+std::string Format(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  const std::string s = FormatVarg(fmt, ap);
+  va_end(ap);
+  return s;
+}
+
+int ParseVarg(const std::string &s, const char *fmt, va_list ap) {
+  return vsscanf(s.c_str(), fmt, ap);
+}
+
+int Parse(const std::string &s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int ret = ParseVarg(s, fmt, ap);
+  va_end(ap);
   return ret;
 }
 

--- a/core/utils/format.h
+++ b/core/utils/format.h
@@ -9,8 +9,12 @@
 namespace bess {
 namespace utils {
 
-[[gnu::format(printf, 1, 2)]] std::string Format(const char *fmt, ...);
 std::string FormatVarg(const char *fmt, va_list ap);
+[[gnu::format(printf, 1, 2)]] std::string Format(const char *fmt, ...);
+
+int ParseVarg(const std::string &s, const char *fmt, va_list ap);
+[[gnu::format(scanf, 2, 3)]] int Parse(const std::string &s, const char *fmt,
+                                       ...);
 
 }  // namespace utils
 }  // namespace bess


### PR DESCRIPTION
This PR adds C++-style declaration of beXX_t type and Ethernet header, which used to rely on DPDK's rte_ether.h and rte_byteorder.h.