### PR TITLE
Enable -Wmissing-field-initializers

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -45,8 +45,7 @@ endif
 CXXFLAGS += -std=gnu++11 -g3 -ggdb3 -Ofast -march=native \
 	    -Werror -isystem $(DPDK_INC_DIR) -D_GNU_SOURCE
 
-HARDCORE = -Wall -Wextra -Wcast-align \
-	   -Wno-missing-field-initializers	# FIXME
+HARDCORE = -Wall -Wextra -Wcast-align
 
 # -Wshadow should not be used for g++ 4.x, as it has too many false positives
 CXXVERSION_5_OR_HIGHER := $(shell expr $(CXXVERSION) \>= 50000)

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -101,13 +101,13 @@ static int collect_metadata(Module* m, GetModuleInfoResponse* response) {
     attr->set_size(m->attrs[i].size);
 
     switch (m->attrs[i].mode) {
-      case bess::metadata::AccessMode::READ:
+      case bess::metadata::Attribute::AccessMode::kRead:
         attr->set_mode("read");
         break;
-      case bess::metadata::AccessMode::WRITE:
+      case bess::metadata::Attribute::AccessMode::kWrite:
         attr->set_mode("write");
         break;
-      case bess::metadata::AccessMode::UPDATE:
+      case bess::metadata::Attribute::AccessMode::kUpdate:
         attr->set_mode("update");
         break;
       default:

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -94,13 +94,14 @@ static int collect_ogates(Module* m, GetModuleInfoResponse* response) {
 }
 
 static int collect_metadata(Module* m, GetModuleInfoResponse* response) {
-  for (size_t i = 0; i < m->num_attrs; i++) {
+  size_t i = 0;
+  for (const auto &it : m->all_attrs()) {
     GetModuleInfoResponse_Attribute* attr = response->add_metadata();
 
-    attr->set_name(m->attrs[i].name);
-    attr->set_size(m->attrs[i].size);
+    attr->set_name(it.name);
+    attr->set_size(it.size);
 
-    switch (m->attrs[i].mode) {
+    switch (it.mode) {
       case bess::metadata::Attribute::AccessMode::kRead:
         attr->set_mode("read");
         break;
@@ -115,6 +116,7 @@ static int collect_metadata(Module* m, GetModuleInfoResponse* response) {
     }
 
     attr->set_offset(m->attr_offsets[i]);
+    i++;
   }
 
   return 0;

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 
 #include <glog/logging.h>
@@ -112,8 +113,11 @@ static void init_eal(char *prog_name, int mb_per_socket, int multi_instance) {
 
   /* DPDK creates duplicated outputs (stdout and syslog).
    * We temporarily disable syslog, then set our log handler */
-  cookie_io_functions_t dpdk_log_init_funcs = {};
-  cookie_io_functions_t dpdk_log_funcs = {};
+  cookie_io_functions_t dpdk_log_init_funcs;
+  cookie_io_functions_t dpdk_log_funcs;
+
+  std::memset(&dpdk_log_init_funcs, 0, sizeof(dpdk_log_init_funcs));
+  std::memset(&dpdk_log_funcs, 0, sizeof(dpdk_log_funcs));
 
   dpdk_log_init_funcs.write = &dpdk_log_init_writer;
   dpdk_log_funcs.write = &dpdk_log_writer;

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -9,6 +9,7 @@
 #define SN_HW_RXCSUM 0
 #define SN_HW_TXCSUM 0
 
+#if 0
 static const struct rte_eth_conf default_eth_conf = {
     .link_speeds = ETH_LINK_SPEED_AUTONEG,
     .rxmode =
@@ -51,6 +52,37 @@ static const struct rte_eth_conf default_eth_conf = {
             .lsc = 0,
         },
 };
+#endif
+
+static const struct rte_eth_conf default_eth_conf() {
+  struct rte_eth_conf ret = {};
+
+  ret.link_speeds = ETH_LINK_SPEED_AUTONEG;
+
+  ret.rxmode = {
+      .mq_mode = ETH_MQ_RX_RSS,       /* doesn't matter for 1-queue */
+      .max_rx_pkt_len = 0,            /* valid only if jumbo is on */
+      .split_hdr_size = 0,            /* valid only if HS is on */
+      .header_split = 0,              /* Header Split */
+      .hw_ip_checksum = SN_HW_RXCSUM, /* IP checksum offload */
+      .hw_vlan_filter = 0,            /* VLAN filtering */
+      .hw_vlan_strip = 0,             /* VLAN strip */
+      .hw_vlan_extend = 0,            /* Extended VLAN */
+      .jumbo_frame = 0,               /* Jumbo Frame support */
+      .hw_strip_crc = 1,              /* CRC stripped by hardware */
+      .enable_scatter = 0,            /* no scattered RX */
+      .enable_lro = 0,                /* no large receive offload */
+  };
+
+  ret.rx_adv_conf.rss_conf = {
+      .rss_key = nullptr,
+      .rss_key_len = 40,
+      /* TODO: query rte_eth_dev_info_get() to set this*/
+      .rss_hf = ETH_RSS_IP | ETH_RSS_UDP | ETH_RSS_TCP | ETH_RSS_SCTP,
+  };
+
+  return ret;
+}
 
 void PMDPort::InitDriver() {
   dpdk_port_t num_dpdk_ports = rte_eth_dev_count();
@@ -272,7 +304,7 @@ struct snobj *PMDPort::Init(struct snobj *conf) {
     return err;
   }
 
-  eth_conf = default_eth_conf;
+  eth_conf = default_eth_conf();
   if (snobj_eval_int(conf, "loopback")) {
     eth_conf.lpbk_mode = 1;
   }
@@ -356,7 +388,7 @@ pb_error_t PMDPort::InitPb(const bess::pb::PMDPortArg &arg) {
     return err;
   }
 
-  eth_conf = default_eth_conf;
+  eth_conf = default_eth_conf();
   if (arg.loopback()) {
     eth_conf.lpbk_mode = 1;
   }

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -55,7 +55,7 @@ static const struct rte_eth_conf default_eth_conf = {
 #endif
 
 static const struct rte_eth_conf default_eth_conf() {
-  struct rte_eth_conf ret = {};
+  struct rte_eth_conf ret = rte_eth_conf();
 
   ret.link_speeds = ETH_LINK_SPEED_AUTONEG;
 
@@ -93,7 +93,6 @@ void PMDPort::InitDriver() {
     struct rte_eth_dev_info dev_info;
     std::string pci_info;
 
-    memset(&dev_info, 0, sizeof(dev_info));
     rte_eth_dev_info_get(i, &dev_info);
 
     if (dev_info.pci_dev) {
@@ -285,7 +284,7 @@ static pb_error_t find_dpdk_port(dpdk_port_t port_id, const std::string &pci,
 struct snobj *PMDPort::Init(struct snobj *conf) {
   dpdk_port_t port_id = -1;
 
-  struct rte_eth_dev_info dev_info = {};
+  struct rte_eth_dev_info dev_info;
   struct rte_eth_conf eth_conf;
   struct rte_eth_rxconf eth_rxconf;
   struct rte_eth_txconf eth_txconf;
@@ -370,7 +369,7 @@ struct snobj *PMDPort::Init(struct snobj *conf) {
 pb_error_t PMDPort::InitPb(const bess::pb::PMDPortArg &arg) {
   dpdk_port_t ret_port_id = -1;
 
-  struct rte_eth_dev_info dev_info = {};
+  struct rte_eth_dev_info dev_info;
   struct rte_eth_conf eth_conf;
   struct rte_eth_rxconf eth_rxconf;
   struct rte_eth_txconf eth_txconf;

--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -484,8 +484,8 @@ pb_error_t VPort::InitPb(const bess::pb::VPortArg &arg) {
 
   pb_error_t err;
 
-  struct tx_queue_opts txq_opts = {};
-  struct rx_queue_opts rxq_opts = {};
+  struct tx_queue_opts txq_opts = tx_queue_opts();
+  struct rx_queue_opts rxq_opts = rx_queue_opts();
 
   fd_ = -1;
   netns_fd_ = -1;
@@ -739,8 +739,8 @@ struct snobj *VPort::Init(struct snobj *conf) {
 
   struct snobj *err = nullptr;
 
-  struct tx_queue_opts txq_opts = {};
-  struct rx_queue_opts rxq_opts = {};
+  struct tx_queue_opts txq_opts = tx_queue_opts();
+  struct rx_queue_opts rxq_opts = rx_queue_opts();
 
   fd_ = -1;
   netns_fd_ = -1;
@@ -931,7 +931,7 @@ int VPort::SendPackets(queue_t qid, snb_array_t pkts, int cnt) {
     rx_desc->seg = snb_dma_addr(snb);
     rx_desc->next = 0;
 
-    rx_desc->meta = {};
+    rx_desc->meta = sn_rx_metadata();
 
     for (struct rte_mbuf *seg = mbuf->next; seg; seg = seg->next) {
       struct sn_rx_desc *next_desc;

--- a/core/drivers/vport.h
+++ b/core/drivers/vport.h
@@ -6,6 +6,7 @@
 
 class VPort : public Port {
  public:
+  VPort() : fd_(), bar_(), map_(), netns_fd_(), container_pid_() {}
   virtual void InitDriver();
 
   pb_error_t InitPb(const bess::pb::VPortArg &arg);
@@ -32,18 +33,18 @@ class VPort : public Port {
   pb_error_t SetIPAddr(const bess::pb::VPortArg &arg);
   struct snobj *SetIPAddr(struct snobj *arg);
 
-  int fd_ = {};
+  int fd_;
 
-  char ifname_[IFNAMSIZ] = {}; /* could be different from Name() */
-  void *bar_ = {};
+  char ifname_[IFNAMSIZ]; /* could be different from Name() */
+  void *bar_;
 
   struct queue inc_qs_[MAX_QUEUES_PER_DIR];
   struct queue out_qs_[MAX_QUEUES_PER_DIR];
 
-  struct sn_ioc_queue_mapping map_ = {};
+  struct sn_ioc_queue_mapping map_;
 
-  int netns_fd_ = {};
-  int container_pid_ = {};
+  int netns_fd_;
+  int container_pid_;
 };
 
 #endif  // BESS_DRIVERS_VPORT_H_

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -124,8 +124,6 @@ void Pipeline::CleanupMetadataComputation() {
   module_components_.clear();
   module_scopes_.clear();
 
-  attributes_.clear();
-
   for (auto &c : scope_components_) {
     c.clear_modules();
   }
@@ -458,6 +456,8 @@ int Pipeline::ComputeMetadataOffsets() {
   return 0;
 }
 
+// TODO: We need to keep track of the number of modules that registered each
+// attribute. Then RegisterAttribute does +1 while Deregister one dpes -1
 int Pipeline::RegisterAttribute(const struct Attribute *attr) {
   attr_id_t id = get_attr_id(attr);
   const auto &it = attributes_.find(id);

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -47,12 +47,14 @@ static inline int IsValidOffset(mt_offset_t offset) {
   return (offset >= 0);
 }
 
-enum class AccessMode { READ = 0, WRITE, UPDATE };
-
-struct mt_attr {
+struct Attribute {
   std::string name;
   int size;
-  AccessMode mode;
+  enum class AccessMode {
+    kRead = 0,
+    kWrite,
+    kUpdate
+  } mode;
   int scope_id;
 };
 
@@ -126,7 +128,7 @@ class Pipeline {
   // Registers attr and returns 0 if no attribute named attr->name with size
   // other than attr->size has already been registered for this pipeline.
   // Returns -errno on error.
-  int RegisterAttribute(const struct mt_attr *attr);
+  int RegisterAttribute(const struct Attribute *attr);
 
  private:
   friend class MetadataTest;
@@ -138,24 +140,24 @@ class Pipeline {
   void CleanupMetadataComputation();
 
   // Add a module to the current scope component.
-  void AddModuleToComponent(Module *m, struct mt_attr *attr);
+  void AddModuleToComponent(Module *m, struct Attribute *attr);
 
   // Returns a pointer to an attribute if it's contained within a module.
-  struct mt_attr *FindAttr(Module *m, struct mt_attr *attr);
+  struct Attribute *FindAttr(Module *m, struct Attribute *attr);
 
   // Traverses module graph upstream to help identify a scope component.
-  void TraverseUpstream(Module *m, struct mt_attr *attr);
+  void TraverseUpstream(Module *m, struct Attribute *attr);
 
   // Traverses module graph downstream to help identify a scope component.
   // Returns 0 if module is part of the scope component, -1 if not.
-  int TraverseDownstream(Module *m, struct mt_attr *attr);
+  int TraverseDownstream(Module *m, struct Attribute *attr);
 
   // Wrapper for identifying scope components.
-  void IdentifySingleScopeComponent(Module *m, struct mt_attr *attr);
+  void IdentifySingleScopeComponent(Module *m, struct Attribute *attr);
 
   // Given a module that writes an attr, identifies the corresponding scope
   // component.
-  void IdentifyScopeComponent(Module *m, struct mt_attr *attr);
+  void IdentifyScopeComponent(Module *m, struct Attribute *attr);
 
   void FillOffsetArrays();
   void AssignOffsets();
@@ -170,7 +172,7 @@ class Pipeline {
   std::map<const Module *, scope_id_t *> module_components_;
 
   // Keeps track of the attributes used by modules in this pipeline
-  std::map<attr_id_t, const struct mt_attr *> attributes_;
+  std::map<attr_id_t, const struct Attribute *> attributes_;
 };
 
 extern bess::metadata::Pipeline default_pipeline;

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -55,7 +55,7 @@ struct Attribute {
     kWrite,
     kUpdate
   } mode;
-  int scope_id;
+  mutable int scope_id;
 };
 
 typedef std::string attr_id_t;
@@ -119,9 +119,6 @@ class Pipeline {
  public:
   Pipeline() : scope_components_(), module_scopes_(){};
 
-  // Debugging tool.
-  void LogAllScopesPerModule();
-
   // Main entry point for calculating metadata offsets.
   int ComputeMetadataOffsets();
 
@@ -139,25 +136,28 @@ class Pipeline {
 
   void CleanupMetadataComputation();
 
+  // Debugging tool.
+  void LogAllScopes();
+
   // Add a module to the current scope component.
-  void AddModuleToComponent(Module *m, struct Attribute *attr);
+  void AddModuleToComponent(Module *m, const struct Attribute *attr);
 
   // Returns a pointer to an attribute if it's contained within a module.
-  struct Attribute *FindAttr(Module *m, struct Attribute *attr);
+  const struct Attribute *FindAttr(Module *m, const struct Attribute *attr) const;
 
   // Traverses module graph upstream to help identify a scope component.
-  void TraverseUpstream(Module *m, struct Attribute *attr);
+  void TraverseUpstream(Module *m, const struct Attribute *attr);
 
   // Traverses module graph downstream to help identify a scope component.
   // Returns 0 if module is part of the scope component, -1 if not.
-  int TraverseDownstream(Module *m, struct Attribute *attr);
+  int TraverseDownstream(Module *m, const struct Attribute *attr);
 
   // Wrapper for identifying scope components.
-  void IdentifySingleScopeComponent(Module *m, struct Attribute *attr);
+  void IdentifySingleScopeComponent(Module *m, const struct Attribute *attr);
 
   // Given a module that writes an attr, identifies the corresponding scope
   // component.
-  void IdentifyScopeComponent(Module *m, struct Attribute *attr);
+  void IdentifyScopeComponent(Module *m, const struct Attribute *attr);
 
   void FillOffsetArrays();
   void AssignOffsets();

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -49,7 +49,7 @@ static inline int IsValidOffset(mt_offset_t offset) {
 
 struct Attribute {
   std::string name;
-  int size;
+  size_t size;  // in bytes
   enum class AccessMode {
     kRead = 0,
     kWrite,

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -59,11 +59,11 @@ class MetadataTest : public ::testing::Test {
 };
 
 TEST(Metadata, RegisterSizeMismatchFails) {
-  struct bess::metadata::mt_attr attr0_s1 = {
-      .name = "attr0", .size = 1, .mode = bess::metadata::AccessMode::READ,
+  struct Attribute attr0_s1 = {
+      .name = "attr0", .size = 1, .mode = Attribute::AccessMode::kRead,
   };
-  struct bess::metadata::mt_attr attr0_s2 = {
-      .name = "attr0", .size = 2, .mode = bess::metadata::AccessMode::WRITE,
+  struct Attribute attr0_s2 = {
+      .name = "attr0", .size = 2, .mode = Attribute::AccessMode::kWrite,
   };
 
   ASSERT_EQ(0, default_pipeline.RegisterAttribute(&attr0_s1));
@@ -71,15 +71,15 @@ TEST(Metadata, RegisterSizeMismatchFails) {
 }
 
 TEST_F(MetadataTest, DisconnectedFails) {
-  ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, bess::metadata::AccessMode::WRITE));
-  ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, bess::metadata::AccessMode::READ));
+  ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, Attribute::AccessMode::kWrite));
+  ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, Attribute::AccessMode::kRead));
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
   ASSERT_TRUE(m1->attr_offsets[0] < 0);
 }
 
 TEST_F(MetadataTest, SingleAttrSimplePipe) {
-  ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, bess::metadata::AccessMode::WRITE));
-  ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, bess::metadata::AccessMode::READ));
+  ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, Attribute::AccessMode::kWrite));
+  ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, Attribute::AccessMode::kRead));
   m0->ConnectModules(0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
@@ -93,46 +93,46 @@ TEST_F(MetadataTest, SingleAttrSimplePipe) {
 
 // Check that the "error" offsets arre assigned correctly
 TEST_F(MetadataTest, SingleAttrSimplePipeBackwardsFails) {
-  ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, bess::metadata::AccessMode::READ));
-  ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, bess::metadata::AccessMode::WRITE));
+  ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, Attribute::AccessMode::kRead));
+  ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, Attribute::AccessMode::kWrite));
 
   m0->ConnectModules(0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
-  ASSERT_EQ(bess::metadata::kMetadataOffsetNoRead, m0->attr_offsets[0]);
-  ASSERT_EQ(bess::metadata::kMetadataOffsetNoWrite, m1->attr_offsets[0]);
+  ASSERT_EQ(kMetadataOffsetNoRead, m0->attr_offsets[0]);
+  ASSERT_EQ(kMetadataOffsetNoWrite, m1->attr_offsets[0]);
 }
 
 // Check that offsets are properly assigned when there are too many attributes.
 TEST_F(MetadataTest, MultipleAttrSimplePipeNoSpaceFails) {
-  size_t sz = bess::metadata::kMetadataAttrMaxSize;
-  size_t n = bess::metadata::kMetadataTotalSize / sz;
+  size_t sz = kMetadataAttrMaxSize;
+  size_t n = kMetadataTotalSize / sz;
   for (size_t i = 0; i < n + 1; i++) {
     std::ostringstream os;
     os << "attr" << i;
     std::string s = os.str();
-    ASSERT_EQ(i, m0->AddMetadataAttr(s, sz, bess::metadata::AccessMode::WRITE));
-    ASSERT_EQ(i, m1->AddMetadataAttr(s, sz, bess::metadata::AccessMode::READ));
+    ASSERT_EQ(i, m0->AddMetadataAttr(s, sz, Attribute::AccessMode::kWrite));
+    ASSERT_EQ(i, m1->AddMetadataAttr(s, sz, Attribute::AccessMode::kRead));
   }
   m0->ConnectModules(0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
-  ASSERT_EQ(bess::metadata::kMetadataOffsetNoSpace, m0->attr_offsets[n]);
-  ASSERT_EQ(bess::metadata::kMetadataOffsetNoSpace, m1->attr_offsets[n]);
+  ASSERT_EQ(kMetadataOffsetNoSpace, m0->attr_offsets[n]);
+  ASSERT_EQ(kMetadataOffsetNoSpace, m1->attr_offsets[n]);
 }
 
 TEST_F(MetadataTest, MultipeAttrSimplePipe) {
-  bool dummy_meta[bess::metadata::kMetadataTotalSize] = {};
-  ASSERT_EQ(0, m0->AddMetadataAttr("a", 2, bess::metadata::AccessMode::WRITE));
-  ASSERT_EQ(1, m0->AddMetadataAttr("b", 3, bess::metadata::AccessMode::WRITE));
-  ASSERT_EQ(2, m0->AddMetadataAttr("c", 5, bess::metadata::AccessMode::WRITE));
-  ASSERT_EQ(3, m0->AddMetadataAttr("d", 8, bess::metadata::AccessMode::WRITE));
-  ASSERT_EQ(0, m1->AddMetadataAttr("a", 2, bess::metadata::AccessMode::READ));
-  ASSERT_EQ(1, m1->AddMetadataAttr("b", 3, bess::metadata::AccessMode::READ));
-  ASSERT_EQ(2, m1->AddMetadataAttr("c", 5, bess::metadata::AccessMode::READ));
-  ASSERT_EQ(3, m1->AddMetadataAttr("d", 8, bess::metadata::AccessMode::READ));
+  bool dummy_meta[kMetadataTotalSize] = {};
+  ASSERT_EQ(0, m0->AddMetadataAttr("a", 2, Attribute::AccessMode::kWrite));
+  ASSERT_EQ(1, m0->AddMetadataAttr("b", 3, Attribute::AccessMode::kWrite));
+  ASSERT_EQ(2, m0->AddMetadataAttr("c", 5, Attribute::AccessMode::kWrite));
+  ASSERT_EQ(3, m0->AddMetadataAttr("d", 8, Attribute::AccessMode::kWrite));
+  ASSERT_EQ(0, m1->AddMetadataAttr("a", 2, Attribute::AccessMode::kRead));
+  ASSERT_EQ(1, m1->AddMetadataAttr("b", 3, Attribute::AccessMode::kRead));
+  ASSERT_EQ(2, m1->AddMetadataAttr("c", 5, Attribute::AccessMode::kRead));
+  ASSERT_EQ(3, m1->AddMetadataAttr("d", 8, Attribute::AccessMode::kRead));
   m0->ConnectModules(0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
@@ -141,11 +141,11 @@ TEST_F(MetadataTest, MultipeAttrSimplePipe) {
     // Check that m1 is reading from where m0 is writing
     ASSERT_EQ(m1->attr_offsets[i], m0->attr_offsets[i]);
 
-    if (m0->attrs[i].mode == bess::metadata::AccessMode::READ)
+    if (m0->attrs[i].mode == Attribute::AccessMode::kRead)
       continue;
 
     // Check that m0 was assigned non-overlapping offsets for writes
-    bess::metadata::mt_offset_t offset = m0->attr_offsets[i];
+    mt_offset_t offset = m0->attr_offsets[i];
     ASSERT_TRUE(offset >= 0);
     for (mt_offset_t j = 0; j < m0->attrs[i].size; j++) {
       ASSERT_FALSE(dummy_meta[offset + j]);
@@ -161,19 +161,19 @@ TEST_F(MetadataTest, MultipeAttrComplexPipe) {
     mods.push_back(create_foo());
   }
 
-  mods[0]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::WRITE);
-  mods[1]->AddMetadataAttr("bar", 2, bess::metadata::AccessMode::WRITE);
-  mods[2]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::READ);
-  mods[2]->AddMetadataAttr("bar", 2, bess::metadata::AccessMode::READ);
-  mods[3]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::WRITE);
-  mods[4]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::READ);
-  mods[5]->AddMetadataAttr("bar", 2, bess::metadata::AccessMode::WRITE);
-  mods[6]->AddMetadataAttr("bar", 2, bess::metadata::AccessMode::READ);
-  mods[6]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::WRITE);
-  mods[7]->AddMetadataAttr("bar", 2, bess::metadata::AccessMode::WRITE);
-  mods[8]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::WRITE);
-  mods[9]->AddMetadataAttr("foo", 2, bess::metadata::AccessMode::READ);
-  mods[9]->AddMetadataAttr("bar", 2, bess::metadata::AccessMode::READ);
+  mods[0]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kWrite);
+  mods[1]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kWrite);
+  mods[2]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kRead);
+  mods[2]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kRead);
+  mods[3]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kWrite);
+  mods[4]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kRead);
+  mods[5]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kWrite);
+  mods[6]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kRead);
+  mods[6]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kWrite);
+  mods[7]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kWrite);
+  mods[8]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kWrite);
+  mods[9]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kRead);
+  mods[9]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kRead);
 
   mods[0]->ConnectModules(0, mods[1], 0);
   mods[1]->ConnectModules(0, mods[2], 0);
