### PR TITLE
Eliminate warnings generated from -Weffc++

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -43,15 +43,16 @@ else
     endif
 endif
 
-CXXFLAGS += -std=gnu++11 -g3 -ggdb3 -Ofast -march=native \
-	    -Werror -isystem $(DPDK_INC_DIR) -D_GNU_SOURCE
+PROTOCXXFLAGS = -std=gnu++11 -O0
 
-HARDCORE = -Wall -Wextra -Wcast-align
+CXXFLAGS += -std=gnu++11 -g3 -ggdb3 -Ofast -march=native \
+	    -Werror -isystem $(DPDK_INC_DIR) -D_GNU_SOURCE \
+	    -Wall -Wextra -Wcast-align
 
 # -Wshadow should not be used for g++ 4.x, as it has too many false positives
 CXXVERSION_5_OR_HIGHER := $(shell expr $(CXXVERSION) \>= 50000)
 ifeq "$(CXXVERSION_5_OR_HIGHER)" "1"
-  HARDCORE += -Wshadow
+  CXXFLAGS += -Wshadow
 endif
 
 LDFLAGS += -rdynamic -L$(DPDK_LIB_DIR) -Wl,-rpath=$(DPDK_LIB_DIR) -pthread \
@@ -159,13 +160,13 @@ $(eval $(call BUILD, \
 	CXX, \
 	%.pb.o, \
 	%.pb.cc $(DEPDIR)/$$@.d, \
-	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+	$$(CXX) -o $$@ -c $$< $$(PROTOCXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
 	CXX, \
 	%.o, \
 	%.cc $(PROTO_HEADERS) $(DEPDIR)/$$@.d, \
-	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(HARDCORE) $$(DEPFLAGS)))
+	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
 	LD, \
@@ -177,7 +178,7 @@ $(eval $(call BUILD, \
 	TEST_CXX, \
 	%_test.o, \
 	%_test.cc $(DEPDIR)/$$@.d, \
-	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(HARDCORE) $$(DEPFLAGS)))
+	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
 	TEST_LD, \
@@ -195,13 +196,13 @@ $(eval $(call BUILD, \
 	TEST_CXX, \
 	gtest-all.o, \
 	$$(GTEST_DIR)/src/gtest-all.cc, \
-	$$(CXX) -o $$@ -c $$< -I$$(GTEST_DIR) $$(CXXFLAGS) $$(HARDCORE) $$(DEPFLAGS)))
+	$$(CXX) -o $$@ -c $$< -I$$(GTEST_DIR) $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
 	BENCH_CXX, \
 	%_bench.o, \
 	%_bench.cc $(DEPDIR)/$$@.d, \
-	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(HARDCORE) $$(DEPFLAGS)))
+	$$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
 	BENCH_LD, \

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -443,7 +443,6 @@ class BESSControlImpl final : public BESSControl::Service {
       }
     }
 
-    memset(&params, 0, sizeof(params));
     params.name = tc_name;
 
     params.priority = request->class_().priority();
@@ -469,7 +468,7 @@ class BESSControlImpl final : public BESSControl::Service {
       params.max_burst[3] = request->class_().max_burst().bits();
     }
 
-    c = tc_init(workers[wid]->s(), &params);
+    c = tc_init(workers[wid]->s(), &params, nullptr);
     if (is_err(c))
       return return_with_error(response, -ptr_to_err(c), "tc_init() failed");
 

