### PR TITLE
Refactor gates and introduce gate hooks

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1308,13 +1308,16 @@ def monitor_tc_all(cli, tcs):
     _monitor_tcs(cli, *tcs)
 
 # tcpdump can write pcap files, so we don't need to support it separately
-@cmd('tcpdump MODULE [OGATE] [TCPDUMP_OPTS...]', 'Capture packets on a gate')
+@cmd('tcpdump MODULE [DIRECTION] [OGATE] [TCPDUMP_OPTS...]', 'Capture packets on a gate')
 def tcpdump_module(cli, module_name, direction, gate, opts):
-    if ogate is None:
-        ogate = 0
+    if gate is None:
+        gate = 0
 
     if opts is None:
         opts = []
+
+    if direction is None:
+        direction = 'out'
 
     fifo = tempfile.mktemp()
     os.mkfifo(fifo, 0600)   # random people should not see packets...
@@ -1331,7 +1334,7 @@ def tcpdump_module(cli, module_name, direction, gate, opts):
 
     cli.bess.pause_all()
     try:
-        cli.bess.enable_tcpdump(fifo, module_name, ogate)
+        cli.bess.enable_tcpdump(fifo, module_name, direction, gate)
     finally:
         cli.bess.resume_all()
 
@@ -1343,7 +1346,7 @@ def tcpdump_module(cli, module_name, direction, gate, opts):
     finally:
         cli.bess.pause_all()
         try:
-            cli.bess.disable_tcpdump(module_name, ogate)
+            cli.bess.disable_tcpdump(module_name, direction, gate)
         finally:
             cli.bess.resume_all()
 

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -194,6 +194,19 @@ def get_var_attrs(cli, var_token, partial_word):
             var_desc = 'configuration filename'
             var_candidates = complete_filename(partial_word)
 
+        if var_token == '[DIRECTION]':
+            var_type = 'name'
+            var_desc = 'gate direction discriminator (default "out")'
+            var_candidates = ['in', 'out']
+
+        if var_token == '[PRIORITY]':
+            var_type = 'int'
+            var_desc = 'gate hook priority (default 0)'
+
+        elif var_token == '[GATE]':
+            var_type = 'gate'
+            var_desc = 'gate index (default 0)'
+
         elif var_token == '[OGATE]':
             var_type = 'gate'
             var_desc = 'output gate of a module (default 0)'
@@ -1333,6 +1346,33 @@ def tcpdump_module(cli, module_name, ogate, opts):
             os.system('stty sane')  # more/less may have screwed the terminal
         except:
             pass
+
+@cmd('track MODULE [DIRECTION] [GATE] [PRIORITY]',
+     'Count the packets and batches on a gate')
+def track_module(cli, module_name, direction, gate, priority):
+    if direction is None:
+        direction = 'out'
+
+    if gate is None:
+        gate = 0
+
+    if priority is None:
+        priority = 0
+
+    cli.bess.pause_all()
+    try:
+        cli.bess.enable_track(module_name, direction, gate, priority)
+    finally:
+        cli.bess.resume_all()
+
+@cmd('untrack MODULE [DIRECTION] [GATE]',
+     'Stop counting the packets and batches on a gate')
+def untrack_module(cli, module_name, direction, gate):
+    cli.bess.pause_all()
+    try:
+        cli.bess.disable_track(module_name, direction, gate)
+    finally:
+        cli.bess.resume_all()
 
 @cmd('interactive', 'Switch to interactive mode')
 def interactive(cli):

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1007,18 +1007,29 @@ def _show_module(cli, module_name):
     if info.igates:
         cli.fout.write('    Input gates:\n')
         for gate in info.igates:
