### PR TITLE
Minor changes in logging behavior

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -4,6 +4,7 @@ import os
 import os.path
 import pprint
 import cStringIO
+import tempfile
 
 import cli
 import commands
@@ -16,7 +17,7 @@ except ImportError:
     print >> sys.stderr, 'Cannot import the API module (libbess-python)'
 
 class BESSCLI(cli.CLI):
-    def __init__(self, bess, cmd_db, fin=sys.stdin, 
+    def __init__(self, bess, cmd_db, fin=sys.stdin,
                  fout=sys.stdout, history_file=None):
         self.bess = bess
         self.cmd_db = cmd_db
@@ -24,7 +25,7 @@ class BESSCLI(cli.CLI):
 
         super(BESSCLI, self).__init__(self.cmd_db.cmdlist, \
                 fin=fin, fout=fout, history_file=history_file)
-    
+
     def get_var_attrs(self, var_token, partial_word):
         return self.cmd_db.get_var_attrs(self, var_token, partial_word)
 
@@ -67,7 +68,7 @@ class BESSCLI(cli.CLI):
                 details = pprint.pformat(e.details)
                 initial_indent = '  error details: '
                 subsequent_indent = ' ' * len(initial_indent)
-                
+
                 for i, line in enumerate(details.splitlines()):
                     if i == 0:
                         self.fout.write('%s%s\n' % (initial_indent, line))
@@ -75,6 +76,14 @@ class BESSCLI(cli.CLI):
                         self.fout.write('%s%s\n' % (subsequent_indent, line))
 
             raise self.HandledError()
+
+    def print_crashlog(self):
+        try:
+            log_path = tempfile.gettempdir() + '/bessd_crash.log'
+            log = open(log_path).read()
+            self.fout.write(log)
+        except:
+            pass
 
     def loop(self):
         try:
@@ -91,11 +100,7 @@ class BESSCLI(cli.CLI):
                     (e.errno, err_code, os.strerror(e.errno)))
 
             if self.bess.peer[0] == 'localhost':
-                try:
-                    log = open('/tmp/bess_crash.log').read()
-                    self.fout.write(log)
-                except:
-                    pass
+                self.print_crashlog()
 
             self.bess.disconnect()
 

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1,6 +1,5 @@
 #include "bessctl.h"
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <grpc++/server.h>
 #include <grpc++/server_builder.h>
@@ -12,6 +11,7 @@
 #include "message.h"
 #include "metadata.h"
 #include "module.h"
+#include "opts.h"
 #include "port.h"
 #include "service.grpc.pb.h"
 #include "tc.h"
@@ -31,10 +31,6 @@ using grpc::ServerContext;
 using grpc::ServerBuilder;
 
 using namespace bess::pb;