@@ -190,12 +190,12 @@ TEST_F(MetadataTest, MultipeAttrComplexPipe) {
 
   // Check that every module was assigned valid, non-overlapping offsets
   for (const auto &it : mods) {
-    bool dummy_meta[bess::metadata::kMetadataTotalSize] = {};
+    bool dummy_meta[kMetadataTotalSize] = {};
     for (size_t i = 0; i < it->num_attrs; i++) {
-      if (it->attrs[i].mode == bess::metadata::AccessMode::READ)
+      if (it->attrs[i].mode == Attribute::AccessMode::kRead)
         continue;
 
-      bess::metadata::mt_offset_t offset = it->attr_offsets[i];
+      mt_offset_t offset = it->attr_offsets[i];
       for (mt_offset_t j = 0; j < it->attrs[i].size; j++) {
         ASSERT_FALSE(dummy_meta[offset + j]);
         dummy_meta[offset + j] = true;
@@ -217,5 +217,6 @@ TEST_F(MetadataTest, MultipeAttrComplexPipe) {
   ASSERT_EQ(mods[7]->attr_offsets[0], mods[9]->attr_offsets[1]);
   ASSERT_EQ(mods[8]->attr_offsets[0], mods[9]->attr_offsets[0]);
 }
-}
-}
+
+}  // namespace metadata
+}  // namespace bess

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -61,10 +61,16 @@ class MetadataTest : public ::testing::Test {
 
 TEST(Metadata, RegisterSizeMismatchFails) {
   struct Attribute attr0_s1 = {
-      .name = "attr0", .size = 1, .mode = Attribute::AccessMode::kRead,
+      .name = "attr0",
+      .size = 1,
+      .mode = Attribute::AccessMode::kRead,
+      .scope_id = -1,
   };
   struct Attribute attr0_s2 = {
-      .name = "attr0", .size = 2, .mode = Attribute::AccessMode::kWrite,
+      .name = "attr0",
+      .size = 2,
+      .mode = Attribute::AccessMode::kWrite,
+      .scope_id = -1,
   };
 
   ASSERT_EQ(0, default_pipeline.RegisterAttribute(&attr0_s1));

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -146,8 +146,8 @@ TEST_F(MetadataTest, MultipeAttrSimplePipe) {
 
     // Check that m0 was assigned non-overlapping offsets for writes
     mt_offset_t offset = m0->attr_offsets[i];
-    ASSERT_TRUE(offset >= 0);
-    for (mt_offset_t j = 0; j < m0->attrs[i].size; j++) {
+    ASSERT_LE(0, offset);
+    for (size_t j = 0; j < m0->attrs[i].size; j++) {
       ASSERT_FALSE(dummy_meta[offset + j]);
       dummy_meta[offset + j] = true;
     }
@@ -196,12 +196,22 @@ TEST_F(MetadataTest, MultipeAttrComplexPipe) {
         continue;
 
       mt_offset_t offset = it->attr_offsets[i];
-      for (mt_offset_t j = 0; j < it->attrs[i].size; j++) {
+      if (offset < 0) {
+        EXPECT_EQ(it, mods[6]);
+        EXPECT_EQ(1, i);
+        EXPECT_STREQ("foo", it->attrs[i].name.c_str());
+        continue;
+      }
+
+      for (size_t j = 0; j < it->attrs[i].size; j++) {
         ASSERT_FALSE(dummy_meta[offset + j]);
         dummy_meta[offset + j] = true;
       }
     }
   }
+
+  // This write is never read by anyone
+  ASSERT_EQ(kMetadataOffsetNoWrite, mods[6]->attr_offsets[1]);
 
   // Check that those assignments conform to the way the modules are connected
   ASSERT_NE(mods[0]->attr_offsets[0], mods[1]->attr_offsets[0]);

--- a/core/module.cc
+++ b/core/module.cc
@@ -4,7 +4,6 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-#include <initializer_list>
 #include <sstream>
 
 #include <glog/logging.h>

--- a/core/module.cc
+++ b/core/module.cc
@@ -232,7 +232,10 @@ int Module::AddMetadataAttr(const std::string &name, int size,
   if (n >= bess::metadata::kMaxAttrsPerModule)
     return -ENOSPC;
 
-  if (!is_valid_attr(name.c_str(), size))
+  if (name.empty())
+    return -EINVAL;
+
+  if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize)
     return -EINVAL;
 
   attrs[n].name = name;

--- a/core/module.cc
+++ b/core/module.cc
@@ -39,6 +39,8 @@ Module *ModuleBuilder::CreateModule(const std::string &name,
   m->set_name(name);
   m->set_module_builder(this);
   m->set_pipeline(pipeline);
+  m->igates = gates();
+  m->ogates = gates();
   return m;
 }
 

--- a/core/module.cc
+++ b/core/module.cc
@@ -225,14 +225,14 @@ void Module::DestroyAllTasks() {
 }
 
 int Module::AddMetadataAttr(const std::string &name, int size,
-                            bess::metadata::AccessMode mode) {
+                            bess::metadata::Attribute::AccessMode mode) {
   size_t n = num_attrs;
   int ret;
 
   if (n >= bess::metadata::kMaxAttrsPerModule)
     return -ENOSPC;
 
-  if (!is_valid_attr(name.c_str(), size, mode))
+  if (!is_valid_attr(name.c_str(), size))
     return -EINVAL;
 
   attrs[n].name = name;

--- a/core/module.cc
+++ b/core/module.cc
@@ -224,7 +224,7 @@ void Module::DestroyAllTasks() {
   }
 }
 
-int Module::AddMetadataAttr(const std::string &name, int size,
+int Module::AddMetadataAttr(const std::string &name, size_t size,
                             bess::metadata::Attribute::AccessMode mode) {
   size_t n = num_attrs;
   int ret;

--- a/core/module.cc
+++ b/core/module.cc
@@ -225,10 +225,9 @@ void Module::DestroyAllTasks() {
 
 int Module::AddMetadataAttr(const std::string &name, size_t size,
                             bess::metadata::Attribute::AccessMode mode) {
-  size_t n = num_attrs;
   int ret;
 
-  if (n >= bess::metadata::kMaxAttrsPerModule)
+  if (attrs.size() >= bess::metadata::kMaxAttrsPerModule)
     return -ENOSPC;
 
   if (name.empty())
@@ -237,17 +236,19 @@ int Module::AddMetadataAttr(const std::string &name, size_t size,
   if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize)
     return -EINVAL;
 
-  attrs[n].name = name;
-  attrs[n].size = size;
-  attrs[n].mode = mode;
-  attrs[n].scope_id = -1;
-  if ((ret = pipeline_->RegisterAttribute(&attrs[n]))) {
+  bess::metadata::Attribute attr;
+  attr.name = name;
+  attr.size = size;
+  attr.mode = mode;
+  attr.scope_id = -1;
+
+  if ((ret = pipeline_->RegisterAttribute(&attr))) {
     return ret;
   }
 
-  num_attrs++;
+  attrs.push_back(attr);
 
-  return n;
+  return attrs.size() - 1;
 }
 
 int Module::GrowGates(struct gates *gates, gate_idx_t gate) {

--- a/core/module.h
+++ b/core/module.h
@@ -335,6 +335,10 @@ class Module {
     return module_builder_->RunCommand(this, cmd, arg);
   }
 
+  const std::vector<bess::metadata::Attribute> &all_attrs() const {
+    return attrs;
+  }
+
  private:
   void set_name(const std::string &name) { name_ = name; }
   void set_module_builder(const ModuleBuilder *builder) {
@@ -350,14 +354,13 @@ class Module {
 
   bess::metadata::Pipeline *pipeline_;
 
+  std::vector<bess::metadata::Attribute> attrs;
+
   DISALLOW_COPY_AND_ASSIGN(Module);
 
   // FIXME: porting in progress ----------------------------
  public:
   struct task *tasks[MAX_TASKS_PER_MODULE] = {};
-
-  size_t num_attrs = 0;
-  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {};
 
   int curr_scope = 0;
 

--- a/core/module.h
+++ b/core/module.h
@@ -312,7 +312,7 @@ class Module {
    * need this function.
    * Returns its allocated ID (>= 0), or a negative number for error */
   int AddMetadataAttr(const std::string &name, int size,
-                      bess::metadata::AccessMode mode);
+                      bess::metadata::Attribute::AccessMode mode);
 
 #if TCPDUMP_GATES
   int EnableTcpDump(const char *fifo, gate_idx_t gate);
@@ -359,7 +359,7 @@ class Module {
   struct task *tasks[MAX_TASKS_PER_MODULE] = {};
 
   size_t num_attrs = 0;
-  struct bess::metadata::mt_attr attrs[bess::metadata::kMaxAttrsPerModule] = {};
+  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {};
 
   int curr_scope = 0;
 
@@ -417,17 +417,11 @@ inline void Module::RunNextModule(struct pkt_batch *batch) {
   RunChooseModule(0, batch);
 }
 
-static inline int is_valid_attr(const std::string &name, size_t size,
-                                bess::metadata::AccessMode mode) {
+static inline int is_valid_attr(const std::string &name, size_t size) {
   if (name.empty())
     return 0;
 
   if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize)
-    return 0;
-
-  if (mode != bess::metadata::AccessMode::READ &&
-      mode != bess::metadata::AccessMode::WRITE &&
-      mode != bess::metadata::AccessMode::UPDATE)
     return 0;
 
   return 1;
@@ -453,7 +447,7 @@ static inline int is_active_gate(struct gates *gates, gate_idx_t idx) {
 typedef struct snobj *(*mod_cmd_func_t)(struct module *, const char *,
                                         struct snobj *);
 
-// Unsafe, but faster version. for offset use mt_attr_offset().
+// Unsafe, but faster version. for offset use Attribute_offset().
 template <typename T>
 inline T *_ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
                                 struct snbuf *pkt) {

--- a/core/module.h
+++ b/core/module.h
@@ -311,7 +311,7 @@ class Module {
    * 'instance'
    * need this function.
    * Returns its allocated ID (>= 0), or a negative number for error */
-  int AddMetadataAttr(const std::string &name, int bytes,
+  int AddMetadataAttr(const std::string &name, size_t size,
                       bess::metadata::Attribute::AccessMode mode);
 
 #if TCPDUMP_GATES

--- a/core/module.h
+++ b/core/module.h
@@ -11,7 +11,6 @@
 #include "snobj.h"
 #include "task.h"
 #include "utils/cdlist.h"
-#include "utils/simd.h"
 
 static inline void set_cmd_response_error(pb_cmd_response_t *response,
                                           const pb_error_t &error) {

--- a/core/module.h
+++ b/core/module.h
@@ -362,8 +362,6 @@ class Module {
  public:
   struct task *tasks[MAX_TASKS_PER_MODULE] = {};
 
-  int curr_scope = 0;
-
   bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule] =
       {};
   struct gates igates = {};

--- a/core/module.h
+++ b/core/module.h
@@ -311,7 +311,7 @@ class Module {
    * 'instance'
    * need this function.
    * Returns its allocated ID (>= 0), or a negative number for error */
-  int AddMetadataAttr(const std::string &name, int size,
+  int AddMetadataAttr(const std::string &name, int bytes,
                       bess::metadata::Attribute::AccessMode mode);
 
 #if TCPDUMP_GATES
@@ -415,16 +415,6 @@ inline void Module::RunChooseModule(gate_idx_t ogate_idx,
 
 inline void Module::RunNextModule(struct pkt_batch *batch) {
   RunChooseModule(0, batch);
-}
-
-static inline int is_valid_attr(const std::string &name, size_t size) {
-  if (name.empty())
-    return 0;
-
-  if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize)
-    return 0;
-
-  return 1;
 }
 
 /* run all per-thread initializers */

--- a/core/module.h
+++ b/core/module.h
@@ -233,7 +233,6 @@ class ModuleBuilder {
  private:
   std::function<Module *()> module_generator_;
 
-  static std::map<std::string, ModuleBuilder> &all_module_builders_;
   static std::map<std::string, Module *> all_modules_;
 
   gate_idx_t kNumIGates;

--- a/core/module.h
+++ b/core/module.h
@@ -364,8 +364,9 @@ class Module {
 
   bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule] =
       {};
-  struct gates igates = {};
-  struct gates ogates = {};
+
+  struct gates igates;
+  struct gates ogates;
 };
 
 void deadend(struct pkt_batch *batch);
@@ -469,10 +470,9 @@ inline T *ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
 template <typename T>
 inline T get_attr_with_offset(bess::metadata::mt_offset_t offset,
                               struct snbuf *pkt) {
-  T _zeroed = {};
   return bess::metadata::IsValidOffset(offset)
              ? _get_attr_with_offset<T>(offset, pkt)
-             : _zeroed;
+             : T();
 }
 
 template <typename T>

--- a/core/modules/ether_encap.cc
+++ b/core/modules/ether_encap.cc
@@ -1,5 +1,8 @@
 #include "ether_encap.h"
 
+#include <rte_config.h>
+#include <rte_ether.h>
+
 enum {
   ATTR_R_ETHER_SRC,
   ATTR_R_ETHER_DST,
@@ -8,6 +11,28 @@ enum {
 
 const Commands<Module> EtherEncap::cmds = {};
 const PbCommands EtherEncap::pb_cmds = {};
+
+struct snobj *EtherEncap::Init(struct snobj *arg [[maybe_unused]]) {
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("ether_src", ETHER_ADDR_LEN, AccessMode::kRead);
+  AddMetadataAttr("ether_dst", ETHER_ADDR_LEN, AccessMode::kRead);
+  AddMetadataAttr("ether_type", 2, AccessMode::kRead);
+
+  return nullptr;
+};
+
+pb_error_t EtherEncap::InitPb(
+    const bess::pb::EtherEncapArg &arg[[maybe_unused]]) {
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("ether_src", ETHER_ADDR_LEN, AccessMode::kRead);
+  AddMetadataAttr("ether_dst", ETHER_ADDR_LEN, AccessMode::kRead);
+  AddMetadataAttr("ether_type", 2, AccessMode::kRead);
+
+  return pb_errno(0);
+};
+
 
 void EtherEncap::ProcessBatch(struct pkt_batch *batch) {
   int cnt = batch->cnt;

--- a/core/modules/ether_encap.h
+++ b/core/modules/ether_encap.h
@@ -6,26 +6,28 @@
 
 #include "../module.h"
 
+using bess::metadata::Attribute;
+
 class EtherEncap : public Module {
  public:
   void ProcessBatch(struct pkt_batch *batch);
 
   size_t num_attrs = 5;
-  struct bess::metadata::mt_attr attrs[bess::metadata::kMaxAttrsPerModule] = {
+  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
       {
           .name = "ether_src",
           .size = ETHER_ADDR_LEN,
-          .mode = bess::metadata::AccessMode::READ,
+          .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "ether_dst",
           .size = ETHER_ADDR_LEN,
-          .mode = bess::metadata::AccessMode::READ,
+          .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "ether_type",
           .size = 2,
-          .mode = bess::metadata::AccessMode::READ,
+          .mode = Attribute::AccessMode::kRead,
       },
   };
 

--- a/core/modules/ether_encap.h
+++ b/core/modules/ether_encap.h
@@ -1,35 +1,15 @@
 #ifndef BESS_MODULES_ETHERENCAP_H_
 #define BESS_MODULES_ETHERENCAP_H_
 
-#include <rte_config.h>
-#include <rte_ether.h>
-
 #include "../module.h"
-
-using bess::metadata::Attribute;
+#include "../module_msg.pb.h"
 
 class EtherEncap : public Module {
  public:
-  void ProcessBatch(struct pkt_batch *batch);
+  struct snobj *Init(struct snobj *arg);
+  pb_error_t InitPb(const bess::pb::EtherEncapArg &arg);
 
-  size_t num_attrs = 5;
-  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
-      {
-          .name = "ether_src",
-          .size = ETHER_ADDR_LEN,
-          .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ether_dst",
-          .size = ETHER_ADDR_LEN,
-          .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ether_type",
-          .size = 2,
-          .mode = Attribute::AccessMode::kRead,
-      },
-  };
+  void ProcessBatch(struct pkt_batch *batch);
 
   static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = 1;

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -261,7 +261,7 @@ struct snobj *ExactMatch::GetDump() const {
       snobj_map_set(f_obj, "offset", snobj_uint(f->offset));
     } else {
       snobj_map_set(f_obj, "name",
-                    snobj_str(ExactMatch::attrs[f->attr_id].name));
+                    snobj_str(all_attrs()[f->attr_id].name));
     }
 
     snobj_list_add(fields, f_obj);

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -34,8 +34,8 @@ pb_error_t ExactMatch::AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
 
   if (field.position_case() == bess::pb::ExactMatchArg_Field::kName) {
     const char *attr = field.name().c_str();
-    f->attr_id =
-        AddMetadataAttr(attr, f->size, bess::metadata::AccessMode::READ);
+    f->attr_id = AddMetadataAttr(attr, f->size,
+                                 bess::metadata::Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
       return pb_error(-f->attr_id, "idx %d: add_metadata_attr() failed", idx);
     }
@@ -83,8 +83,8 @@ struct snobj *ExactMatch::AddFieldOne(struct snobj *field, struct EmField *f,
   const char *attr = static_cast<char *>(snobj_eval_str(field, "attr"));
 
   if (attr) {
-    f->attr_id =
-        AddMetadataAttr(attr, f->size, bess::metadata::AccessMode::READ);
+    f->attr_id = AddMetadataAttr(attr, f->size,
+                                 bess::metadata::Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
       return snobj_err(-f->attr_id, "idx %d: add_metadata_attr() failed", idx);
     }

--- a/core/modules/generic_encap.cc
+++ b/core/modules/generic_encap.cc
@@ -21,8 +21,8 @@ pb_error_t GenericEncap::AddFieldOne(
 
   if (field.attribute_case() == bess::pb::GenericEncapArg_Field::kName) {
     const char *attr = field.name().c_str();
-    f->attr_id =
-        AddMetadataAttr(attr, f->size, bess::metadata::AccessMode::READ);
+    f->attr_id = AddMetadataAttr(attr, f->size,
+                                 bess::metadata::Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
       return pb_error(-f->attr_id, "idx %d: add_metadata_attr() failed", idx);
     }
@@ -60,8 +60,8 @@ struct snobj *GenericEncap::AddFieldOne(struct snobj *field, struct Field *f,
   struct snobj *t;
 
   if (attr) {
-    f->attr_id =
-        AddMetadataAttr(attr, f->size, bess::metadata::AccessMode::READ);
+    f->attr_id = AddMetadataAttr(attr, f->size,
+                                 bess::metadata::Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
       return snobj_err(-f->attr_id, "idx %d: add_metadata_attr() failed", idx);
     }

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -15,6 +15,30 @@ enum {
 const Commands<Module> IPEncap::cmds = {};
 const PbCommands IPEncap::pb_cmds = {};
 
+struct snobj *IPEncap::Init(struct snobj *arg [[maybe_unused]]) {
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("ip_src", 4, AccessMode::kRead);
+  AddMetadataAttr("ip_dst", 4, AccessMode::kRead);
+  AddMetadataAttr("ip_proto", 1, AccessMode::kRead);
+  AddMetadataAttr("ip_nexthop", 4, AccessMode::kWrite);
+  AddMetadataAttr("ether_type", 2, AccessMode::kWrite);
+
+  return nullptr;
+};
+
+pb_error_t IPEncap::InitPb(const bess::pb::IPEncapArg &arg [[maybe_unused]]) {
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("ip_src", 4, AccessMode::kRead);
+  AddMetadataAttr("ip_dst", 4, AccessMode::kRead);
+  AddMetadataAttr("ip_proto", 1, AccessMode::kRead);
+  AddMetadataAttr("ip_nexthop", 4, AccessMode::kWrite);
+  AddMetadataAttr("ether_type", 2, AccessMode::kWrite);
+
+  return pb_errno(0);
+}
+
 void IPEncap::ProcessBatch(struct pkt_batch *batch) {
   int cnt = batch->cnt;
 

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -2,37 +2,14 @@
 #define BESS_MODULES_IPENCAP_H_
 
 #include "../module.h"
-
-using bess::metadata::Attribute;
+#include "../module_msg.pb.h"
 
 class IPEncap : public Module {
  public:
-  virtual void ProcessBatch(struct pkt_batch *batch);
+  struct snobj *Init(struct snobj *arg);
+  pb_error_t InitPb(const bess::pb::IPEncapArg &arg);
 
-  size_t num_attrs = 5;
-  struct Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
-      {
-          .name = "ip_src", .size = 4, .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ip_dst", .size = 4, .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ip_proto",
-          .size = 1,
-          .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ip_nexthop",
-          .size = 4,
-          .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ether_type",
-          .size = 2,
-          .mode = Attribute::AccessMode::kWrite,
-      },
-  };
+  virtual void ProcessBatch(struct pkt_batch *batch);
 
   static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = 1;

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -3,32 +3,34 @@
 
 #include "../module.h"
 
+using bess::metadata::Attribute;
+
 class IPEncap : public Module {
  public:
   virtual void ProcessBatch(struct pkt_batch *batch);
 
   size_t num_attrs = 5;
-  struct bess::metadata::mt_attr attrs[bess::metadata::kMaxAttrsPerModule] = {
+  struct Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
       {
-          .name = "ip_src", .size = 4, .mode = bess::metadata::AccessMode::READ,
+          .name = "ip_src", .size = 4, .mode = Attribute::AccessMode::kRead,
       },
       {
-          .name = "ip_dst", .size = 4, .mode = bess::metadata::AccessMode::READ,
+          .name = "ip_dst", .size = 4, .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "ip_proto",
           .size = 1,
-          .mode = bess::metadata::AccessMode::READ,
+          .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "ip_nexthop",
           .size = 4,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "ether_type",
           .size = 2,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = Attribute::AccessMode::kWrite,
       },
   };
 

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -57,8 +57,8 @@ class L2Forward : public Module {
   static const PbCommands pb_cmds;
 
  private:
-  struct l2_table l2_table_ = {};
-  gate_idx_t default_gate_ = {};
+  struct l2_table l2_table_;
+  gate_idx_t default_gate_;
 };
 
 #endif  // BESS_MODULES_L2FORWARD_H_

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -31,7 +31,7 @@ class Measure : public Module {
   static const PbCommands pb_cmds;
 
  private:
-  struct histogram hist_ = {};
+  struct histogram hist_;
 
   uint64_t start_time_;
   int warmup_; /* second */

--- a/core/modules/mttest.cc
+++ b/core/modules/mttest.cc
@@ -7,7 +7,7 @@ const PbCommands MetadataTest::pb_cmds = {};
 
 pb_error_t MetadataTest::AddAttributes(
     const google::protobuf::Map<std::string, int64_t> &attributes,
-    bess::metadata::AccessMode mode) {
+    Attribute::AccessMode mode) {
   for (const auto &kv : attributes) {
     int ret;
 
@@ -20,15 +20,15 @@ pb_error_t MetadataTest::AddAttributes(
 
     /* check /var/log/syslog for log messages */
     switch (mode) {
-      case bess::metadata::AccessMode::READ:
+      case Attribute::AccessMode::kRead:
         LOG(INFO) << "module " << name() << ": " << attr_name << ", "
                   << attr_size << " bytes, read" << std::endl;
         break;
-      case bess::metadata::AccessMode::WRITE:
+      case Attribute::AccessMode::kWrite:
         LOG(INFO) << "module " << name() << ": " << attr_name << ", "
                   << attr_size << " bytes, write" << std::endl;
         break;
-      case bess::metadata::AccessMode::UPDATE:
+      case Attribute::AccessMode::kUpdate:
         LOG(INFO) << "module " << name() << ": " << attr_name << ", "
                   << attr_size << " bytes, update" << std::endl;
         break;
@@ -39,7 +39,7 @@ pb_error_t MetadataTest::AddAttributes(
 }
 
 struct snobj *MetadataTest::AddAttributes(struct snobj *attributes,
-                                          bess::metadata::AccessMode mode) {
+                                          Attribute::AccessMode mode) {
   if (snobj_type(attributes) != TYPE_MAP) {
     return snobj_err(EINVAL,
                      "argument must be a map of "
@@ -59,15 +59,15 @@ struct snobj *MetadataTest::AddAttributes(struct snobj *attributes,
 
     /* check /var/log/syslog for log messages */
     switch (mode) {
-      case bess::metadata::AccessMode::READ:
+      case Attribute::AccessMode::kRead:
         LOG(INFO) << "module " << name() << ": " << attr_name << ", "
                   << attr_size << " bytes, read" << std::endl;
         break;
-      case bess::metadata::AccessMode::WRITE:
+      case Attribute::AccessMode::kWrite:
         LOG(INFO) << "module " << name() << ": " << attr_name << ", "
                   << attr_size << " bytes, write" << std::endl;
         break;
-      case bess::metadata::AccessMode::UPDATE:
+      case Attribute::AccessMode::kUpdate:
         LOG(INFO) << "module " << name() << ": " << attr_name << ", "
                   << attr_size << " bytes, update" << std::endl;
         break;
@@ -80,17 +80,17 @@ struct snobj *MetadataTest::AddAttributes(struct snobj *attributes,
 pb_error_t MetadataTest::InitPb(const bess::pb::MetadataTestArg &arg) {
   pb_error_t err;
 
-  err = AddAttributes(arg.read(), bess::metadata::AccessMode::READ);
+  err = AddAttributes(arg.read(), Attribute::AccessMode::kRead);
   if (err.err() != 0) {
     return err;
   }
 
-  err = AddAttributes(arg.write(), bess::metadata::AccessMode::WRITE);
+  err = AddAttributes(arg.write(), Attribute::AccessMode::kWrite);
   if (err.err() != 0) {
     return err;
   }
 
-  err = AddAttributes(arg.update(), bess::metadata::AccessMode::UPDATE);
+  err = AddAttributes(arg.update(), Attribute::AccessMode::kUpdate);
   if (err.err() != 0) {
     return err;
   }
@@ -103,21 +103,21 @@ struct snobj *MetadataTest::Init(struct snobj *arg) {
   struct snobj *err;
 
   if ((attributes = snobj_eval(arg, "read"))) {
-    err = AddAttributes(attributes, bess::metadata::AccessMode::READ);
+    err = AddAttributes(attributes, Attribute::AccessMode::kRead);
     if (err) {
       return err;
     }
   }
 
   if ((attributes = snobj_eval(arg, "write"))) {
-    err = AddAttributes(attributes, bess::metadata::AccessMode::WRITE);
+    err = AddAttributes(attributes, Attribute::AccessMode::kWrite);
     if (err) {
       return err;
     }
   }
 
   if ((attributes = snobj_eval(arg, "update"))) {
-    err = AddAttributes(attributes, bess::metadata::AccessMode::UPDATE);
+    err = AddAttributes(attributes, Attribute::AccessMode::kUpdate);
     if (err) {
       return err;
     }

--- a/core/modules/mttest.h
+++ b/core/modules/mttest.h
@@ -4,6 +4,8 @@
 #include "../module.h"
 #include "../module_msg.pb.h"
 
+using bess::metadata::Attribute;
+
 class MetadataTest : public Module {
  public:
   struct snobj *Init(struct snobj *arg);
@@ -19,10 +21,10 @@ class MetadataTest : public Module {
 
  private:
   struct snobj *AddAttributes(struct snobj *attrs,
-                              bess::metadata::AccessMode mode);
+                              Attribute::AccessMode mode);
   pb_error_t AddAttributes(
       const google::protobuf::Map<std::string, int64_t> &attrs,
-      bess::metadata::AccessMode mode);
+      Attribute::AccessMode mode);
 };
 
 #endif  // BESS_MODULES_MTTEST_H_

--- a/core/modules/noop.cc
+++ b/core/modules/noop.cc
@@ -24,7 +24,9 @@ pb_error_t NoOP::InitPb(const bess::pb::EmptyArg &) {
 }
 
 struct task_result NoOP::RunTask(void *) {
-  return {};
+  return {
+      .packets = 0, .bits = 0,
+  };
 }
 
 ADD_MODULE(NoOP, "noop", "creates a task that does nothing")

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -65,7 +65,8 @@ pb_error_t SetMetadata::AddAttrOne(
     }
   }
 
-  ret = AddMetadataAttr(name, size, bess::metadata::AccessMode::WRITE);
+  ret = AddMetadataAttr(name, size,
+                        bess::metadata::Attribute::AccessMode::kWrite);
   if (ret < 0)
     return pb_error(-ret, "add_metadata_attr() failed");
 
@@ -142,7 +143,8 @@ struct snobj *SetMetadata::AddAttrOne(struct snobj *attr) {
     }
   }
 
-  ret = AddMetadataAttr(name, size, bess::metadata::AccessMode::WRITE);
+  ret = AddMetadataAttr(name, size,
+                        bess::metadata::Attribute::AccessMode::kWrite);
   if (ret < 0)
     return snobj_err(-ret, "add_metadata_attr() failed");
 

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -41,7 +41,7 @@ pb_error_t SetMetadata::AddAttrOne(
   std::string name;
   size_t size = 0;
   int offset = -1;
-  value_t value = {};
+  value_t value = value_t();
 
   int ret;
 
@@ -102,7 +102,7 @@ struct snobj *SetMetadata::AddAttrOne(struct snobj *attr) {
   std::string name;
   size_t size = 0;
   int offset = -1;
-  value_t value = {};
+  value_t value = value_t();
 
   struct snobj *t;
 

--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -25,7 +25,8 @@ pb_error_t Split::InitPb(const bess::pb::SplitArg &arg) {
   mask_ = ((uint64_t)1 << (size_ * 8)) - 1;
   const char *name = arg.name().c_str();
   if (arg.name().length()) {
-    attr_id_ = AddMetadataAttr(name, size_, bess::metadata::AccessMode::READ);
+    attr_id_ = AddMetadataAttr(name, size_,
+                               bess::metadata::Attribute::AccessMode::kRead);
     if (attr_id_ < 0)
       return pb_error(-attr_id_, "add_metadata_attr() failed");
   } else {
@@ -53,7 +54,8 @@ struct snobj *Split::Init(struct snobj *arg) {
   const char *name = snobj_eval_str(arg, "name");
 
   if (name) {
-    attr_id_ = AddMetadataAttr(name, size_, bess::metadata::AccessMode::READ);
+    attr_id_ = AddMetadataAttr(name, size_,
+                               bess::metadata::Attribute::AccessMode::kRead);
     if (attr_id_ < 0)
       return snobj_err(-attr_id_, "add_metadata_attr() failed");
   } else if (snobj_eval_exists(arg, "offset")) {

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -17,6 +17,26 @@ enum {
 const Commands<Module> VXLANDecap::cmds = {};
 const PbCommands VXLANDecap::pb_cmds = {};
 
+struct snobj *VXLANDecap::Init(struct snobj *arg [[maybe_unused]]) {
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("tun_ip_src", 4, AccessMode::kWrite);
+  AddMetadataAttr("tun_ip_dst", 4, AccessMode::kWrite);
+  AddMetadataAttr("tun_id", 4, AccessMode::kWrite);
+
+  return nullptr;
+};
+
+pb_error_t VXLANDecap::InitPb(const bess::pb::VXLANDecapArg &arg [[maybe_unused]]) {
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("tun_ip_src", 4, AccessMode::kWrite);
+  AddMetadataAttr("tun_ip_dst", 4, AccessMode::kWrite);
+  AddMetadataAttr("tun_id", 4, AccessMode::kWrite);
+
+  return pb_errno(0);
+}
+
 void VXLANDecap::ProcessBatch(struct pkt_batch *batch) {
   int cnt = batch->cnt;
 

--- a/core/modules/vxlan_decap.h
+++ b/core/modules/vxlan_decap.h
@@ -2,29 +2,14 @@
 #define BESS_MODULES_VXLANDECAP_H_
 
 #include "../module.h"
+#include "../module_msg.pb.h"
 
 class VXLANDecap : public Module {
  public:
+  virtual struct snobj *Init(struct snobj *arg);
+  pb_error_t InitPb(const bess::pb::VXLANDecapArg &arg);
+ 
   void ProcessBatch(struct pkt_batch *batch);
-
-  size_t num_attrs = 3;
-  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
-      {
-          .name = "tun_ip_src",
-          .size = 4,
-          .mode = bess::metadata::Attribute::AccessMode::kWrite,
-      },
-      {
-          .name = "tun_ip_dst",
-          .size = 4,
-          .mode = bess::metadata::Attribute::AccessMode::kWrite,
-      },
-      {
-          .name = "tun_id",
-          .size = 4,
-          .mode = bess::metadata::Attribute::AccessMode::kWrite,
-      },
-  };
 
   static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = 1;

--- a/core/modules/vxlan_decap.h
+++ b/core/modules/vxlan_decap.h
@@ -8,21 +8,21 @@ class VXLANDecap : public Module {
   void ProcessBatch(struct pkt_batch *batch);
 
   size_t num_attrs = 3;
-  struct bess::metadata::mt_attr attrs[bess::metadata::kMaxAttrsPerModule] = {
+  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
       {
           .name = "tun_ip_src",
           .size = 4,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = bess::metadata::Attribute::AccessMode::kWrite,
       },
       {
           .name = "tun_ip_dst",
           .size = 4,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = bess::metadata::Attribute::AccessMode::kWrite,
       },
       {
           .name = "tun_id",
           .size = 4,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = bess::metadata::Attribute::AccessMode::kWrite,
       },
   };
 

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -22,12 +22,23 @@ const Commands<Module> VXLANEncap::cmds = {};
 const PbCommands VXLANEncap::pb_cmds = {};
 
 pb_error_t VXLANEncap::InitPb(const bess::pb::VXLANEncapArg &arg) {
-  dstport_ = rte_cpu_to_be_16(4789);
+  auto dstport = arg.dstport();
+  if (dstport == 0) {
+    dstport_ = rte_cpu_to_be_16(4789);
+  } else {
+    if (dstport >= 65536)
+      return pb_error(EINVAL, "invalid 'dstport' field");
+    dstport_ = rte_cpu_to_be_16(dstport);
+  }
 
-  int dstport = arg.dstport();
-  if (dstport <= 0 || dstport >= 65536)
-    return pb_error(EINVAL, "invalid 'dstport' field");
-  dstport_ = rte_cpu_to_be_16(dstport);
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("tun_ip_src", 4, AccessMode::kRead);
+  AddMetadataAttr("tun_ip_dst", 4, AccessMode::kRead);
+  AddMetadataAttr("tun_id", 4, AccessMode::kRead);
+  AddMetadataAttr("ip_src", 4, AccessMode::kWrite);
+  AddMetadataAttr("ip_dst", 4, AccessMode::kWrite);
+  AddMetadataAttr("ip_proto", 1, AccessMode::kWrite);
 
   return pb_errno(0);
 }
@@ -41,6 +52,15 @@ struct snobj *VXLANEncap::Init(struct snobj *arg) {
       return snobj_err(EINVAL, "invalid 'dstport' field");
     dstport_ = rte_cpu_to_be_16(dstport);
   }
+
+  using AccessMode = bess::metadata::Attribute::AccessMode;
+
+  AddMetadataAttr("tun_ip_src", 4, AccessMode::kRead);
+  AddMetadataAttr("tun_ip_dst", 4, AccessMode::kRead);
+  AddMetadataAttr("tun_id", 4, AccessMode::kRead);
+  AddMetadataAttr("ip_src", 4, AccessMode::kWrite);
+  AddMetadataAttr("ip_dst", 4, AccessMode::kWrite);
+  AddMetadataAttr("ip_proto", 1, AccessMode::kWrite);
 
   return nullptr;
 }

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -4,6 +4,8 @@
 #include "../module.h"
 #include "../module_msg.pb.h"
 
+using bess::metadata::Attribute;
+
 class VXLANEncap : public Module {
  public:
   VXLANEncap() : Module(), dstport_() {}
@@ -13,34 +15,34 @@ class VXLANEncap : public Module {
   virtual void ProcessBatch(struct pkt_batch *batch);
 
   size_t num_attrs = 6;
-  struct bess::metadata::mt_attr attrs[bess::metadata::kMaxAttrsPerModule] = {
+  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
       {
           .name = "tun_ip_src",
           .size = 4,
-          .mode = bess::metadata::AccessMode::READ,
+          .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "tun_ip_dst",
           .size = 4,
-          .mode = bess::metadata::AccessMode::READ,
+          .mode = Attribute::AccessMode::kRead,
       },
       {
-          .name = "tun_id", .size = 4, .mode = bess::metadata::AccessMode::READ,
+          .name = "tun_id", .size = 4, .mode = Attribute::AccessMode::kRead,
       },
       {
           .name = "ip_src",
           .size = 4,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = Attribute::AccessMode::kWrite,
       },
       {
           .name = "ip_dst",
           .size = 4,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = Attribute::AccessMode::kWrite,
       },
       {
           .name = "ip_proto",
           .size = 1,
-          .mode = bess::metadata::AccessMode::WRITE,
+          .mode = Attribute::AccessMode::kWrite,
       },
   };
 

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -12,39 +12,8 @@ class VXLANEncap : public Module {
 
   virtual struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::VXLANEncapArg &arg);
-  virtual void ProcessBatch(struct pkt_batch *batch);
 
-  size_t num_attrs = 6;
-  struct bess::metadata::Attribute attrs[bess::metadata::kMaxAttrsPerModule] = {
-      {
-          .name = "tun_ip_src",
-          .size = 4,
-          .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "tun_ip_dst",
-          .size = 4,
-          .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "tun_id", .size = 4, .mode = Attribute::AccessMode::kRead,
-      },
-      {
-          .name = "ip_src",
-          .size = 4,
-          .mode = Attribute::AccessMode::kWrite,
-      },
-      {
-          .name = "ip_dst",
-          .size = 4,
-          .mode = Attribute::AccessMode::kWrite,
-      },
-      {
-          .name = "ip_proto",
-          .size = 1,
-          .mode = Attribute::AccessMode::kWrite,
-      },
-  };
+  virtual void ProcessBatch(struct pkt_batch *batch);
 
   static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = 1;

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -3,6 +3,8 @@
 #include "../utils/endian.h"
 #include "../utils/format.h"
 
+using bess::metadata::Attribute;
+
 /* k1 = k2 & mask */
 static void mask(void *k1, const void *k2, const void *mask, int key_size) {
   uint64_t *a = static_cast<uint64_t *>(k1);
@@ -76,7 +78,7 @@ struct snobj *WildcardMatch::AddFieldOne(struct snobj *field,
     return snobj_err(EINVAL, "specify 'offset' or 'attr'");
   }
 
-  f->attr_id = AddMetadataAttr(attr, f->size, bess::metadata::AccessMode::READ);
+  f->attr_id = AddMetadataAttr(attr, f->size, Attribute::AccessMode::kRead);
   if (f->attr_id < 0) {
     return snobj_err(-f->attr_id, "add_metadata_attr() failed");
   }
@@ -102,7 +104,7 @@ pb_error_t WildcardMatch::AddFieldOne(
              bess::pb::WildcardMatchArg_Field::kAttribute) {
     const char *attr = field.attribute().c_str();
     f->attr_id =
-        AddMetadataAttr(attr, f->size, bess::metadata::AccessMode::READ);
+        AddMetadataAttr(attr, f->size, Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
       return pb_error(-f->attr_id, "add_metadata_attr() failed");
     }

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -314,7 +314,7 @@ struct snobj *WildcardMatch::GetDump() const {
       snobj_map_set(f_obj, "offset", snobj_uint(f->offset));
     } else {
       snobj_map_set(f_obj, "name",
-                    snobj_str(WildcardMatch::attrs[f->attr_id].name));
+                    snobj_str(WildcardMatch::all_attrs()[f->attr_id].name));
     }
 
     snobj_list_add(fields, f_obj);

--- a/core/snctl.cc
+++ b/core/snctl.cc
@@ -808,13 +808,13 @@ static struct snobj *collect_metadata(Module *m) {
     snobj_map_set(attr, "size", snobj_uint(m->attrs[i].size));
 
     switch (m->attrs[i].mode) {
-      case bess::metadata::AccessMode::READ:
+      case bess::metadata::Attribute::AccessMode::kRead:
         snobj_map_set(attr, "mode", snobj_str("read"));
         break;
-      case bess::metadata::AccessMode::WRITE:
+      case bess::metadata::Attribute::AccessMode::kWrite:
         snobj_map_set(attr, "mode", snobj_str("write"));
         break;
-      case bess::metadata::AccessMode::UPDATE:
+      case bess::metadata::Attribute::AccessMode::kUpdate:
         snobj_map_set(attr, "mode", snobj_str("update"));
         break;
       default:

--- a/core/snctl.cc
+++ b/core/snctl.cc
@@ -800,14 +800,15 @@ static struct snobj *collect_ogates(Module *m) {
 
 static struct snobj *collect_metadata(Module *m) {
   struct snobj *metadata = snobj_list();
+  size_t i = 0;
 
-  for (size_t i = 0; i < m->num_attrs; i++) {
+  for (const auto &it : m->all_attrs()) {
     struct snobj *attr = snobj_map();
 
-    snobj_map_set(attr, "name", snobj_str(m->attrs[i].name));
-    snobj_map_set(attr, "size", snobj_uint(m->attrs[i].size));
+    snobj_map_set(attr, "name", snobj_str(it.name));
+    snobj_map_set(attr, "size", snobj_uint(it.size));
 
-    switch (m->attrs[i].mode) {
+    switch (it.mode) {
       case bess::metadata::Attribute::AccessMode::kRead:
         snobj_map_set(attr, "mode", snobj_str("read"));
         break;
@@ -822,8 +823,8 @@ static struct snobj *collect_metadata(Module *m) {
     }
 
     snobj_map_set(attr, "offset", snobj_int(m->attr_offsets[i]));
-
     snobj_list_add(metadata, attr);
+    i++;
   }
 
   return metadata;

--- a/core/task.cc
+++ b/core/task.cc
@@ -76,19 +76,19 @@ void assign_default_tc(int wid, struct task *t) {
 
   struct tc *c_def;
 
-  struct tc_params params = {};
-
-  params.parent = nullptr;
-  params.auto_free = 1; /* when no task is left, this TC is freed */
-  params.priority = DEFAULT_PRIORITY;
-  params.share = 1;
-  params.share_resource = RESOURCE_CNT;
+  struct tc_params params = tc_params();
 
   if (t->m->NumTasks() == 1) {
     params.name = "_tc_" + t->m->name();
   } else {
     params.name = "_tc_" + t->m->name() + std::to_string(task_to_tid(t));
   }
+
+  params.parent = nullptr;
+  params.auto_free = 1; /* when no task is left, this TC is freed */
+  params.priority = DEFAULT_PRIORITY;
+  params.share = 1;
+  params.share_resource = RESOURCE_CNT;
 
   c_def = tc_init(workers[wid]->s(), &params);
 

--- a/core/tc_bench.cc
+++ b/core/tc_bench.cc
@@ -20,7 +20,7 @@ class TCFixture : public benchmark::Fixture {
     s_ = sched_init();
 
     for (int i = 0; i < num_classes; i++) {
-      struct tc_params params = {};
+      struct tc_params params = tc_params();
 
       params.name = "class_" + std::to_string(i);
       params.parent = nullptr;

--- a/core/utils/htable.cc
+++ b/core/utils/htable.cc
@@ -289,7 +289,7 @@ int HTableBase::InitEx(struct ht_params *params) {
 }
 
 int HTableBase::Init(size_t key_size, size_t value_size) {
-  struct ht_params params = {};
+  struct ht_params params;
 
   params.key_size = key_size;
   params.value_size = value_size;


### PR DESCRIPTION
GCC's `-Wextra` includes `-Wmissing-field-initializers`, but there were spots that partially initialize structs (the 'missing' fields are implicitly filled with zero, since there is no really partial initialization in C/C++). I temporarily disabled this warning, since otherwise it would have needed some major work. This PR contains commits from my yak shaving to enable the warning option.

- Now all modules must register metadata attributes explicitly, rather than overloading the `attrs` array. Two reasons:
  - The attribute struct has the `scope_id` field for internal purposes, but modules don't (and shouldn't) know what it is. Because of this requiring modules to specify the value of scope_id would be a bit awkward.
  - Some modules (with a fixed set of metadata attributes) use the attrs array while other modules dynamically register attributes. These two different modes make things conceptually a bit more complex.

- Some minor code cleanup was done (e.g., int -> size_t) as necessary