-            cli.fout.write('      %5d: %s\n' % \
-                    (gate.igate,
+            track_str = 'batches N/A packets N/A'
+            try:
+                track_str = 'batches %-16d packets %-16d' % (gate.cnt,
+                        gate.pkts)
+            except:
+                pass
+            cli.fout.write('      %5d: %s %s\n' % \
+                    (gate.igate, track_str,
                      ', '.join('%s:%d ->' % (g.name, g.ogate) \
                              for g in gate.ogates)))
 
     if info.ogates:
         cli.fout.write('    Output gates:\n')
         for gate in info.ogates:
+            track_str = 'batches N/A packets N/A'
+            try:
+                track_str = 'batches %-16d packets %-16d' % (gate.cnt,
+                        gate.pkts)
+            except:
+                pass
             cli.fout.write(
-                    '      %5d: batches %-16d packets %-16d -> %d:%s\n' % \
-                    (gate.ogate, gate.cnt, gate.pkts,
-                     gate.igate, gate.name))
+                    '      %5d: %s -> %d:%s\n' % \
+                    (gate.ogate, track_str, gate.igate, gate.name))
 
     if 'dump' in info:
         dump_str = pprint.pformat(info.dump, width=74)

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -199,13 +199,9 @@ def get_var_attrs(cli, var_token, partial_word):
             var_desc = 'gate direction discriminator (default "out")'
             var_candidates = ['in', 'out']
 
-        if var_token == '[PRIORITY]':
-            var_type = 'int'
-            var_desc = 'gate hook priority (default 0)'
-
         elif var_token == '[GATE]':
             var_type = 'gate'
-            var_desc = 'gate index (default 0)'
+            var_desc = 'gate index (default all)'
 
         elif var_token == '[OGATE]':
             var_type = 'gate'
@@ -1313,7 +1309,7 @@ def monitor_tc_all(cli, tcs):
 
 # tcpdump can write pcap files, so we don't need to support it separately
 @cmd('tcpdump MODULE [OGATE] [TCPDUMP_OPTS...]', 'Capture packets on a gate')
-def tcpdump_module(cli, module_name, ogate, opts):
+def tcpdump_module(cli, module_name, direction, gate, opts):
     if ogate is None:
         ogate = 0
 
@@ -1358,30 +1354,18 @@ def tcpdump_module(cli, module_name, ogate, opts):
         except:
             pass
 
-@cmd('track MODULE [DIRECTION] [GATE] [PRIORITY]',
+@cmd('track ENABLE_DISABLE [MODULE] [DIRECTION] [GATE]',
      'Count the packets and batches on a gate')
-def track_module(cli, module_name, direction, gate, priority):
+def track_module(cli, flag, module_name, direction, gate):
     if direction is None:
         direction = 'out'
 
-    if gate is None:
-        gate = 0
-
-    if priority is None:
-        priority = 0
-
     cli.bess.pause_all()
     try:
-        cli.bess.enable_track(module_name, direction, gate, priority)
-    finally:
-        cli.bess.resume_all()
-
-@cmd('untrack MODULE [DIRECTION] [GATE]',
-     'Stop counting the packets and batches on a gate')
-def untrack_module(cli, module_name, direction, gate):
-    cli.bess.pause_all()
-    try:
-        cli.bess.disable_track(module_name, direction, gate)
+        if flag == 'enable':
+            cli.bess.enable_track(module_name, direction, gate)
+        else:
+            cli.bess.disable_track(module_name, direction, gate)
     finally:
         cli.bess.resume_all()
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -12,6 +12,7 @@ DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$(@:.o=.d)
 $(shell mkdir -p $(DEPDIR) >/dev/null)
 $(shell mkdir -p $(DEPDIR)/utils >/dev/null)
 $(shell mkdir -p $(DEPDIR)/modules >/dev/null)
+$(shell mkdir -p $(DEPDIR)/hooks >/dev/null)
 $(shell mkdir -p $(DEPDIR)/drivers >/dev/null)
 
 # e.g., 4.9.3 -> 40903
@@ -84,8 +85,8 @@ PROTO_SRCS += $(patsubst %.proto,%.grpc.pb.cc, $(notdir $(PROTOS)))
 PROTO_HEADERS = $(patsubst %.cc,%.h, $(PROTO_SRCS))
 PROTOCFLAGS += --proto_path=$(PROTO_DIR) --cpp_out=. --grpc_out=. --plugin=protoc-gen-grpc=`which grpc_cpp_plugin`
 
-ALL_SRCS = $(wildcard *.cc utils/*.cc modules/*.cc drivers/*.cc)
-HEADERS = $(wildcard *.h utils/*.h modules/*.h drivers/*.h)
+ALL_SRCS = $(wildcard *.cc utils/*.cc modules/*.cc hooks/*.cc drivers/*.cc)
+HEADERS = $(wildcard *.h utils/*.h modules/*.h hooks/*.h drivers/*.h)
 
 TEST_SRCS = $(filter %_test.cc gtest_main.cc, $(ALL_SRCS))
 TEST_OBJS = $(TEST_SRCS:.cc=.o)

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -939,7 +939,8 @@ class BESSControlImpl final : public BESSControl::Service {
       return return_with_error(response, EINVAL,
                                "Output gate '%hu' does not exist", ogate);
 
-    ret = m->EnableTcpDump(fifo, ogate);
+    // TODO(melvin): actually change protobufs when new bessctl arrives
+    ret = m->EnableTcpDump(fifo, 0, ogate);
 
     if (ret < 0) {
       return return_with_error(response, -ret, "Enabling tcpdump %s:%d failed",
@@ -977,7 +978,8 @@ class BESSControlImpl final : public BESSControl::Service {
                                "Output gate '%hu' does not exist", ogate);
     }
 
-    ret = m->DisableTcpDump(ogate);
+    // TODO(melvin): actually change protobufs when new bessctl arrives
+    ret = m->DisableTcpDump(0, ogate);
 
     if (ret < 0) {
       return return_with_error(response, -ret, "Disabling tcpdump %s:%d failed",

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -54,15 +54,15 @@ static inline Status return_with_errno(T* response, int code) {
 }
 
 static int collect_igates(Module* m, GetModuleInfoResponse* response) {
-  for (int i = 0; i < m->igates.curr_size; i++) {
-    if (!is_active_gate(&m->igates, i))
+  for (const auto& g : m->igates) {
+    if (!g) {
       continue;
+    }
 
     GetModuleInfoResponse_IGate* igate = response->add_igates();
-    struct gate* g = m->igates.arr[i];
     struct gate* og;
 
-    igate->set_igate(i);
+    igate->set_igate(g->gate_idx);
 
     cdlist_for_each_entry(og, &g->in.ogates_upstream, out.igate_upstream) {
       GetModuleInfoResponse_IGate_OGate* ogate = igate->add_ogates();
@@ -75,13 +75,14 @@ static int collect_igates(Module* m, GetModuleInfoResponse* response) {
 }
 
 static int collect_ogates(Module* m, GetModuleInfoResponse* response) {
-  for (int i = 0; i < m->ogates.curr_size; i++) {
-    if (!is_active_gate(&m->ogates, i))
+  for (const auto& g : m->ogates) {
+    if (!g) {
       continue;
-    GetModuleInfoResponse_OGate* ogate = response->add_ogates();
-    struct gate* g = m->ogates.arr[i];
+    }
 
-    ogate->set_ogate(i);
+    GetModuleInfoResponse_OGate* ogate = response->add_ogates();
+
+    ogate->set_ogate(g->gate_idx);
     for (const auto& hook : g->hooks) {
       if (hook->name() == kGateHookTrackGate) {
         TrackGate* t = reinterpret_cast<TrackGate*>(hook);
@@ -100,7 +101,7 @@ static int collect_ogates(Module* m, GetModuleInfoResponse* response) {
 
 static int collect_metadata(Module* m, GetModuleInfoResponse* response) {
   size_t i = 0;
-  for (const auto &it : m->all_attrs()) {
+  for (const auto& it : m->all_attrs()) {
     GetModuleInfoResponse_Attribute* attr = response->add_metadata();
 
     attr->set_name(it.name);
@@ -934,7 +935,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
     Module* m = it->second;
 
-    if (ogate >= m->ogates.curr_size)
+    if (ogate >= m->ogates.size())
       return return_with_error(response, EINVAL,
                                "Output gate '%hu' does not exist", ogate);
 
@@ -971,7 +972,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     Module* m = it->second;
-    if (ogate >= m->ogates.curr_size) {
+    if (ogate >= m->ogates.size()) {
       return return_with_error(response, EINVAL,
                                "Output gate '%hu' does not exist", ogate);
     }

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -20,8 +20,8 @@
 #include <rte_version.h>
 
 #include "module.h"
-#include "snobj.h"
 #include "snbuf.h"
+#include "snobj.h"
 #include "tc.h"
 #include "utils/htable.h"
 
@@ -271,11 +271,11 @@ static std::string print_code(char *symbol, int context) {
 #elif __x86_64
   ip = (void *)uc->uc_mcontext.gregs[REG_RIP];
 #else
-#  error neither x86 or x86-64
+#error neither x86 or x86-64
 #endif
 
   oops << "A critical error has occured. Aborting... (pid=" << getpid()
-             << ", tid=" << (pid_t)syscall(SYS_gettid) << ")" << std::endl;
+       << ", tid=" << (pid_t)syscall(SYS_gettid) << ")" << std::endl;
   oops << "Signal: " << sig_num << " (" << strsignal(sig_num)
        << "), si_code: " << info->si_code << " ("
        << si_code_to_str(sig_num, info->si_code)
@@ -375,7 +375,7 @@ void dump_types(void) {
   printf("sizeof(task)=%zu\n", sizeof(struct task));
 
   printf("sizeof(Module)=%zu\n", sizeof(Module));
-  printf("sizeof(gate)=%zu\n", sizeof(struct gate));
+  printf("sizeof(gate)=%zu\n", sizeof(Gate));
 
   printf("sizeof(worker_context)=%zu\n", sizeof(Worker));
 

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -375,7 +375,9 @@ void dump_types(void) {
   printf("sizeof(task)=%zu\n", sizeof(struct task));
 
   printf("sizeof(Module)=%zu\n", sizeof(Module));
-  printf("sizeof(gate)=%zu\n", sizeof(Gate));
+  printf("sizeof(Gate)=%zu\n", sizeof(bess::Gate));
+  printf("sizeof(IGate)=%zu\n", sizeof(bess::IGate));
+  printf("sizeof(OGate)=%zu\n", sizeof(bess::OGate));
 
   printf("sizeof(worker_context)=%zu\n", sizeof(Worker));
 

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -1,0 +1,51 @@
+#include "gate.h"
+
+#include <algorithm>
+
+int Gate::AddHook(GateHook *hook) {
+  for (const auto &h : hooks_) {
+    if (h->name() == hook->name()) {
+      return EEXIST;
+    }
+  }
+
+  hooks_.push_back(hook);
+  std::sort(hooks_.begin(), hooks_.end(), GateHookComp);
+  return 0;
+}
+
+GateHook *Gate::FindHook(const std::string &name) {
+  for (const auto &hook : hooks_) {
+    if (hook->name() == name) {
+      return hook;
+    }
+  }
+  return nullptr;
+}
+
+void Gate::RemoveHook(const std::string &name) {
+  for (auto it = hooks_.begin(); it != hooks_.end(); ++it) {
+    GateHook *hook = *it;
+    if (hook->name() == name) {
+      delete hook;
+      hooks_.erase(it);
+      return;
+    }
+  }
+}
+
+void Gate::ClearHooks() {
+  for (auto &hook : hooks_) {
+    delete hook;
+  }
+  hooks_.clear();
+}
+
+void IGate::RemoveOgate(const OGate *og) {
+  for (auto it = ogates_upstream_.begin(); it != ogates_upstream_.end(); ++it) {
+    if (*it == og) {
+      ogates_upstream_.erase(it);
+      return;
+    }
+  }
+}

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+namespace bess {
+
 int Gate::AddHook(GateHook *hook) {
   for (const auto &h : hooks_) {
     if (h->name() == hook->name()) {
@@ -48,4 +50,5 @@ void IGate::RemoveOgate(const OGate *og) {
       return;
     }
   }
+}
 }

--- a/core/gate.h
+++ b/core/gate.h
@@ -3,9 +3,12 @@
 
 #include <vector>
 
+#include "pktbatch.h"
 #include "utils/common.h"
 
 class Module;
+
+namespace bess {
 
 typedef uint16_t gate_idx_t;
 
@@ -29,9 +32,9 @@ class Gate;
 class GateHook {
  public:
   GateHook(const std::string &name, uint16_t priority = 0, Gate *gate = nullptr)
-      : gate_(gate), name_(name), priority_(priority){};
+      : gate_(gate), name_(name), priority_(priority){}
 
-  virtual ~GateHook(){};
+  virtual ~GateHook(){}
 
   const std::string &name() const { return name_; }
 
@@ -39,7 +42,7 @@ class GateHook {
 
   uint16_t priority() const { return priority_; }
 
-  virtual void ProcessBatch(const struct pkt_batch *){};
+  virtual void ProcessBatch(const struct pkt_batch *) {}
 
  protected:
   Gate *gate_;
@@ -59,9 +62,9 @@ inline bool GateHookComp(const GateHook *lhs, const GateHook *rhs) {
 class Gate {
  public:
   Gate(Module *m, gate_idx_t idx, void *arg)
-      : module_(m), gate_idx_(idx), arg_(arg){};
+      : module_(m), gate_idx_(idx), arg_(arg){}
 
-  virtual ~Gate(){};
+  virtual ~Gate(){}
 
   Module *module() const { return module_; }
 
@@ -101,7 +104,7 @@ class IGate;
 class OGate : public Gate {
  public:
   OGate(Module *m, gate_idx_t idx, void *arg)
-      : Gate(m, idx, arg), igate_(), igate_idx_(){};
+      : Gate(m, idx, arg), igate_(), igate_idx_(){}
 
   void set_igate(IGate *ig) { igate_ = ig; }
   IGate *igate() const { return igate_; }
@@ -116,7 +119,7 @@ class OGate : public Gate {
 
 class IGate : public Gate {
  public:
-  IGate(Module *m, gate_idx_t idx, void *arg) : Gate(m, idx, arg){};
+  IGate(Module *m, gate_idx_t idx, void *arg) : Gate(m, idx, arg){}
 
   const std::vector<OGate *> &ogates_upstream() const {
     return ogates_upstream_;
@@ -129,5 +132,6 @@ class IGate : public Gate {
  private:
   std::vector<OGate *> ogates_upstream_;
 };
+}
 
-#endif // BESS_GATE_H_
+#endif  // BESS_GATE_H_

--- a/core/gate.h
+++ b/core/gate.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-#include "utils/cdlist.h"
+#include "utils/common.h"
 
 class Module;
 
@@ -20,7 +20,7 @@ typedef uint16_t gate_idx_t;
 static_assert(MAX_GATES < INVALID_GATE, "invalid macro value");
 static_assert(DROP_GATE <= MAX_GATES, "invalid macro value");
 
-struct gate;
+class Gate;
 
 // Gate hooks allow you to run arbitrary code on the packets flowing through a
 // gate before they get delievered to the upstream module.
@@ -28,22 +28,21 @@ struct gate;
 // can attach/detach them at runtime.
 class GateHook {
  public:
-  GateHook(const std::string &name, uint16_t priority = 0,
-           struct gate *gate = nullptr)
+  GateHook(const std::string &name, uint16_t priority = 0, Gate *gate = nullptr)
       : gate_(gate), name_(name), priority_(priority){};
 
   virtual ~GateHook(){};
 
   const std::string &name() const { return name_; }
 
-  void set_gate(struct gate *gate) { gate_ = gate; }
+  void set_gate(Gate *gate) { gate_ = gate; }
 
   uint16_t priority() const { return priority_; }
 
   virtual void ProcessBatch(const struct pkt_batch *){};
 
  protected:
-  struct gate *gate_;
+  Gate *gate_;
 
  private:
   const std::string &name_;
@@ -57,30 +56,78 @@ inline bool GateHookComp(const GateHook *lhs, const GateHook *rhs) {
   return (lhs->priority() < rhs->priority());
 }
 
-struct gate {
+class Gate {
+ public:
+  Gate(Module *m, gate_idx_t idx, void *arg)
+      : module_(m), gate_idx_(idx), arg_(arg){};
+
+  virtual ~Gate(){};
+
+  Module *module() const { return module_; }
+
+  gate_idx_t gate_idx() const { return gate_idx_; }
+
+  void *arg() const { return arg_; }
+
+  const std::vector<GateHook *> &hooks() const { return hooks_; }
+
+  // Inserts hook in priority order and returns 0 on success.
+  int AddHook(GateHook *hook);
+
+  GateHook *FindHook(const std::string &name);
+
+  void RemoveHook(const std::string &name);
+
+  void ClearHooks();
+
+ private:
   /* immutable values */
-  Module *m;           /* the module this gate belongs to */
-  gate_idx_t gate_idx; /* input/output gate index of itself */
+  Module *module_;      /* the module this gate belongs to */
+  gate_idx_t gate_idx_; /* input/output gate index of itself */
 
   /* mutable values below */
-  void *arg;
-
-  union {
-    struct {
-      struct cdlist_item igate_upstream;
-      struct gate *igate;
-      gate_idx_t igate_idx; /* cache for igate->gate_idx */
-    } out;
-
-    struct {
-      struct cdlist_head ogates_upstream;
-    } in;
-  };
+  void *arg_;
 
   // TODO(melvin): Consider using a map here instead. It gets rid of the need to
   // scan to find modules for queries. Not sure how priority would work in a
   // map, though.
-  std::vector<GateHook *> hooks;
+  std::vector<GateHook *> hooks_;
+
+  DISALLOW_COPY_AND_ASSIGN(Gate);
 };
 
-#endif
+class IGate;
+
+class OGate : public Gate {
+ public:
+  OGate(Module *m, gate_idx_t idx, void *arg)
+      : Gate(m, idx, arg), igate_(), igate_idx_(){};
+
+  void set_igate(IGate *ig) { igate_ = ig; }
+  IGate *igate() const { return igate_; }
+
+  void set_igate_idx(gate_idx_t idx) { igate_idx_ = idx; }
+  gate_idx_t igate_idx() const { return igate_idx_; }
+
+ private:
+  IGate *igate_;
+  gate_idx_t igate_idx_; /* cache for igate->gate_idx */
+};
+
+class IGate : public Gate {
+ public:
+  IGate(Module *m, gate_idx_t idx, void *arg) : Gate(m, idx, arg){};
+
+  const std::vector<OGate *> &ogates_upstream() const {
+    return ogates_upstream_;
+  }
+
+  void PushOgate(OGate *og) { ogates_upstream_.push_back(og); }
+
+  void RemoveOgate(const OGate *og);
+
+ private:
+  std::vector<OGate *> ogates_upstream_;
+};
+
+#endif // BESS_GATE_H_

--- a/core/gate.h
+++ b/core/gate.h
@@ -83,16 +83,4 @@ struct gate {
   std::vector<GateHook *> hooks;
 };
 
-// TODO(melvin): not sure this necessary anymore. consider replacing with
-// std::vector
-struct gates {
-  /* Resizable array of 'struct gate *'.
-   * Unconnected elements are filled with nullptr */
-  struct gate **arr;
-
-  /* The current size of the array.
-   * Always <= m->mclass->num_[i|o]gates */
-  gate_idx_t curr_size;
-};
-
 #endif

--- a/core/gate.h
+++ b/core/gate.h
@@ -1,6 +1,8 @@
 #ifndef BESS_GATE_H_
 #define BESS_GATE_H_
 
+#include <vector>
+
 #include "utils/cdlist.h"
 
 class Module;
@@ -18,19 +20,56 @@ typedef uint16_t gate_idx_t;
 static_assert(MAX_GATES < INVALID_GATE, "invalid macro value");
 static_assert(DROP_GATE <= MAX_GATES, "invalid macro value");
 
+struct gate;
+
+// Gate hooks allow you to run arbitrary code on the packets flowing through a
+// gate before they get delievered to the upstream module.
+// TODO(melvin): GateHooks should be structured like Modules/Drivers, so bessctl
+// can attach/detach them at runtime.
+class GateHook {
+ public:
+  GateHook(const std::string &name, uint16_t priority = 0,
+           struct gate *gate = nullptr)
+      : gate_(gate), name_(name), priority_(priority){};
+
+  virtual ~GateHook(){};
+
+  const std::string &name() const { return name_; }
+
+  void set_gate(struct gate *gate) { gate_ = gate; }
+
+  uint16_t priority() const { return priority_; }
+
+  virtual void ProcessBatch(const struct pkt_batch *){};
+
+ protected:
+  struct gate *gate_;
+
+ private:
+  const std::string &name_;
+
+  const uint16_t priority_;
+
+  DISALLOW_COPY_AND_ASSIGN(GateHook);
+};
+
+inline bool GateHookComp(const GateHook *lhs, const GateHook *rhs) {
+  return (lhs->priority() < rhs->priority());
+}
+
 struct gate {
   /* immutable values */
   Module *m;           /* the module this gate belongs to */
   gate_idx_t gate_idx; /* input/output gate index of itself */
-                       /*  index is relative to module, not global */
+
   /* mutable values below */
   void *arg;
 
   union {
     struct {
-      struct cdlist_item igate_upstream; /* next and prev module*/
-      struct gate *igate;                /* self */
-      gate_idx_t igate_idx;              /* cache for igate->gate_idx */
+      struct cdlist_item igate_upstream;
+      struct gate *igate;
+      gate_idx_t igate_idx; /* cache for igate->gate_idx */
     } out;
 
     struct {
@@ -38,17 +77,14 @@ struct gate {
     } in;
   };
 
-/* TODO: generalize with gate hooks */
-#if TRACK_GATES
-  uint64_t cnt;
-  uint64_t pkts;
-#endif
-#if TCPDUMP_GATES
-  uint32_t tcpdump;
-  int fifo_fd;
-#endif
+  // TODO(melvin): Consider using a map here instead. It gets rid of the need to
+  // scan to find modules for queries. Not sure how priority would work in a
+  // map, though.
+  std::vector<GateHook *> hooks;
 };
 
+// TODO(melvin): not sure this necessary anymore. consider replacing with
+// std::vector
 struct gates {
   /* Resizable array of 'struct gate *'.
    * Unconnected elements are filled with nullptr */

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -1,0 +1,87 @@
+#include "gate.h"
+
+#include <gtest/gtest.h>
+
+#include "hooks/tcpdump.h"
+#include "hooks/track.h"
+#include "module.h"
+#include "pktbatch.h"
+
+namespace {
+
+class GateTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    g = new Gate(nullptr, 0, nullptr);
+    ASSERT_EQ(nullptr, g->arg());
+  }
+
+  virtual void TearDown() { delete g; }
+
+  Gate *g;
+};
+
+class IOGateTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    og = new OGate(nullptr, 0, nullptr);
+    ig = new IGate(nullptr, 0, nullptr);
+    ASSERT_NE(nullptr, og);
+    ASSERT_NE(nullptr, ig);
+  }
+
+  virtual void TearDown() {
+    delete og;
+    delete ig;
+  }
+
+  OGate *og;
+  IGate *ig;
+};
+
+TEST_F(GateTest, AddExistingHookFails) {
+  ASSERT_EQ(0, g->AddHook(new TrackGate()));
+  ASSERT_EQ(EEXIST, g->AddHook(new TrackGate()));
+}
+
+TEST_F(GateTest, HookPriority) {
+  ASSERT_EQ(0, g->AddHook(new TrackGate()));
+  ASSERT_EQ(0, g->AddHook(new TcpDump()));
+  ASSERT_EQ(kGateHookTrackGate, g->hooks()[0]->name());
+}
+
+TEST_F(GateTest, FindHook) {
+  ASSERT_EQ(nullptr, g->FindHook(kGateHookTrackGate));
+  ASSERT_EQ(0, g->AddHook(new TrackGate()));
+  ASSERT_NE(nullptr, g->FindHook(kGateHookTrackGate));
+}
+
+TEST_F(GateTest, RemoveHook) {
+  ASSERT_EQ(0, g->AddHook(new TrackGate()));
+  g->RemoveHook(kGateHookTrackGate);
+  ASSERT_EQ(nullptr, g->FindHook(kGateHookTrackGate));
+}
+
+TEST(HookTest, TrackGate) {
+  TrackGate t;
+  struct pkt_batch b;
+  b.cnt = 32;
+  t.ProcessBatch(&b);
+  ASSERT_EQ(1, t.cnt());
+  ASSERT_EQ(b.cnt, t.pkts());
+}
+
+TEST_F(IOGateTest, OGate) {
+  og->set_igate(ig);
+  og->set_igate_idx(0);
+  ASSERT_EQ(ig, og->igate());
+  ASSERT_EQ(0, og->igate_idx());
+}
+
+TEST_F(IOGateTest, IGate) {
+  ig->PushOgate(og);
+  ASSERT_EQ(og, ig->ogates_upstream()[0]);
+  ig->RemoveOgate(og);
+  ASSERT_EQ(0, ig->ogates_upstream().size());
+}
+}

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -7,7 +7,7 @@
 #include "module.h"
 #include "pktbatch.h"
 