-
-DECLARE_int32(c);
-// Capture the port command line flag.
-DECLARE_int32(p);
 
 template <typename T>
 static inline Status return_with_error(T* response, int code, const char* fmt,

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -89,7 +89,7 @@ namespace bessd {
 
 void ProcessCommandLineArgs() {
   if (FLAGS_t) {
-    bess::debug::dump_types();
+    bess::debug::DumpTypes();
     exit(EXIT_SUCCESS);
   }
 

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -297,8 +297,9 @@ static void CloseStdStreams() {
 
   // For whatever reason if fd happens to be assigned 0, 1, or 2, do not close
   // it since it now points to our custom handler
-  if (fd > 2)
+  if (fd > 2) {
     close(fd);
+  }
 }
 
 int Daemonize() {

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -14,21 +14,24 @@ void ProcessCommandLineArgs();
 // Checks that we are running as superuser.
 void CheckRunningAsRoot();
 
-// Write the pid value to the given file fd.  Overwrites anything present at that fd.
-// Dies if unable to overwrite the file.
+// Write the pid value to the given file fd.  Overwrites anything present at
+// that fd.  Dies if unable to overwrite the file.
 void WritePidfile(int fd, pid_t pid);
 
-// Read the pid value from the given file fd.  Returns true and the read pid value upon success.  Returns false upon failure.
+// Read the pid value from the given file fd.  Returns true and the read pid
+// value upon success.  Returns false upon failure.
 std::tuple<bool, pid_t> ReadPidfile(int fd);
 
-// Tries to acquire the daemon pidfile lock for the file open at the given fd.  Dies if an
-// error occurs when trying to acquire the lock.  Returns a pair <lockheld, pid> where
-// lockheld is a bool indicating if the lock is held and pid is a pid_t that is non-zero
-// if lockheld is true indicating the process holding the lock.
+// Tries to acquire the daemon pidfile lock for the file open at the given fd.
+// Dies if an error occurs when trying to acquire the lock.  Returns a pair
+// <lockheld, pid> where lockheld is a bool indicating if the lock is held and
+// pid is a pid_t that is non-zero if lockheld is true indicating the process
+// holding the lock.
 std::tuple<bool, pid_t> TryAcquirePidfileLock(int fd);
 
 // Ensures that we are a unique instance.
-void CheckUniqueInstance(const std::string &pidfile_path);
+// Returns the (locked) file descriptor of pidfile_path.
+int CheckUniqueInstance(const std::string &pidfile_path);
 
 // Starts BESS as a daemon running in the background.
 int Daemonize();

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -31,7 +31,7 @@ std::tuple<bool, pid_t> TryAcquirePidfileLock(int fd);
 void CheckUniqueInstance(const std::string &pidfile_path);
 
 // Starts BESS as a daemon running in the background.
-int StartDaemon();
+int Daemonize();
 
 // Sets BESS's resource limit.  Returns true upon success.
 bool SetResourceLimit();

--- a/core/bessd_test.cc
+++ b/core/bessd_test.cc
@@ -253,7 +253,8 @@ TEST(CheckUniqueInstance, HeldKillCurrentHolder) {
     signal(SIGTERM, SIG_IGN);
 
     // Child process.
-    CheckUniqueInstance(kTestLockFilePath);
+    int pidfile_fd = CheckUniqueInstance(kTestLockFilePath);
+    WritePidfile(pidfile_fd, getpid());
   }, {
     ASSERT_NO_FATAL_FAILURE(CheckUniqueInstance(kTestLockFilePath));
     unlink(kTestLockFilePath);

--- a/core/bessd_test.cc
+++ b/core/bessd_test.cc
@@ -261,10 +261,10 @@ TEST(CheckUniqueInstance, HeldKillCurrentHolder) {
 }
 
 // Checks that we can do a basic call to start the daemon.
-TEST(StartDaemon, BasicRun) {
+TEST(Daemonize, BasicRun) {
   DO_MULTI_PROCESS_TEST({
     int signal_fd = -1;
-    ASSERT_NO_FATAL_FAILURE(signal_fd = StartDaemon(););
+    ASSERT_NO_FATAL_FAILURE(signal_fd = Daemonize(););
     ASSERT_NE(-1, signal_fd);
 
     uint64_t one = 1;

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -379,6 +379,8 @@ void SetTrapHandler() {
   struct sigaction sigact;
   size_t i;
 
+  unlink(P_tmpdir "/bessd_crash.log");
+
   sigact.sa_sigaction = TrapHandler;
   sigact.sa_flags = SA_RESTART | SA_SIGINFO;
 

--- a/core/debug.h
+++ b/core/debug.h
@@ -4,8 +4,9 @@
 namespace bess {
 namespace debug {
 
-void dump_types(void);
-void dump_stack(void);
+void SetTrapHandler(void);
+void GoPanic(void);
+void DumpTypes(void);
 
 }  // namespace debug
 }  // namespace bess

--- a/core/debug.h
+++ b/core/debug.h
@@ -1,8 +1,13 @@
 #ifndef BESS_DEBUG_H_
 #define BESS_DEBUG_H_
 
-/* #define RTE_LIBRTE_MBUF_DEBUG */
+namespace bess {
+namespace debug {
 
 void dump_types(void);
+void dump_stack(void);
+
+}  // namespace debug
+}  // namespace bess
 
 #endif  // BESS_DEBUG_H_

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -128,7 +128,8 @@ static void init_eal(char *prog_name, int mb_per_socket, int multi_instance) {
   disable_syslog();
   ret = rte_eal_init(rte_argc, const_cast<char **>(rte_argv));
   if (ret < 0) {
-    LOG(FATAL) << "rte_eal_init() failed: ret = " << ret;
+    LOG(ERROR) << "rte_eal_init() failed: ret = " << ret;
+    exit(EXIT_FAILURE);
   }
 
   enable_syslog();

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -87,7 +87,8 @@ static const struct rte_eth_conf default_eth_conf() {
 void PMDPort::InitDriver() {
   dpdk_port_t num_dpdk_ports = rte_eth_dev_count();
 
-  LOG(INFO) << num_dpdk_ports << " DPDK PMD ports have been recognized:";
+  LOG(INFO) << static_cast<int>(num_dpdk_ports)
+            << " DPDK PMD ports have been recognized:";
 
   for (dpdk_port_t i = 0; i < num_dpdk_ports; i++) {
     struct rte_eth_dev_info dev_info;
@@ -103,9 +104,9 @@ void PMDPort::InitDriver() {
           dev_info.pci_dev->id.vendor_id, dev_info.pci_dev->id.device_id);
     }
 
-    LOG(INFO) << "DPDK port_id " << i << " (" << dev_info.driver_name
-              << ")   RXQ " << dev_info.max_rx_queues << " TXQ "
-              << dev_info.max_tx_queues << "  " << pci_info;
+    LOG(INFO) << "DPDK port_id " << static_cast<int>(i) << " ("
+              << dev_info.driver_name << ")   RXQ " << dev_info.max_rx_queues
+              << " TXQ " << dev_info.max_tx_queues << "  " << pci_info;
   }
 }
 
@@ -459,7 +460,7 @@ void PMDPort::DeInit() {
     rte_eth_dev_close(dpdk_port_id_);
     ret = rte_eth_dev_detach(dpdk_port_id_, name);
     if (ret < 0) {
-      LOG(WARNING) << "rte_eth_dev_detach(" << dpdk_port_id_
+      LOG(WARNING) << "rte_eth_dev_detach(" << static_cast<int>(dpdk_port_id_)
                    << ") failed: " << rte_strerror(-ret);
     }
   }
@@ -479,7 +480,7 @@ void PMDPort::CollectStats(bool reset) {
 
   ret = rte_eth_stats_get(dpdk_port_id_, &stats);
   if (ret < 0) {
-    LOG(ERROR) << "rte_eth_stats_get(" << dpdk_port_id_
+    LOG(ERROR) << "rte_eth_stats_get(" << static_cast<int>(dpdk_port_id_)
                << ") failed: " << rte_strerror(-ret);
     return;
   }

--- a/core/main.cc
+++ b/core/main.cc
@@ -14,7 +14,8 @@ int main(int argc, char *argv[]) {
   FLAGS_logbuflevel = -1;
   FLAGS_colorlogtostderr = true;
   google::InitGoogleLogging(argv[0]);
-  google::InstallFailureFunction(bess::debug::dump_stack);
+  google::InstallFailureFunction(bess::debug::GoPanic);
+  bess::debug::SetTrapHandler();
 
   google::SetUsageMessage("BESS Command Line Options:");
   google::ParseCommandLineFlags(&argc, &argv, true);

--- a/core/main.cc
+++ b/core/main.cc
@@ -22,13 +22,19 @@ int main(int argc, char *argv[]) {
 
   bess::bessd::CheckRunningAsRoot();
 
+  int pidfile_fd = bess::bessd::CheckUniqueInstance(FLAGS_i);
+  ignore_result(bess::bessd::SetResourceLimit());
+
   int signal_fd = -1;
-  if (!FLAGS_f) {
+  if (FLAGS_f) {
+    LOG(INFO) << "Launching BESS daemon in process mode...";
+  } else {
+    LOG(INFO) << "Launching BESS daemon in background...";
     signal_fd = bess::bessd::Daemonize();
   }
 
-  bess::bessd::CheckUniqueInstance(FLAGS_i);
-  ignore_result(bess::bessd::SetResourceLimit());
+  // Store our PID (child's, if daemonized) in the PID file.
+  bess::bessd::WritePidfile(pidfile_fd, getpid());
 
   // TODO(barath): Make these DPDK calls generic, so as to not be so tied to
   // DPDK.

--- a/core/main.cc
+++ b/core/main.cc
@@ -4,6 +4,7 @@
 #include <glog/logging.h>
 
 #include "bessd.h"
+#include "debug.h"
 #include "dpdk.h"
 #include "master.h"
 #include "opts.h"
@@ -12,6 +13,7 @@
 
 int main(int argc, char *argv[]) {
   google::InitGoogleLogging(argv[0]);
+  google::InstallFailureFunction(bess::debug::dump_stack);
 
   google::SetUsageMessage("BESS Command Line Options:");
   google::ParseCommandLineFlags(&argc, &argv, true);

--- a/core/main.cc
+++ b/core/main.cc
@@ -11,6 +11,8 @@
 #include "snbuf.h"
 
 int main(int argc, char *argv[]) {
+  FLAGS_logbuflevel = -1;
+  FLAGS_colorlogtostderr = true;
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureFunction(bess::debug::dump_stack);
 

--- a/core/main.cc
+++ b/core/main.cc
@@ -23,10 +23,8 @@ int main(int argc, char *argv[]) {
   bess::bessd::CheckRunningAsRoot();
 
   int signal_fd = -1;
-  if (FLAGS_f) {
-    LOG(INFO) << "Launching BESS daemon in process mode...";
-  } else {
-    signal_fd = bess::bessd::StartDaemon();
+  if (!FLAGS_f) {
+    signal_fd = bess::bessd::Daemonize();
   }
 
   bess::bessd::CheckUniqueInstance(FLAGS_i);

--- a/core/main.cc
+++ b/core/main.cc
@@ -1,6 +1,5 @@
 #include <rte_launch.h>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "bessd.h"

--- a/core/master.cc
+++ b/core/master.cc
@@ -72,11 +72,13 @@ static int init_listen_fd(uint16_t port) {
   }
 
   if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) < 0) {
-    PLOG(FATAL) << "setsockopt(SO_REUSEADDR)";
+    PLOG(ERROR) << "setsockopt(SO_REUSEADDR)";
+    // error, but we can keep going
   }
 
   if (setsockopt(listen_fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l)) < 0) {
-    PLOG(FATAL) << "setsockopt(SO_LINGER)";
+    PLOG(ERROR) << "setsockopt(SO_LINGER)";
+    // error, but we can keep going
   }
 
   memset(&s_addr, 0, sizeof(s_addr));
@@ -87,7 +89,9 @@ static int init_listen_fd(uint16_t port) {
 
   if (bind(listen_fd, (struct sockaddr *)&s_addr, sizeof(s_addr)) < 0) {
     if (errno == EADDRINUSE) {
-      LOG(FATAL) << "Error: port " << port << " is already in use";
+      LOG(ERROR) << "Error: TCP port " << port << " is already in use. "
+                 << "You can specify another port number with -p option.";
+      exit(EXIT_FAILURE);
     } else {
       PLOG(FATAL) << "bind()";
     }

--- a/core/master.cc
+++ b/core/master.cc
@@ -102,7 +102,7 @@ static int init_listen_fd(uint16_t port) {
   }
 
   LOG(INFO) << "Master: listening on " << inet_ntoa(s_addr.sin_addr) << ":"
-            << std::hex << port;
+            << port;
 
   return listen_fd;
 }
@@ -138,7 +138,7 @@ static struct client *init_client(int fd, struct sockaddr_in c_addr) {
 
 static void close_client(struct client *c) {
   LOG(INFO) << "Master: client " << inet_ntoa(c->addr.sin_addr) << ":"
-            << std::hex << c->addr.sin_port << " disconnected";
+            << c->addr.sin_port << " disconnected";
 
   close(c->fd);
 
@@ -435,7 +435,7 @@ again:
       goto again;
 
     LOG(INFO) << "Master: a new client from " << inet_ntoa(c->addr.sin_addr)
-              << ":" << std::hex << c->addr.sin_port;
+              << ":" << c->addr.sin_port;
   } else {
     c = (struct client *)ev.data.ptr;
 

--- a/core/master.cc
+++ b/core/master.cc
@@ -13,20 +13,17 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <rte_config.h>
 #include <rte_lcore.h>
 
+#include "opts.h"
 #include "snctl.h"
 #include "snobj.h"
 #include "worker.h"
 
 #define INIT_BUF_SIZE 4096
 #define MAX_BUF_SIZE (8 * 1048576)
-
-// Capture the port command line flag.
-DECLARE_int32(p);
 
 static struct {
   int listen_fd;

--- a/core/snbuf.cc
+++ b/core/snbuf.cc
@@ -2,17 +2,14 @@
 
 #include <cassert>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <rte_errno.h>
 
-#include "utils/common.h"
 #include "dpdk.h"
+#include "opts.h"
+#include "utils/common.h"
 
 #define NUM_MEMPOOL_CACHE 512
-
-// Capture the "debug mode" command line flag.
-DECLARE_bool(d);
 
 struct rte_mbuf pframe_template;
 

--- a/core/snbuf.cc
+++ b/core/snbuf.cc
@@ -53,8 +53,8 @@ again:
       &pool_priv, snbuf_pkt_init, (void *)(uintptr_t)sid, sid, 0);
 
   if (!pframe_pool[sid]) {
-    LOG(WARN) << "Allocating " << current_try - 1 << " buffers on socket "
-              << sid << ": Failed (" << rte_strerror(rte_errno) << ")";
+    LOG(WARNING) << "Allocating " << current_try - 1 << " buffers on socket "
+                 << sid << ": Failed (" << rte_strerror(rte_errno) << ")";
     if (current_try > minimum_try) {
       current_try /= 2;
       goto again;

--- a/core/snbuf.cc
+++ b/core/snbuf.cc
@@ -53,7 +53,7 @@ again:
       &pool_priv, snbuf_pkt_init, (void *)(uintptr_t)sid, sid, 0);
 
   if (!pframe_pool[sid]) {
-    LOG(INFO) << "Allocating " << current_try - 1 << " buffers on socket "
+    LOG(WARN) << "Allocating " << current_try - 1 << " buffers on socket "
               << sid << ": Failed (" << rte_strerror(rte_errno) << ")";
     if (current_try > minimum_try) {
       current_try /= 2;

--- a/core/snbuf.h
+++ b/core/snbuf.h
@@ -6,7 +6,6 @@
 #include <rte_config.h>
 #include <rte_mbuf.h>
 
-#include "debug.h"
 #include "worker.h"
 #include "metadata.h"
 

--- a/core/snctl.cc
+++ b/core/snctl.cc
@@ -5,25 +5,18 @@
 #include <cstdlib>
 #include <cstring>
 
-#include <algorithm>
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "hooks/tcpdump.h"
 #include "hooks/track.h"
 #include "metadata.h"
 #include "module.h"
+#include "opts.h"
 #include "port.h"
 #include "tc.h"
 #include "utils/ether.h"
 #include "utils/time.h"
 #include "worker.h"
-
-// Capture the default core command line flag.
-DECLARE_int32(c);
-
-// Capture the "debug mode" command line flag.
-DECLARE_bool(d);
 
 struct handler_map {
   const char *cmd;

--- a/core/snobj.h
+++ b/core/snobj.h
@@ -9,7 +9,6 @@
 #include <cstring>
 #include <string>
 
-#include "debug.h"
 #include "mem_alloc.h"
 #include "utils/common.h"
 

--- a/core/task.cc
+++ b/core/task.cc
@@ -2,15 +2,12 @@
 
 #include <cassert>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "module.h"
+#include "opts.h"
 #include "tc.h"
 #include "worker.h"
-
-// Capture the default core command line flag.
-DECLARE_int32(c);
 
 struct cdlist_head all_tasks = CDLIST_HEAD_INIT(all_tasks);
 

--- a/core/tc.cc
+++ b/core/tc.cc
@@ -4,24 +4,21 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "debug.h"
 #include "mem_alloc.h"
-#include "worker.h"
+#include "opts.h"
 #include "task.h"
 #include "utils/common.h"
 #include "utils/time.h"
 #include "utils/random.h"
+#include "worker.h"
 
 // TODO(barath): move this global container of TCs to the TC class once it exists.
 namespace TCContainer {
 std::unordered_map<std::string, struct tc *> tcs;
 }  // TCContainer
-
-// Capture the "print TC stats" command line flag.
-DECLARE_bool(s);
 
 /* this library is not thread safe */
 

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -67,8 +67,11 @@ class BESS(object):
                     % (host, port))
 
     def disconnect(self):
-        if self.is_connected():
+        try:
             self.s.close()
+        except:
+            pass
+        finally:
             self.s = None
 
     def set_debug(self, flag):

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -46,7 +46,7 @@ class BESS(object):
             if e.errno not in [errno.EAGAIN, errno.EWOULDBLOCK]:
                 self.s.close()
                 self.s = None
-                return False
+                raise e
 
         return True
 


### PR DESCRIPTION
This PR includes the following minor changes:

- Use LOG(FATAL) only for totally unexpected errors.
  - e.g., If another BESS process is running, the error log message should be ERROR, not FATAL.
- Disable glog's default failure handler (stack backtrace), since it interferes with BESS's own fault handler, which prints out more detailed information
- Redirect all outputs to stdout/stderr/cout/cerr to Google glog.
  - If running in foreground mode, glog will print out log messages (depending on the -stderrthreshold option of glog)
- When log messages are printed to stderr (in foreground mode), colored output is enabled by default.
- Restore the "crash log" feature: bessctl shows the stack backtrace if it detects abnormal termination of the process.
- SIGUSR1 signal can be used to print out the current call stack of master/worker threads, without terminating the process.