--- a/core/gate.h
+++ b/core/gate.h
@@ -32,9 +32,9 @@ class Gate;
 class GateHook {
  public:
   GateHook(const std::string &name, uint16_t priority = 0, Gate *gate = nullptr)
-      : gate_(gate), name_(name), priority_(priority){}
+      : gate_(gate), name_(name), priority_(priority) {}
 
-  virtual ~GateHook(){}
+  virtual ~GateHook() {}
 
   const std::string &name() const { return name_; }
 
@@ -62,9 +62,9 @@ inline bool GateHookComp(const GateHook *lhs, const GateHook *rhs) {
 class Gate {
  public:
   Gate(Module *m, gate_idx_t idx, void *arg)
-      : module_(m), gate_idx_(idx), arg_(arg){}
+      : module_(m), gate_idx_(idx), arg_(arg), hooks_() {}
 
-  virtual ~Gate(){}
+  virtual ~Gate() {}
 
   Module *module() const { return module_; }
 
@@ -104,7 +104,7 @@ class IGate;
 class OGate : public Gate {
  public:
   OGate(Module *m, gate_idx_t idx, void *arg)
-      : Gate(m, idx, arg), igate_(), igate_idx_(){}
+      : Gate(m, idx, arg), igate_(), igate_idx_() {}
 
   void set_igate(IGate *ig) { igate_ = ig; }
   IGate *igate() const { return igate_; }
@@ -115,11 +115,14 @@ class OGate : public Gate {
  private:
   IGate *igate_;
   gate_idx_t igate_idx_; /* cache for igate->gate_idx */
+
+  DISALLOW_COPY_AND_ASSIGN(OGate);
 };
 
 class IGate : public Gate {
  public:
-  IGate(Module *m, gate_idx_t idx, void *arg) : Gate(m, idx, arg){}
+  IGate(Module *m, gate_idx_t idx, void *arg)
+      : Gate(m, idx, arg), ogates_upstream_() {}
 
   const std::vector<OGate *> &ogates_upstream() const {
     return ogates_upstream_;
@@ -132,6 +135,7 @@ class IGate : public Gate {
  private:
   std::vector<OGate *> ogates_upstream_;
 };
-}
+
+}  // namespace bess
 
 #endif  // BESS_GATE_H_

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -60,7 +60,7 @@ static inline attr_id_t get_attr_id(const struct Attribute *attr) {
 
 class ScopeComponentComp {
  public:
-  ScopeComponentComp(const bool &revparam = false) { reverse_ = revparam; }
+  ScopeComponentComp(const bool &revparam = false) : reverse_(revparam) {}
 
   bool operator()(const ScopeComponent *lhs, const ScopeComponent *rhs) const {
     if (reverse_) {
@@ -364,7 +364,7 @@ void Pipeline::AssignOffsets() {
   FillOffsetArrays();
 }
 
-void Pipeline::LogAllScopes() {
+void Pipeline::LogAllScopes() const {
   for (size_t i = 0; i < scope_components_.size(); i++) {
     VLOG(1) << "scope component for " << scope_components_[i].size()
             << "-byte attr " << scope_components_[i].attr_id() << "at offset "
@@ -383,11 +383,13 @@ void Pipeline::LogAllScopes() {
       break;
     }
 
+    const scope_id_t *scope_arr = module_components_.find(m)->second;
+
     LOG(INFO) << "Module " << m->name()
               << " part of the following scope components: ";
     for (size_t i = 0; i < kMetadataTotalSize; i++) {
-      if (module_components_[m][i] != -1) {
-        LOG(INFO) << "scope " << module_components_[m][i] << " at offset " << i;
+      if (scope_arr[i] != -1) {
+        LOG(INFO) << "scope " << scope_arr[i] << " at offset " << i;
       }
     }
   }

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -48,6 +48,8 @@ static inline int IsValidOffset(mt_offset_t offset) {
 }
 
 struct Attribute {
+  Attribute() : name(), size(), mode(), scope_id() {}
+
   std::string name;
   size_t size;  // in bytes
   enum class AccessMode {
@@ -117,7 +119,11 @@ class ScopeComponent {
 
 class Pipeline {
  public:
-  Pipeline() : scope_components_(), module_scopes_(){};
+  Pipeline()
+      : scope_components_(),
+        module_scopes_(),
+        module_components_(),
+        attributes_() {}
 
   // Main entry point for calculating metadata offsets.
   int ComputeMetadataOffsets();
@@ -137,13 +143,14 @@ class Pipeline {
   void CleanupMetadataComputation();
 
   // Debugging tool.
-  void LogAllScopes();
+  void LogAllScopes() const;
 
   // Add a module to the current scope component.
   void AddModuleToComponent(Module *m, const struct Attribute *attr);
 
   // Returns a pointer to an attribute if it's contained within a module.
-  const struct Attribute *FindAttr(Module *m, const struct Attribute *attr) const;
+  const struct Attribute *FindAttr(Module *m,
+                                   const struct Attribute *attr) const;
 
   // Traverses module graph upstream to help identify a scope component.
   void TraverseUpstream(Module *m, const struct Attribute *attr);

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -39,6 +39,8 @@ namespace metadata {
 
 class MetadataTest : public ::testing::Test {
  protected:
+  MetadataTest() : m0(), m1() {}
+
   virtual void SetUp() {
     default_pipeline.CleanupMetadataComputation();
     default_pipeline.attributes_.clear();
@@ -57,21 +59,23 @@ class MetadataTest : public ::testing::Test {
 
   Module *m0;
   Module *m1;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(MetadataTest);
 };
 
 TEST(Metadata, RegisterSizeMismatchFails) {
-  struct Attribute attr0_s1 = {
-      .name = "attr0",
-      .size = 1,
-      .mode = Attribute::AccessMode::kRead,
-      .scope_id = -1,
-  };
-  struct Attribute attr0_s2 = {
-      .name = "attr0",
-      .size = 2,
-      .mode = Attribute::AccessMode::kWrite,
-      .scope_id = -1,
-  };
+  struct Attribute attr0_s1;
+  attr0_s1.name = "attr0";
+  attr0_s1.size = 1;
+  attr0_s1.mode = Attribute::AccessMode::kRead;
+  attr0_s1.scope_id = -1;
+
+  struct Attribute attr0_s2;
+  attr0_s2.name = "attr0";
+  attr0_s2.size = 2;
+  attr0_s2.mode = Attribute::AccessMode::kWrite;
+  attr0_s2.scope_id = -1;
 
   ASSERT_EQ(0, default_pipeline.RegisterAttribute(&attr0_s1));
   ASSERT_EQ(-EEXIST, default_pipeline.RegisterAttribute(&attr0_s2));

--- a/core/module.cc
+++ b/core/module.cc
@@ -233,7 +233,7 @@ int Module::AddMetadataAttr(const std::string &name, size_t size,
                             bess::metadata::Attribute::AccessMode mode) {
   int ret;
 
-  if (attrs.size() >= bess::metadata::kMaxAttrsPerModule)
+  if (attrs_.size() >= bess::metadata::kMaxAttrsPerModule)
     return -ENOSPC;
 
   if (name.empty())
@@ -252,9 +252,9 @@ int Module::AddMetadataAttr(const std::string &name, size_t size,
     return ret;
   }
 
-  attrs.push_back(attr);
+  attrs_.push_back(attr);
 
-  return attrs.size() - 1;
+  return attrs_.size() - 1;
 }
 
 /* returns -errno if fails */

--- a/core/module.h
+++ b/core/module.h
@@ -87,15 +87,14 @@ class ModuleBuilder {
       std::function<pb_error_t(Module *, const google::protobuf::Any &)>
           init_func)
       : module_generator_(module_generator),
+        kNumIGates(igates),
+        kNumOGates(ogates),
         class_name_(class_name),
         name_template_(name_template),
         help_text_(help_text),
         cmds_(cmds),
         pb_cmds_(pb_cmds),
-        init_func_(init_func) {
-    kNumIGates = igates;
-    kNumOGates = ogates;
-  }
+        init_func_(init_func) {}
 
   /* returns a pointer to the created module.
    * if error, returns nullptr and *perr is set */
@@ -194,8 +193,16 @@ class ModuleBuilder {
 class Module {
   // overide this section to create a new module -----------------------------
  public:
-  Module() = default;
-  virtual ~Module(){};
+  Module()
+      : name_(),
+        module_builder_(),
+        pipeline_(),
+        attrs_(),
+        tasks(),
+        attr_offsets(),
+        igates(),
+        ogates() {}
+  virtual ~Module() {}
 
   pb_error_t Init(const google::protobuf::Any &arg);
 
@@ -270,7 +277,7 @@ class Module {
   }
 
   const std::vector<bess::metadata::Attribute> &all_attrs() const {
-    return attrs;
+    return attrs_;
   }
 
  private:
@@ -288,16 +295,15 @@ class Module {
 
   bess::metadata::Pipeline *pipeline_;
 
-  std::vector<bess::metadata::Attribute> attrs;
+  std::vector<bess::metadata::Attribute> attrs_;
 
   DISALLOW_COPY_AND_ASSIGN(Module);
 
   // FIXME: porting in progress ----------------------------
  public:
-  struct task *tasks[MAX_TASKS_PER_MODULE] = {};
+  struct task *tasks[MAX_TASKS_PER_MODULE];
 
-  bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule] =
-      {};
+  bess::metadata::mt_offset_t attr_offsets[bess::metadata::kMaxAttrsPerModule];
 
   std::vector<bess::IGate *> igates;
   std::vector<bess::OGate *> ogates;

--- a/core/port.h
+++ b/core/port.h
@@ -159,13 +159,15 @@ class Port {
   // overide this section to create a new driver -----------------------------
  public:
   Port()
-      : port_builder_(),
+      : name_(),
+        port_builder_(),
         num_queues(),
         queue_size(),
         users(),
         queue_stats(),
         port_stats() {}
-  virtual ~Port(){};
+
+  virtual ~Port() {}
 
   pb_error_t Init(const google::protobuf::Any &arg);
 

--- a/core/snctl.cc
+++ b/core/snctl.cc
@@ -258,7 +258,6 @@ static struct snobj *handle_add_tc(struct snobj *q) {
       return snobj_err(EINVAL, "worker:%d does not exist", wid);
   }
 
-  memset(&params, 0, sizeof(params));
   params.name = tc_name;
 
   params.priority = snobj_eval_int(q, "priority");
@@ -301,7 +300,7 @@ static struct snobj *handle_add_tc(struct snobj *q) {
     }
   }
 
-  c = tc_init(workers[wid]->s(), &params);
+  c = tc_init(workers[wid]->s(), &params, nullptr);
   if (is_err(c))
     return snobj_err(-ptr_to_err(c), "tc_init() failed");
 

--- a/core/task.cc
+++ b/core/task.cc
@@ -98,13 +98,12 @@ void task_detach(struct task *t) {
   }
 }
 
-#include <iostream>
 void assign_default_tc(int wid, struct task *t) {
   static int next_default_tc_id;
 
   struct tc *c_def;
 
-  struct tc_params params = tc_params();
+  struct tc_params params;
 
   if (t->m->NumTasks() == 1) {
     params.name = "_tc_" + t->m->name();
@@ -112,19 +111,18 @@ void assign_default_tc(int wid, struct task *t) {
     params.name = "_tc_" + t->m->name() + std::to_string(task_to_tid(t));
   }
 
-  params.parent = nullptr;
   params.auto_free = 1; /* when no task is left, this TC is freed */
   params.priority = DEFAULT_PRIORITY;
   params.share = 1;
   params.share_resource = RESOURCE_CNT;
 
-  c_def = tc_init(workers[wid]->s(), &params);
+  c_def = tc_init(workers[wid]->s(), &params, nullptr);
 
   /* maybe the default name is too long, or already occupied */
   if (is_err_or_null(c_def)) {
     do {
       params.name = "_tc_noname" + std::to_string(next_default_tc_id++);
-      c_def = tc_init(workers[wid]->s(), &params);
+      c_def = tc_init(workers[wid]->s(), &params, nullptr);
     } while (ptr_to_err(c_def) == -EEXIST);
   }
 

--- a/core/tc.cc
+++ b/core/tc.cc
@@ -65,7 +65,8 @@ pgroup_add:
 }
 
 /* TODO: separate tc creation and association with scheduler */
-struct tc *tc_init(struct sched *s, const struct tc_params *params) {
+struct tc *tc_init(struct sched *s, const struct tc_params *params,
+                   struct tc *parent) {
   struct tc *c;
 
   int i;
@@ -96,7 +97,7 @@ struct tc *tc_init(struct sched *s, const struct tc_params *params) {
   c->s = s;
   s->num_classes++;
 
-  c->parent = params->parent ?: &s->root;
+  c->parent = parent ?: &s->root;
   tc_inc_refcnt(c->parent);
 
   c->last_tsc = rdtsc();

--- a/core/tc.h
+++ b/core/tc.h
@@ -46,9 +46,16 @@ struct pgroup {
 };
 
 struct tc_params {
-  std::string name;
+  tc_params()
+      : name(),
+        auto_free(),
+        priority(),
+        share(),
+        share_resource(RESOURCE_CNT),
+        limit(),
+        max_burst() {}
 
-  struct tc *parent;
+  std::string name;
 
   /* Used for auto-generated TCs.
    * (if its last task is detached, free the tc as well) */
@@ -174,7 +181,8 @@ struct sched {
   struct cdlist_head tcs_all;
 };
 
-struct tc *tc_init(struct sched *s, const struct tc_params *prof);
+struct tc *tc_init(struct sched *s, const struct tc_params *prof,
+                   struct tc *parent);
 void _tc_do_free(struct tc *c);
 
 void tc_join(struct tc *c);

--- a/core/tc_bench.cc
+++ b/core/tc_bench.cc
@@ -20,15 +20,14 @@ class TCFixture : public benchmark::Fixture {
     s_ = sched_init();
 
     for (int i = 0; i < num_classes; i++) {
-      struct tc_params params = tc_params();
+      struct tc_params params;
 
       params.name = "class_" + std::to_string(i);
-      params.parent = nullptr;
       params.priority = 0;
       params.share = 1;
       params.share_resource = state.range(1);
 
-      struct tc *c = tc_init(s_, &params);
+      struct tc *c = tc_init(s_, &params, nullptr);
       CHECK(!c->state.queued) << "c->state.queued=" << c->state.queued;
       CHECK(!c->state.runnable) << "c->state.runnable=" << c->state.runnable;
 

--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -147,9 +147,8 @@ class unique_fd {
   // Constructs a unique fd that owns the given fd.
   unique_fd(int fd) : fd_(fd) {}
 
-  // Move constructor 
-  unique_fd(unique_fd &&other) {
-    fd_ = other.fd_;
+  // Move constructor
+  unique_fd(unique_fd &&other) : fd_(other.fd_) {
     other.fd_ = -1;
   }
 

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -41,7 +41,7 @@ class EndianBase<uint64_t> {
 };
 
 template <typename T>
-class [[gnu::packed]] BigEndian : public EndianBase<T> {
+class [[gnu::packed]] BigEndian final : public EndianBase<T> {
  public:
   BigEndian() = default;
   BigEndian(const T &value) : value_(value) {}
@@ -62,6 +62,8 @@ using be16_t = BigEndian<uint16_t>;
 using be32_t = BigEndian<uint32_t>;
 using be64_t = BigEndian<uint64_t>;
 
+// POD means trivial (no special constructor/destructor) and
+// standard layout (i.e., binary compatible with C struct)
 static_assert(std::is_pod<be16_t>::value, "not a POD type");
 static_assert(std::is_pod<be32_t>::value, "not a POD type");
 static_assert(std::is_pod<be64_t>::value, "not a POD type");

--- a/core/utils/htable.cc
+++ b/core/utils/htable.cc
@@ -385,7 +385,7 @@ int HTableBase::clone_table(HTableBase *t_old, uint32_t num_buckets,
 
 /* may be called recursively */
 int HTableBase::expand_buckets() {
-  HTableBase *t = new HTableBase;
+  HTableBase *t = new HTableBase();
   uint32_t num_buckets = (bucket_mask_ + 1) * 2;
 
   assert(num_buckets == align_ceil_pow2(num_buckets));

--- a/core/utils/pcap_handle.cc
+++ b/core/utils/pcap_handle.cc
@@ -2,15 +2,14 @@
 
 #include "pcap.h"
 
-PcapHandle::PcapHandle(const std::string& dev) {
+PcapHandle::PcapHandle(const std::string& dev) : handle_() {
   char errbuf[PCAP_ERRBUF_SIZE];
   handle_ = pcap_open_live(dev.c_str(), PCAP_SNAPLEN, 1, -1, errbuf);
 }
 
 PcapHandle::PcapHandle(pcap_t *handle) : handle_(handle) {}
 
-PcapHandle::PcapHandle(PcapHandle&& other) {
-  handle_ = other.handle_;
+PcapHandle::PcapHandle(PcapHandle&& other) : handle_(other.handle_) {
   other.handle_ = nullptr;
 }
 

--- a/core/utils/random.h
+++ b/core/utils/random.h
@@ -7,8 +7,8 @@
 
 class Random {
  public:
-  Random() { SetSeed(rdtsc()); }
-  Random(uint64_t seed) { SetSeed(seed); }
+  Random() : seed_(rdtsc()) {}
+  Random(uint64_t seed) : seed_(seed) {}
 
   void SetSeed(uint64_t seed) { this->seed_ = seed; };
 

--- a/core/worker.h
+++ b/core/worker.h
@@ -46,7 +46,8 @@ struct gate_task {
 class Worker {
  public:
   Worker()
-      : wid_(),
+      : status_(),
+        wid_(),
         core_(),
         socket_(),
         fd_event_(),
@@ -57,9 +58,10 @@ class Worker {
         current_ns_(),
         igate_stack_(),
         stack_depth_(),
+        pending_gates_(),
         splits_() {}
 
-  ~Worker() {}
+  virtual ~Worker() {}
 
   /* ----------------------------------------------------------------------
    * functions below are invoked by non-worker threads (the master)
@@ -149,8 +151,6 @@ class Worker {
   }
 
  private:
-  DISALLOW_COPY_AND_ASSIGN(Worker);
-
   volatile worker_status_t status_;
 
   int wid_;  /* always [0, MAX_WORKERS - 1] */
@@ -178,6 +178,8 @@ class Worker {
 
   /* better be the last field. it's huge */
   struct pkt_batch splits_[MAX_GATES + 1];
+
+  DISALLOW_COPY_AND_ASSIGN(Worker);
 };
 
 extern int num_workers;


### PR DESCRIPTION
... since we all love Scott Meyers and his book.

But I did not end up adding -Weffc++ to Makefile, since it generates too pedantic warnings for modules/drivers (e.g., "define copy/assignment constructors whenever there are pointer members"). Also the semantics of -Weffc++ seems to be subtly different on various g++ versions.