-namespace {
+namespace bess {
 
 class GateTest : public ::testing::Test {
  protected:

--- a/core/hooks/tcpdump.cc
+++ b/core/hooks/tcpdump.cc
@@ -1,0 +1,40 @@
+#include "tcpdump.h"
+
+#include <sys/uio.h>
+
+#include <glog/logging.h>
+
+#include "../utils/common.h"
+#include "../utils/pcap.h"
+#include "../utils/time.h"
+
+void TcpDump::ProcessBatch(const struct pkt_batch *batch) {
+  struct timeval tv;
+
+  int ret = 0;
+
+  gettimeofday(&tv, nullptr);
+
+  for (int i = 0; i < batch->cnt; i++) {
+    struct snbuf *pkt = batch->pkts[i];
+    struct pcap_rec_hdr rec = {
+        .ts_sec = (uint32_t)tv.tv_sec,
+        .ts_usec = (uint32_t)tv.tv_usec,
+        .incl_len = pkt->mbuf.data_len,
+        .orig_len = pkt->mbuf.pkt_len,
+    };
+
+    struct iovec vec[2] = {{&rec, sizeof(rec)},
+                           {snb_head_data(pkt), (size_t)snb_head_len(pkt)}};
+
+    ret = writev(fifo_fd_, vec, 2);
+    if (ret < 0) {
+      if (errno == EPIPE) {
+        DLOG(WARNING) << "Broken pipe: stopping tcpdump";
+        close(fifo_fd_);
+        fifo_fd_ = 0;
+      }
+      return;
+    }
+  }
+}

--- a/core/hooks/tcpdump.h
+++ b/core/hooks/tcpdump.h
@@ -8,10 +8,11 @@ const std::string kGateHookTcpDumpGate = "tcpdump";
 const uint16_t kGateHookPriorityTcpDump = 1;
 
 // TcpDump dumps copies of the packets seen by a gate. Useful for debugging.
-class TcpDump : public GateHook {
+class TcpDump : public bess::GateHook {
  public:
   TcpDump()
-      : GateHook(kGateHookTcpDumpGate, kGateHookPriorityTcpDump), fifo_fd_(){};
+      : bess::GateHook(kGateHookTcpDumpGate, kGateHookPriorityTcpDump),
+        fifo_fd_(){};
 
   int fifo_fd() const { return fifo_fd_; }
   void set_fifo_fd(int fifo_fd) { fifo_fd_ = fifo_fd; }

--- a/core/hooks/tcpdump.h
+++ b/core/hooks/tcpdump.h
@@ -1,0 +1,23 @@
+#ifndef BESS_HOOKS_TCPDUMP_
+#define BESS_HOOKS_TCPDUMP_
+
+#include "../module.h"
+
+const std::string kGateHookTcpDumpGate = "tcpdump";
+
+// TcpDump dumps copies of the packets seen by a gate. Useful for debugging.
+class TcpDump : public GateHook {
+ public:
+  TcpDump(uint16_t priority = 0)
+      : GateHook(kGateHookTcpDumpGate, priority), fifo_fd_(){};
+
+  int fifo_fd() const { return fifo_fd_; }
+  void set_fifo_fd(int fifo_fd) { fifo_fd_ = fifo_fd; }
+
+  void ProcessBatch(const struct pkt_batch *batch);
+
+ private:
+  int fifo_fd_;
+};
+
+#endif  // BESS_HOOKS_TCPDUMP_

--- a/core/hooks/tcpdump.h
+++ b/core/hooks/tcpdump.h
@@ -5,11 +5,13 @@
 
 const std::string kGateHookTcpDumpGate = "tcpdump";
 
+const uint16_t kGateHookPriorityTcpDump = 1;
+
 // TcpDump dumps copies of the packets seen by a gate. Useful for debugging.
 class TcpDump : public GateHook {
  public:
-  TcpDump(uint16_t priority = 0)
-      : GateHook(kGateHookTcpDumpGate, priority), fifo_fd_(){};
+  TcpDump()
+      : GateHook(kGateHookTcpDumpGate, kGateHookPriorityTcpDump), fifo_fd_(){};
 
   int fifo_fd() const { return fifo_fd_; }
   void set_fifo_fd(int fifo_fd) { fifo_fd_ = fifo_fd; }

--- a/core/hooks/track.cc
+++ b/core/hooks/track.cc
@@ -1,0 +1,6 @@
+#include "track.h"
+
+void TrackGate::ProcessBatch(const struct pkt_batch *batch) {
+  cnt_ += 1;
+  pkts_ += batch->cnt;
+}

--- a/core/hooks/track.h
+++ b/core/hooks/track.h
@@ -4,12 +4,15 @@
 #include "../module.h"
 
 const std::string kGateHookTrackGate = "track_gate";
+const uint16_t kGateHookPriorityTrackGate = 0;
 
 // TrackGate counts the number of packets and batches seen by a gate.
 class TrackGate : public GateHook {
  public:
-  TrackGate(uint16_t priority = 0)
-      : GateHook(kGateHookTrackGate, priority), cnt_(), pkts_(){};
+  TrackGate()
+      : GateHook(kGateHookTrackGate, kGateHookPriorityTrackGate),
+        cnt_(),
+        pkts_(){};
 
   uint64_t cnt() const { return cnt_; }
   void incr_cnt(uint64_t n) { cnt_ += n; }

--- a/core/hooks/track.h
+++ b/core/hooks/track.h
@@ -7,10 +7,10 @@ const std::string kGateHookTrackGate = "track_gate";
 const uint16_t kGateHookPriorityTrackGate = 0;
 
 // TrackGate counts the number of packets and batches seen by a gate.
-class TrackGate : public GateHook {
+class TrackGate : public bess::GateHook {
  public:
   TrackGate()
-      : GateHook(kGateHookTrackGate, kGateHookPriorityTrackGate),
+      : bess::GateHook(kGateHookTrackGate, kGateHookPriorityTrackGate),
         cnt_(),
         pkts_(){};
 

--- a/core/hooks/track.h
+++ b/core/hooks/track.h
@@ -1,0 +1,27 @@
+#ifndef BESS_HOOKS_TRACK_
+#define BESS_HOOKS_TRACK_
+
+#include "../module.h"
+
+const std::string kGateHookTrackGate = "track_gate";
+
+// TrackGate counts the number of packets and batches seen by a gate.
+class TrackGate : public GateHook {
+ public:
+  TrackGate(uint16_t priority = 0)
+      : GateHook(kGateHookTrackGate, priority), cnt_(), pkts_(){};
+
+  uint64_t cnt() const { return cnt_; }
+  void incr_cnt(uint64_t n) { cnt_ += n; }
+
+  uint64_t pkts() const { return pkts_; }
+  void incr_pkts(uint64_t n) { pkts_ += n; }
+
+  void ProcessBatch(const struct pkt_batch *batch);
+
+ private:
+  uint64_t cnt_;
+  uint64_t pkts_;
+};
+
+#endif  // BESS_HOOKS_TRACK_

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -146,7 +146,8 @@ void Pipeline::AddModuleToComponent(Module *m, const struct Attribute *attr) {
   component.add_module(m);
 }
 
-const struct Attribute *Pipeline::FindAttr(Module *m, const struct Attribute *attr) const {
+const struct Attribute *Pipeline::FindAttr(Module *m,
+                                           const struct Attribute *attr) const {
   for (const auto &it : m->all_attrs()) {
     if (get_attr_id(&it) == get_attr_id(attr)) {
       return &it;
@@ -175,8 +176,7 @@ void Pipeline::TraverseUpstream(Module *m, const struct Attribute *attr) {
   }
   module_scopes_[m] = static_cast<int>(scope_components_.size());
 
-  for (int i = 0; i < m->igates.curr_size; i++) {
-    struct gate *g = m->igates.arr[i];
+  for (const auto &g : m->igates) {
     struct gate *og;
 
     cdlist_for_each_entry(og, &g->in.ogates_upstream, out.igate_upstream) {
@@ -184,13 +184,12 @@ void Pipeline::TraverseUpstream(Module *m, const struct Attribute *attr) {
     }
   }
 
-  if (m->igates.curr_size == 0) {
+  if (m->igates.size() == 0) {
     scope_components_.back().set_invalid(true);
   }
 }
 
 int Pipeline::TraverseDownstream(Module *m, const struct Attribute *attr) {
-  struct gate *ogate;
   const struct Attribute *found_attr;
   int8_t in_scope = 0;
 
@@ -207,8 +206,7 @@ int Pipeline::TraverseDownstream(Module *m, const struct Attribute *attr) {
     AddModuleToComponent(m, found_attr);
     found_attr->scope_id = scope_components_.size();
 
-    for (int i = 0; i < m->ogates.curr_size; i++) {
-      ogate = m->ogates.arr[i];
+    for (const auto &ogate : m->ogates) {
       if (!ogate) {
         continue;
       }
@@ -226,8 +224,7 @@ int Pipeline::TraverseDownstream(Module *m, const struct Attribute *attr) {
     return -1;
   }
 
-  for (int i = 0; i < m->ogates.curr_size; i++) {
-    ogate = m->ogates.arr[i];
+  for (const auto &ogate : m->ogates) {
     if (!ogate) {
       continue;
     }
@@ -246,23 +243,21 @@ int Pipeline::TraverseDownstream(Module *m, const struct Attribute *attr) {
   return in_scope ? 0 : -1;
 }
 
-void Pipeline::IdentifySingleScopeComponent(Module *m, const struct Attribute *attr) {
+void Pipeline::IdentifySingleScopeComponent(Module *m,
+                                            const struct Attribute *attr) {
   scope_components_.emplace_back();
   IdentifyScopeComponent(m, attr);
   scope_components_.back().set_scope_id(scope_components_.size());
 }
 
 void Pipeline::IdentifyScopeComponent(Module *m, const struct Attribute *attr) {
-  struct gate *ogate;
-
   AddModuleToComponent(m, attr);
   attr->scope_id = scope_components_.size();
 
   /* cycle detection */
   module_scopes_[m] = static_cast<int>(scope_components_.size());
 
-  for (int i = 0; i < m->ogates.curr_size; i++) {
-    ogate = m->ogates.arr[i];
+  for (const auto &ogate : m->ogates) {
     if (!ogate) {
       continue;
     }
@@ -318,8 +313,8 @@ void Pipeline::AssignOffsets() {
   const ScopeComponent *comp2;
 
   for (size_t i = 0; i < scope_components_.size(); i++) {
-    std::priority_queue<const ScopeComponent *, std::vector<const ScopeComponent *>,
-                        ScopeComponentComp>
+    std::priority_queue<const ScopeComponent *,
+                        std::vector<const ScopeComponent *>, ScopeComponentComp>
         h;
     comp1 = &scope_components_[i];
 
@@ -374,8 +369,8 @@ void Pipeline::AssignOffsets() {
 void Pipeline::LogAllScopes() {
   for (size_t i = 0; i < scope_components_.size(); i++) {
     VLOG(1) << "scope component for " << scope_components_[i].size()
-              << "-byte attr " << scope_components_[i].attr_id() << "at offset "
-              << scope_components_[i].offset() << ": {";
+            << "-byte attr " << scope_components_[i].attr_id() << "at offset "
+            << scope_components_[i].offset() << ": {";
 
     for (const auto &it : scope_components_[i].modules()) {
       VLOG(1) << it->name();

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -177,10 +177,8 @@ void Pipeline::TraverseUpstream(Module *m, const struct Attribute *attr) {
   module_scopes_[m] = static_cast<int>(scope_components_.size());
 
   for (const auto &g : m->igates) {
-    struct gate *og;
-
-    cdlist_for_each_entry(og, &g->in.ogates_upstream, out.igate_upstream) {
-      TraverseUpstream(og->m, attr);
+    for (const auto &og : g->ogates_upstream()) {
+      TraverseUpstream(og->module(), attr);
     }
   }
 
@@ -211,7 +209,7 @@ int Pipeline::TraverseDownstream(Module *m, const struct Attribute *attr) {
         continue;
       }
 
-      TraverseDownstream(ogate->out.igate->m, attr);
+      TraverseDownstream(ogate->igate()->module(), attr);
     }
 
     module_scopes_[m] = -1;
@@ -229,7 +227,7 @@ int Pipeline::TraverseDownstream(Module *m, const struct Attribute *attr) {
       continue;
     }
 
-    if (TraverseDownstream(ogate->out.igate->m, attr) != -1) {
+    if (TraverseDownstream(ogate->igate()->module(), attr) != -1) {
       in_scope = 1;
     }
   }
@@ -262,7 +260,7 @@ void Pipeline::IdentifyScopeComponent(Module *m, const struct Attribute *attr) {
       continue;
     }
 
-    TraverseDownstream(ogate->out.igate->m, attr);
+    TraverseDownstream(ogate->igate()->module(), attr);
   }
 }
 

--- a/core/module.cc
+++ b/core/module.cc
@@ -260,8 +260,8 @@ int Module::AddMetadataAttr(const std::string &name, size_t size,
 /* returns -errno if fails */
 int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
                            gate_idx_t igate_idx) {
-  OGate *ogate;
-  IGate *igate;
+  bess::OGate *ogate;
+  bess::IGate *igate;
 
   if (ogate_idx >= module_builder_->NumOGates() || ogate_idx >= MAX_GATES) {
     return -EINVAL;
@@ -273,7 +273,7 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
   }
 
   /* already being used? */
-  if (is_active_gate<OGate>(ogates, ogate_idx)) {
+  if (is_active_gate<bess::OGate>(ogates, ogate_idx)) {
     return -EBUSY;
   }
 
@@ -281,7 +281,7 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
     ogates.emplace_back();
   }
 
-  ogate = new OGate(this, ogate_idx, m_next);
+  ogate = new bess::OGate(this, ogate_idx, m_next);
   if (!ogate) {
     return -ENOMEM;
   }
@@ -291,7 +291,7 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
     m_next->igates.emplace_back();
   }
 
-  igate = new IGate(m_next, igate_idx, m_next);
+  igate = new bess::IGate(m_next, igate_idx, m_next);
   if (!igate) {
     delete ogate;
     return -ENOMEM;
@@ -310,15 +310,15 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
 }
 
 int Module::DisconnectModules(gate_idx_t ogate_idx) {
-  OGate *ogate;
-  IGate *igate;
+  bess::OGate *ogate;
+  bess::IGate *igate;
 
   if (ogate_idx >= module_builder_->NumOGates()) {
     return -EINVAL;
   }
 
   /* no error even if the ogate is unconnected already */
-  if (!is_active_gate<OGate>(ogates, ogate_idx)) {
+  if (!is_active_gate<bess::OGate>(ogates, ogate_idx)) {
     return 0;
   }
 
@@ -346,14 +346,14 @@ int Module::DisconnectModules(gate_idx_t ogate_idx) {
 }
 
 int Module::DisconnectModulesUpstream(gate_idx_t igate_idx) {
-  IGate *igate;
+  bess::IGate *igate;
 
   if (igate_idx >= module_builder_->NumIGates()) {
     return -EINVAL;
   }
 
   /* no error even if the igate is unconnected already */
-  if (!is_active_gate<IGate>(igates, igate_idx)) {
+  if (!is_active_gate<bess::IGate>(igates, igate_idx)) {
     return 0;
   }
 
@@ -505,16 +505,16 @@ int Module::EnableTcpDump(const char *fifo, int is_igate, gate_idx_t gate_idx) {
       .snaplen = PCAP_SNAPLEN,
       .network = PCAP_NETWORK,
   };
-  Gate *gate;
+  bess::Gate *gate;
 
   int fd;
   int ret;
 
   /* Don't allow tcpdump to be attached to gates that are not active */
-  if (!is_igate && !is_active_gate<OGate>(ogates, gate_idx))
+  if (!is_igate && !is_active_gate<bess::OGate>(ogates, gate_idx))
     return -EINVAL;
 
-  if (is_igate && !is_active_gate<IGate>(igates, gate_idx))
+  if (is_igate && !is_active_gate<bess::IGate>(igates, gate_idx))
     return -EINVAL;
 
   fd = open(fifo, O_WRONLY | O_NONBLOCK);
@@ -552,13 +552,13 @@ int Module::EnableTcpDump(const char *fifo, int is_igate, gate_idx_t gate_idx) {
 }
 
 int Module::DisableTcpDump(int is_igate, gate_idx_t gate_idx) {
-  if (!is_igate && !is_active_gate<OGate>(ogates, gate_idx))
+  if (!is_igate && !is_active_gate<bess::OGate>(ogates, gate_idx))
     return -EINVAL;
 
-  if (is_igate && !is_active_gate<IGate>(igates, gate_idx))
+  if (is_igate && !is_active_gate<bess::IGate>(igates, gate_idx))
     return -EINVAL;
 
-  Gate *gate;
+  bess::Gate *gate;
   if (is_igate) {
     gate = igates[gate_idx];
   } else {

--- a/core/module.cc
+++ b/core/module.cc
@@ -42,8 +42,6 @@ Module *ModuleBuilder::CreateModule(const std::string &name,
   m->set_name(name);
   m->set_module_builder(this);
   m->set_pipeline(pipeline);
-  m->igates = gates();
-  m->ogates = gates();
   return m;
 }
 
@@ -56,26 +54,29 @@ int ModuleBuilder::DestroyModule(Module *m, bool erase) {
   m->Deinit();
 
   // disconnect from upstream modules.
-  for (int i = 0; i < m->igates.curr_size; i++) {
+  for (size_t i = 0; i < m->igates.size(); i++) {
     ret = m->DisconnectModulesUpstream(i);
-    if (ret)
+    if (ret) {
       return ret;
+    }
   }
 
   // disconnect downstream modules
-  for (gate_idx_t i = 0; i < m->ogates.curr_size; i++) {
+  for (size_t i = 0; i < m->ogates.size(); i++) {
     ret = m->DisconnectModules(i);
-    if (ret)
+    if (ret) {
       return ret;
+    }
   }
 
   m->DestroyAllTasks();
 
-  if (erase)
+  if (erase) {
     all_modules_.erase(m->name());
+  }
 
-  mem_free(m->ogates.arr);
-  mem_free(m->igates.arr);
+  m->ogates.clear();
+  m->igates.clear();
   delete m;
   return 0;
 }
@@ -256,79 +257,44 @@ int Module::AddMetadataAttr(const std::string &name, size_t size,
   return attrs.size() - 1;
 }
 
-int Module::GrowGates(struct gates *gates, gate_idx_t gate) {
-  struct gate **new_arr;
-  gate_idx_t old_size;
-  gate_idx_t new_size;
-
-  new_size = gates->curr_size ?: 1;
-
-  while (new_size <= gate)
-    new_size *= 2;
-
-  if (new_size > MAX_GATES)
-    new_size = MAX_GATES;
-
-  new_arr =
-      (struct gate **)mem_realloc(gates->arr, sizeof(struct gate *) * new_size);
-  if (!new_arr)
-    return -ENOMEM;
-
-  gates->arr = new_arr;
-
-  old_size = gates->curr_size;
-  gates->curr_size = new_size;
-
-  /* initialize the newly created gates */
-  memset(&gates->arr[old_size], 0,
-         sizeof(struct gate *) * (new_size - old_size));
-
-  return 0;
-}
-
 /* returns -errno if fails */
 int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
                            gate_idx_t igate_idx) {
   struct gate *ogate;
   struct gate *igate;
 
-  if (ogate_idx >= module_builder_->NumOGates() || ogate_idx >= MAX_GATES)
+  if (ogate_idx >= module_builder_->NumOGates() || ogate_idx >= MAX_GATES) {
     return -EINVAL;
+  }
 
   if (igate_idx >= m_next->module_builder()->NumIGates() ||
-      igate_idx >= MAX_GATES)
+      igate_idx >= MAX_GATES) {
     return -EINVAL;
-
-  if (ogate_idx >= ogates.curr_size) {
-    int ret = GrowGates(&ogates, ogate_idx);
-    if (ret)
-      return ret;
   }
 
   /* already being used? */
-  if (is_active_gate(&ogates, ogate_idx))
+  if (is_active_gate(ogates, ogate_idx)) {
     return -EBUSY;
-
-  if (igate_idx >= m_next->igates.curr_size) {
-    int ret = m_next->GrowGates(&m_next->igates, igate_idx);
-    if (ret)
-      return ret;
   }
 
+  if (ogate_idx >= ogates.size()) {
+    ogates.emplace_back();
+  }
   ogate = (struct gate *)mem_alloc(sizeof(struct gate));
-  if (!ogate)
+  if (!ogate) {
     return -ENOMEM;
+  }
+  ogates[ogate_idx] = ogate;
 
-  ogates.arr[ogate_idx] = ogate;
-
+  if (igate_idx >= m_next->igates.size()) {
+    m_next->igates.emplace_back();
+  }
   igate = (struct gate *)mem_alloc(sizeof(struct gate));
   if (!igate) {
-    if (!igate) {
-      mem_free(ogate);
-      return -ENOMEM;
-    }
+    mem_free(ogate);
+    return -ENOMEM;
   }
-  m_next->igates.arr[igate_idx] = igate;
+  m_next->igates[igate_idx] = igate;
 
   igate->m = m_next;
   igate->gate_idx = igate_idx;
@@ -353,16 +319,19 @@ int Module::DisconnectModules(gate_idx_t ogate_idx) {
   struct gate *ogate;
   struct gate *igate;
 
-  if (ogate_idx >= module_builder_->NumOGates())
+  if (ogate_idx >= module_builder_->NumOGates()) {
     return -EINVAL;
+  }
 
   /* no error even if the ogate is unconnected already */
-  if (!is_active_gate(&ogates, ogate_idx))
+  if (!is_active_gate(ogates, ogate_idx)) {
     return 0;
+  }
 
-  ogate = ogates.arr[ogate_idx];
-  if (!ogate)
+  ogate = ogates[ogate_idx];
+  if (!ogate) {
     return 0;
+  }
 
   igate = ogate->out.igate;
 
@@ -370,7 +339,7 @@ int Module::DisconnectModules(gate_idx_t ogate_idx) {
   cdlist_del(&ogate->out.igate_upstream);
   if (cdlist_is_empty(&igate->in.ogates_upstream)) {
     Module *m_next = igate->m;
-    m_next->igates.arr[igate->gate_idx] = nullptr;
+    m_next->igates[igate->gate_idx] = nullptr;
     for (auto &hook : igate->hooks) {
       delete hook;
     }
@@ -378,7 +347,7 @@ int Module::DisconnectModules(gate_idx_t ogate_idx) {
     mem_free(igate);
   }
 
-  ogates.arr[ogate_idx] = nullptr;
+  ogates[ogate_idx] = nullptr;
   for (auto &hook : ogate->hooks) {
     delete hook;
   }
@@ -393,28 +362,29 @@ int Module::DisconnectModulesUpstream(gate_idx_t igate_idx) {
   struct gate *ogate;
   struct gate *ogate_next;
 
-  if (igate_idx >= module_builder_->NumIGates())
+  if (igate_idx >= module_builder_->NumIGates()) {
     return -EINVAL;
+  }
 
   /* no error even if the igate is unconnected already */
-  if (!is_active_gate(&igates, igate_idx))
+  if (!is_active_gate(igates, igate_idx)) {
     return 0;
+  }
 
-  igate = igates.arr[igate_idx];
-  if (!igate)
+  igate = igates[igate_idx];
+  if (!igate) {
     return 0;
+  }
 
   cdlist_for_each_entry_safe(ogate, ogate_next, &igate->in.ogates_upstream,
                              out.igate_upstream) {
     Module *m_prev = ogate->m;
-    m_prev->ogates.arr[ogate->gate_idx] = nullptr;
+    m_prev->ogates[ogate->gate_idx] = nullptr;
     ogate->hooks.clear();
-    mem_free(ogate);
   }
 
-  igates.arr[igate_idx] = nullptr;
+  igates[igate_idx] = nullptr;
   igate->hooks.clear();
-  mem_free(igate);
 
   return 0;
 }
@@ -556,7 +526,7 @@ int Module::EnableTcpDump(const char *fifo, gate_idx_t ogate) {
   int ret;
 
   /* Don't allow tcpdump to be attached to gates that are not active */
-  if (!is_active_gate(&ogates, ogate))
+  if (!is_active_gate(ogates, ogate))
     return -EINVAL;
 
   fd = open(fifo, O_WRONLY | O_NONBLOCK);
@@ -578,7 +548,7 @@ int Module::EnableTcpDump(const char *fifo, gate_idx_t ogate) {
   }
 
   TcpDump *tcpdump = nullptr;
-  gate = ogates.arr[ogate];
+  gate = ogates[ogate];
   for (const auto &hook : gate->hooks) {
     if (hook->name() == kGateHookTcpDumpGate) {
       tcpdump = reinterpret_cast<TcpDump *>(hook);
@@ -597,15 +567,15 @@ int Module::EnableTcpDump(const char *fifo, gate_idx_t ogate) {
 }
 
 int Module::DisableTcpDump(gate_idx_t ogate) {
-  if (!is_active_gate(&ogates, ogate))
+  if (!is_active_gate(ogates, ogate))
     return -EINVAL;
 
-  struct gate *gate = ogates.arr[ogate];
-  for (size_t i = 0; i < gate->hooks.size(); i++) {
-    GateHook *hook = gate->hooks[i];
+  struct gate *gate = ogates[ogate];
+  for (auto it = gate->hooks.begin(); it != gate->hooks.end(); ++it) {
+    GateHook *hook = *it;
     if (hook->name() == kGateHookTcpDumpGate) {
       delete hook;
-      gate->hooks.erase(gate->hooks.begin() + i);
+      gate->hooks.erase(it);
       break;
     }
   }

--- a/core/module.h
+++ b/core/module.h
@@ -242,7 +242,6 @@ class Module {
                      gate_idx_t igate_idx);
   int DisconnectModulesUpstream(gate_idx_t igate_idx);
   int DisconnectModules(gate_idx_t ogate_idx);
-  int GrowGates(struct gates *gates, gate_idx_t gate);
 
   int NumTasks();
   task_id_t RegisterTask(void *arg);
@@ -301,8 +300,8 @@ class Module {
   bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule] =
       {};
 
-  struct gates igates;
-  struct gates ogates;
+  std::vector<struct gate *> igates;
+  std::vector<struct gate *> ogates;
 };
 
 void deadend(struct pkt_batch *batch);
@@ -311,12 +310,12 @@ inline void Module::RunChooseModule(gate_idx_t ogate_idx,
                                     struct pkt_batch *batch) {
   struct gate *ogate;
 
-  if (unlikely(ogate_idx >= ogates.curr_size)) {
+  if (unlikely(ogate_idx >= ogates.size())) {
     deadend(batch);
     return;
   }
 
-  ogate = ogates.arr[ogate_idx];
+  ogate = ogates[ogate_idx];
 
   if (unlikely(!ogate)) {
     deadend(batch);
@@ -348,8 +347,9 @@ static inline gate_idx_t get_igate() {
   return ctx.igate_stack_top();
 }
 
-static inline int is_active_gate(struct gates *gates, gate_idx_t idx) {
-  return idx < gates->curr_size && gates->arr && gates->arr[idx] != nullptr;
+static inline int is_active_gate(const std::vector<struct gate *> &gates,
+                                 gate_idx_t idx) {
+  return idx < gates.size() && gates.size() && gates[idx];
 }
 
 typedef struct snobj *(*mod_cmd_func_t)(struct module *, const char *,

--- a/core/module.h
+++ b/core/module.h
@@ -257,9 +257,9 @@ class Module {
   int AddMetadataAttr(const std::string &name, size_t size,
                       bess::metadata::Attribute::AccessMode mode);
 
-  int EnableTcpDump(const char *fifo, gate_idx_t gate);
+  int EnableTcpDump(const char *fifo, int is_igate, gate_idx_t gate_idx);
 
-  int DisableTcpDump(gate_idx_t gate);
+  int DisableTcpDump(int is_igate, gate_idx_t gate_idx);
 
   struct snobj *RunCommand(const std::string &cmd, struct snobj *arg) {
     return module_builder_->RunCommand(this, cmd, arg);

--- a/core/module.h
+++ b/core/module.h
@@ -299,15 +299,15 @@ class Module {
   bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule] =
       {};
 
-  std::vector<IGate *> igates;
-  std::vector<OGate *> ogates;
+  std::vector<bess::IGate *> igates;
+  std::vector<bess::OGate *> ogates;
 };
 
 void deadend(struct pkt_batch *batch);
 
 inline void Module::RunChooseModule(gate_idx_t ogate_idx,
                                     struct pkt_batch *batch) {
-  Gate *ogate;
+  bess::Gate *ogate;
 
   if (unlikely(ogate_idx >= ogates.size())) {
     deadend(batch);

--- a/core/module.h
+++ b/core/module.h
@@ -258,19 +258,9 @@ class Module {
   int AddMetadataAttr(const std::string &name, size_t size,
                       bess::metadata::Attribute::AccessMode mode);
 
-#if TCPDUMP_GATES
   int EnableTcpDump(const char *fifo, gate_idx_t gate);
 
   int DisableTcpDump(gate_idx_t gate);
-
-  void DumpPcapPkts(struct gate *gate, struct pkt_batch *batch);
-#else
-  /* Cannot enable tcpdump */
-  inline int enable_tcpdump(const char *, gate_idx_t) { return -EINVAL; }
-
-  /* Cannot disable tcpdump */
-  inline int disable_tcpdump(Module *, int) { return -EINVAL; }
-#endif
 
   struct snobj *RunCommand(const std::string &cmd, struct snobj *arg) {
     return module_builder_->RunCommand(this, cmd, arg);

--- a/core/module.h
+++ b/core/module.h
@@ -11,7 +11,6 @@
 #include "snbuf.h"
 #include "snobj.h"
 #include "task.h"
-#include "utils/cdlist.h"
 
 static inline void set_cmd_response_error(pb_cmd_response_t *response,
                                           const pb_error_t &error) {
@@ -300,15 +299,15 @@ class Module {
   bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule] =
       {};
 
-  std::vector<struct gate *> igates;
-  std::vector<struct gate *> ogates;
+  std::vector<IGate *> igates;
+  std::vector<OGate *> ogates;
 };
 
 void deadend(struct pkt_batch *batch);
 
 inline void Module::RunChooseModule(gate_idx_t ogate_idx,
                                     struct pkt_batch *batch) {
-  struct gate *ogate;
+  Gate *ogate;
 
   if (unlikely(ogate_idx >= ogates.size())) {
     deadend(batch);
@@ -347,7 +346,8 @@ static inline gate_idx_t get_igate() {
   return ctx.igate_stack_top();
 }
 
-static inline int is_active_gate(const std::vector<struct gate *> &gates,
+template <typename T>
+static inline int is_active_gate(const std::vector<T *> &gates,
                                  gate_idx_t idx) {
   return idx < gates.size() && gates.size() && gates[idx];
 }

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -196,11 +196,11 @@ TEST_F(ModuleTester, ConnectModules) {
   ASSERT_NE(nullptr, m2);
 
   EXPECT_EQ(0, m1->ConnectModules(0, m2, 0));
-  EXPECT_EQ(1, m1->ogates.curr_size);
-  EXPECT_EQ(m2, m1->ogates.arr[0]->out.igate->m);
-  EXPECT_EQ(1, m2->igates.curr_size);
+  EXPECT_EQ(1, m1->ogates.size());
+  EXPECT_EQ(m2, m1->ogates[0]->out.igate->m);
+  EXPECT_EQ(1, m2->igates.size());
 
-  cdlist_for_each_entry(og, &m2->igates.arr[0]->in.ogates_upstream,
+  cdlist_for_each_entry(og, &m2->igates[0]->in.ogates_upstream,
                         out.igate_upstream) {
     ASSERT_NE(nullptr, og);
     EXPECT_EQ(m1, og->m);

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -6,8 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include "utils/cdlist.h"
-
 namespace {
 
 // Mocking out misc things  ------------------------------------------------
@@ -188,7 +186,6 @@ TEST_F(ModuleTester, RunCommandPb) {
 
 TEST_F(ModuleTester, ConnectModules) {
   Module *m1, *m2;
-  struct gate *og;
 
   EXPECT_EQ(0, create_acme("m1", &m1));
   ASSERT_NE(nullptr, m1);
@@ -197,13 +194,12 @@ TEST_F(ModuleTester, ConnectModules) {
 
   EXPECT_EQ(0, m1->ConnectModules(0, m2, 0));
   EXPECT_EQ(1, m1->ogates.size());
-  EXPECT_EQ(m2, m1->ogates[0]->out.igate->m);
+  EXPECT_EQ(m2, m1->ogates[0]->igate()->module());
   EXPECT_EQ(1, m2->igates.size());
 
-  cdlist_for_each_entry(og, &m2->igates[0]->in.ogates_upstream,
-                        out.igate_upstream) {
+  for (const auto &og : m2->igates[0]->ogates_upstream()) {
     ASSERT_NE(nullptr, og);
-    EXPECT_EQ(m1, og->m);
+    EXPECT_EQ(m1, og->module());
   }
 }
 

--- a/core/snctl.cc
+++ b/core/snctl.cc
@@ -761,6 +761,16 @@ static struct snobj *collect_igates(Module *m) {
 
     snobj_map_set(igate, "igate", snobj_uint(g->gate_idx));
 
+    for (const auto &hook : g->hooks) {
+      if (hook->name() == kGateHookTrackGate) {
+        TrackGate *t = reinterpret_cast<TrackGate *>(hook);
+        snobj_map_set(igate, "cnt", snobj_uint(t->cnt()));
+        snobj_map_set(igate, "pkts", snobj_uint(t->pkts()));
+        snobj_map_set(igate, "timestamp", snobj_double(get_epoch_time()));
+        break;
+      }
+    }
+
     cdlist_for_each_entry(og, &g->in.ogates_upstream, out.igate_upstream) {
       struct snobj *ogate = snobj_map();
       snobj_map_set(ogate, "ogate", snobj_uint(og->gate_idx));
@@ -788,7 +798,6 @@ static struct snobj *collect_ogates(Module *m) {
 
     snobj_map_set(ogate, "ogate", snobj_uint(g->gate_idx));
 
-    // TODO(melvin): refactor struct gate to avoid this ugliness
     for (const auto &hook : g->hooks) {
       if (hook->name() == kGateHookTrackGate) {
         TrackGate *t = reinterpret_cast<TrackGate *>(hook);

--- a/core/snctl.cc
+++ b/core/snctl.cc
@@ -5,9 +5,12 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <algorithm>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "hooks/tcpdump.h"
+#include "hooks/track.h"
 #include "metadata.h"
 #include "module.h"
 #include "port.h"
@@ -147,8 +150,8 @@ static struct snobj *handle_reset_tcs(struct snobj *) {
     struct tc *c = it.second;
 
     if (c->num_tasks) {
-      return snobj_err(EBUSY, "TC %s still has %d tasks", c->settings.name.c_str(),
-                       c->num_tasks);
+      return snobj_err(EBUSY, "TC %s still has %d tasks",
+                       c->settings.name.c_str(), c->num_tasks);
     }
 
     if (c->settings.auto_free)
@@ -784,11 +787,18 @@ static struct snobj *collect_ogates(Module *m) {
     struct gate *g = m->ogates.arr[i];
 
     snobj_map_set(ogate, "ogate", snobj_uint(i));
-#if TRACK_GATES
-    snobj_map_set(ogate, "cnt", snobj_uint(g->cnt));
-    snobj_map_set(ogate, "pkts", snobj_uint(g->pkts));
-    snobj_map_set(ogate, "timestamp", snobj_double(get_epoch_time()));
-#endif
+
+    // TODO(melvin): refactor struct gate to avoid this ugliness
+    for (const auto &hook : g->hooks) {
+      if (hook->name() == kGateHookTrackGate) {
+        TrackGate *t = reinterpret_cast<TrackGate *>(hook);
+        snobj_map_set(ogate, "cnt", snobj_uint(t->cnt()));
+        snobj_map_set(ogate, "pkts", snobj_uint(t->pkts()));
+        snobj_map_set(ogate, "timestamp", snobj_double(get_epoch_time()));
+        break;
+      }
+    }
+
     snobj_map_set(ogate, "name", snobj_str(g->out.igate->m->name()));
     snobj_map_set(ogate, "igate", snobj_uint(g->out.igate->gate_idx));
 
@@ -891,6 +901,7 @@ static struct snobj *handle_connect_modules(struct snobj *q) {
   m2 = it2->second;
 
   ret = m1->ConnectModules(ogate, m2, igate);
+
   if (ret < 0)
     return snobj_err(-ret, "Connection %s:%d->%d:%s failed", m1_name, ogate,
                      igate, m2_name);
@@ -1051,6 +1062,102 @@ static struct snobj *handle_disable_tcpdump(struct snobj *q) {
   return nullptr;
 }
 
+static struct snobj *handle_enable_track(struct snobj *q) {
+  const char *m_name;
+  gate_idx_t gate_idx;
+  struct gate *gate;
+  uint16_t priority;
+  int is_igate;
+
+  Module *m;
+
+  m_name = snobj_eval_str(q, "name");
+  gate_idx = snobj_eval_uint(q, "gate");
+  priority = snobj_eval_uint(q, "priority");
+  is_igate = snobj_eval_int(q, "is_igate");
+
+  if (!m_name)
+    return snobj_err(EINVAL, "Missing 'name' field");
+
+  const auto &it = ModuleBuilder::all_modules().find(m_name);
+  if (it == ModuleBuilder::all_modules().end())
+    return snobj_err(ENOENT, "No module '%s' found", m_name);
+  m = it->second;
+
+  if (!is_igate && gate_idx >= m->ogates.curr_size) {
+    return snobj_err(EINVAL, "Output gate '%hu' does not exist", gate_idx);
+  }
+
+  if (is_igate && gate_idx >= m->igates.curr_size) {
+    return snobj_err(EINVAL, "Input gate '%hu' does not exist", gate_idx);
+  }
+
+  if (is_igate) {
+    gate = m->igates.arr[gate_idx];
+  } else {
+    gate = m->ogates.arr[gate_idx];
+  }
+
+  for (const auto &hook : gate->hooks) {
+    if (hook->name() == kGateHookTrackGate) {
+      return nullptr;
+    }
+  }
+
+  // TODO(melvin): consider refactoring struct gate and exposing a method like
+  // AddHook(...) to replace this
+  gate->hooks.push_back(new TrackGate(priority));
+  std::sort(gate->hooks.begin(), gate->hooks.end(), GateHookComp);
+
+  return nullptr;
+}
+
+static struct snobj *handle_disable_track(struct snobj *q) {
+  const char *m_name;
+  gate_idx_t gate_idx;
+  struct gate *gate;
+  int is_igate;
+
+  Module *m;
+
+  m_name = snobj_eval_str(q, "name");
+  gate_idx = snobj_eval_uint(q, "gate");
+  is_igate = snobj_eval_int(q, "is_igate");
+
+  if (!m_name)
+    return snobj_err(EINVAL, "Missing 'name' field");
+
+  const auto &it = ModuleBuilder::all_modules().find(m_name);
+  if (it == ModuleBuilder::all_modules().end())
+    return snobj_err(ENOENT, "No module '%s' found", m_name);
+  m = it->second;
+
+  if (!is_igate && gate_idx >= m->ogates.curr_size) {
+    return snobj_err(EINVAL, "Output gate '%hu' does not exist", gate_idx);
+  }
+
+  if (is_igate && gate_idx >= m->igates.curr_size) {
+    return snobj_err(EINVAL, "Input gate '%hu' does not exist", gate_idx);
+  }
+
+  if (is_igate) {
+    gate = m->igates.arr[gate_idx];
+  } else {
+    gate = m->ogates.arr[gate_idx];
+  }
+
+  for (size_t i = 0; i < gate->hooks.size(); i++) {
+    GateHook *hook = gate->hooks[i];
+    if (hook->name() == kGateHookTrackGate) {
+      delete hook;
+      gate->hooks.erase(gate->hooks.begin() + i);
+      return nullptr;
+    }
+  }
+
+  return nullptr;
+}
+
 /* Adding this mostly to provide a reasonable way to exit when daemonized */
 static struct snobj *handle_kill_bess(struct snobj *) {
   LOG(WARNING) << "Halt requested by a client";
@@ -1109,6 +1216,9 @@ static struct handler_map sn_handlers[] = {
 
     {"enable_tcpdump", 1, handle_enable_tcpdump},
     {"disable_tcpdump", 1, handle_disable_tcpdump},
+
+    {"enable_track", 1, handle_enable_track},
+    {"disable_track", 1, handle_disable_track},
 
     {"kill_bess", 1, handle_kill_bess},
 

--- a/core/task.cc
+++ b/core/task.cc
@@ -20,7 +20,7 @@ struct task_result task_scheduled(struct task *t) {
   // Depth first goes through all pending modules and services
   while (ctx.gates_pending()) {
     struct gate_task task = ctx.pop_ogate_and_packets();
-    OGate *ogate = reinterpret_cast<OGate *>(task.gate);
+    bess::OGate *ogate = reinterpret_cast<bess::OGate *>(task.gate);
     struct pkt_batch *next_packets = &(task.batch);
 
     ctx.push_igate(ogate->igate_idx());

--- a/core/task.cc
+++ b/core/task.cc
@@ -20,20 +20,20 @@ struct task_result task_scheduled(struct task *t) {
   // Depth first goes through all pending modules and services
   while (ctx.gates_pending()) {
     struct gate_task task = ctx.pop_ogate_and_packets();
-    gate *ogate = task.gate;
+    OGate *ogate = reinterpret_cast<OGate *>(task.gate);
     struct pkt_batch *next_packets = &(task.batch);
 
-    ctx.push_igate(ogate->out.igate_idx);
+    ctx.push_igate(ogate->igate_idx());
 
-    for (const auto &hook : ogate->hooks) {
+    for (auto &hook : ogate->hooks()) {
       hook->ProcessBatch(next_packets);
     }
 
-    for (const auto &hook : ogate->out.igate->hooks) {
+    for (auto &hook : ogate->igate()->hooks()) {
       hook->ProcessBatch(next_packets);
     }
 
-    ((Module *)ogate->arg)->ProcessBatch(next_packets);
+    ((Module *)ogate->arg())->ProcessBatch(next_packets);
 
     ctx.pop_igate();
   }

--- a/core/worker.h
+++ b/core/worker.h
@@ -39,7 +39,7 @@ typedef enum {
 } worker_status_t;
 
 struct gate_task {
-  struct gate *gate;
+  Gate *gate;
   struct pkt_batch batch;
 };
 
@@ -122,7 +122,7 @@ class Worker {
 
   // Store gate+packets into tasks for worker to service.
   // Returns true on success.
-  inline bool push_ogate_and_packets(gate *gate, pkt_batch *batch) {
+  inline bool push_ogate_and_packets(Gate *gate, pkt_batch *batch) {
     if (pending_gates_ > MAX_MODULES_PER_PATH * BRANCH_FACTOR) {
       LOG(ERROR) << "Gate servicing stack overrun -- loop in execution?";
       return false;

--- a/core/worker.h
+++ b/core/worker.h
@@ -39,7 +39,7 @@ typedef enum {
 } worker_status_t;
 
 struct gate_task {
-  Gate *gate;
+  bess::Gate *gate;
   struct pkt_batch batch;
 };
 
@@ -122,7 +122,7 @@ class Worker {
 
   // Store gate+packets into tasks for worker to service.
   // Returns true on success.
-  inline bool push_ogate_and_packets(Gate *gate, pkt_batch *batch) {
+  inline bool push_ogate_and_packets(bess::Gate *gate, pkt_batch *batch) {
     if (pending_gates_ > MAX_MODULES_PER_PATH * BRANCH_FACTOR) {
       LOG(ERROR) << "Gate servicing stack overrun -- loop in execution?";
       return false;

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -211,6 +211,15 @@ class BESS(object):
         args = {'name': m, 'ogate': ogate}
         return self._request_bess('disable_tcpdump', args)
 
+    def enable_track(self, m, direction='out', gate=0, priority=0):
+        args = {'name': m, 'gate_idx': gate, 'is_igate': int(direction == 'in'),
+                'priority': priority}
+        return self._request_bess('enable_track', args)
+
+    def disable_track(self, m, direction='out', gate=0):
+        args = {'name': m, 'gate_idx': gate, 'is_igate': int(direction == 'in')}
+        return self._request_bess('disable_track', args)
+
     def list_workers(self):
         return self._request_bess('list_workers')
 

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -203,12 +203,13 @@ class BESS(object):
     def run_module_command(self, name, cmd, arg):
         return self._request_module(name, cmd, arg)
 
-    def enable_tcpdump(self, fifo, m, ogate=0):
-        args = {'name': m, 'ogate': ogate, 'fifo': fifo}
+    def enable_tcpdump(self, fifo, m, direction='out', gate=0):
+        args = {'name': m, 'is_igate': int(direction == 'in'), 'gate': gate,
+                'fifo': fifo}
         return self._request_bess('enable_tcpdump', args)
 
-    def disable_tcpdump(self, m, ogate=0):
-        args = {'name': m, 'ogate': ogate}
+    def disable_tcpdump(self, m, direction='out', gate=0):
+        args = {'name': m, 'is_igate': int(direction == 'in'), 'gate': gate}
         return self._request_bess('disable_tcpdump', args)
 
     def enable_track(self, m, direction='out', gate=None):

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -211,12 +211,11 @@ class BESS(object):
         args = {'name': m, 'ogate': ogate}
         return self._request_bess('disable_tcpdump', args)
 
-    def enable_track(self, m, direction='out', gate=0, priority=0):
-        args = {'name': m, 'gate_idx': gate, 'is_igate': int(direction == 'in'),
-                'priority': priority}
+    def enable_track(self, m, direction='out', gate=None):
+        args = {'name': m, 'gate_idx': gate, 'is_igate': int(direction == 'in')}
         return self._request_bess('enable_track', args)
 
-    def disable_track(self, m, direction='out', gate=0):
+    def disable_track(self, m, direction='out', gate=None):
         args = {'name': m, 'gate_idx': gate, 'is_igate': int(direction == 'in')}
         return self._request_bess('disable_track', args)
 


### PR DESCRIPTION
It would be helpful to have a mechanism by which developers can debug pipelines of modules. Currently this is accomplished with #defines and by conditionally tacking extra fields on the end of struct gate. This patch replaces the existing process with a more general mechanism, gate hooks.