### PR TITLE
Fix dangling pointer bug of Pipeline::attrs_

### DIFF
--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -466,6 +466,8 @@ int Pipeline::RegisterAttribute(const std::string &attr_name, size_t size) {
     count++;
     return 0;
   } else {
+    LOG(ERROR) << "Attribute '" << attr_name << "' has size mismatch: registered("
+               << registered_size << ") vs new(" << size << ")";
     return -EINVAL;
   }
 }
@@ -473,8 +475,8 @@ int Pipeline::RegisterAttribute(const std::string &attr_name, size_t size) {
 void Pipeline::DeregisterAttribute(const std::string &attr_name) {
   const auto &it = registered_attrs_.find(attr_name);
   if (it == registered_attrs_.end()) {
-    LOG(ERROR) << "ReregisteredAttribute() called, but " << attr_name
-             << " was not registered";
+    LOG(ERROR) << "ReregisteredAttribute() called, but '" << attr_name
+             << "' was not registered";
     return;
   }
 

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -452,16 +452,41 @@ int Pipeline::ComputeMetadataOffsets() {
   return 0;
 }
 
-// TODO: We need to keep track of the number of modules that registered each
-// attribute. Then RegisterAttribute does +1 while Deregister one does -1
-int Pipeline::RegisterAttribute(const struct Attribute *attr) {
-  attr_id_t id = get_attr_id(attr);
-  const auto &it = attributes_.find(id);
-  if (it == attributes_.end()) {
-    attributes_.emplace(id, attr);
+int Pipeline::RegisterAttribute(const std::string &attr_name, size_t size) {
+  const auto &it = registered_attrs_.find(attr_name);
+  if (it == registered_attrs_.end()) {
+    registered_attrs_.emplace(attr_name, std::make_tuple(size, 1));
     return 0;
   }
-  return (it->second->size == attr->size) ? 0 : -EEXIST;
+
+  size_t registered_size = std::get<0>(it->second);
+  int &count = std::get<1>(it->second);
+
+  if (registered_size == size) {
+    count++;
+    return 0;
+  } else {
+    return -EINVAL;
+  }
+}
+
+void Pipeline::DeregisterAttribute(const std::string &attr_name) {
+  const auto &it = registered_attrs_.find(attr_name);
+  if (it == registered_attrs_.end()) {
+    LOG(ERROR) << "ReregisteredAttribute() called, but " << attr_name
+             << " was not registered";
+    return;
+  }
+
+  int &count = std::get<1>(it->second);
+
+  count--;
+  assert(count >= 0);
+
+  if (count == 0) {
+    // No more modules are using the attribute. Remove it from the map.
+    registered_attrs_.erase(it);
+  }
 }
 
 }  // namespace metadata

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -123,15 +123,16 @@ class Pipeline {
       : scope_components_(),
         module_scopes_(),
         module_components_(),
-        attributes_() {}
+        registered_attrs_() {}
 
   // Main entry point for calculating metadata offsets.
   int ComputeMetadataOffsets();
 
-  // Registers attr and returns 0 if no attribute named attr->name with size
-  // other than attr->size has already been registered for this pipeline.
-  // Returns -errno on error.
-  int RegisterAttribute(const struct Attribute *attr);
+  // Registers attr and returns 0 if no attribute named @attr_name with size
+  // other than @size has already been registered for this pipeline.
+  // Returns -EINVAL on error.
+  int RegisterAttribute(const std::string &attr_name, size_t size);
+  void DeregisterAttribute(const std::string &attr_name);
 
  private:
   friend class MetadataTest;
@@ -179,7 +180,11 @@ class Pipeline {
   std::map<const Module *, scope_id_t *> module_components_;
 
   // Keeps track of the attributes used by modules in this pipeline
-  std::map<attr_id_t, const struct Attribute *> attributes_;
+  // count(=int) represents how many modules registered the attribute, and the
+  // attribute is deregistered once it reaches back to 0.
+  // Those modules should agree on the same size(=size_t).
+  std::map<std::string, std::tuple<size_t, int> >
+      registered_attrs_;
 };
 
 extern bess::metadata::Pipeline default_pipeline;

--- a/core/module.h
+++ b/core/module.h
@@ -251,7 +251,6 @@ class Module {
 
   int NumTasks();
   task_id_t RegisterTask(void *arg);
-  void DestroyAllTasks();
 
   /* Modules should call this function to declare additional metadata
    * attributes at initialization time.
@@ -281,6 +280,9 @@ class Module {
   }
 
  private:
+  void DestroyAllTasks();
+  void DeregisterAllAttributes();
+
   void set_name(const std::string &name) { name_ = name; }
   void set_module_builder(const ModuleBuilder *builder) {
     module_builder_ = builder;


### PR DESCRIPTION
- attrs_ used to maintain a map of string->Attribute*, where the
  attribute pointer is provided by the caller of RegisterAttribute().
  - However the caller may call the function with a stack-allocated
    Attribute instance, then the pointer would be immediately invalid.
  - This issue caused process crash with sample/exactmatch.bess,
    due to memory corruption
  - This issue caused AddMetadataAttr failure with
    samples/wildcardmatch.bess, due to a garbase value of the size of
    already registered attribute with the same name.
- Now Pipeline keeps track or how many modules are actually using
  each attribute.
  - If no modules are using an attribute any longer, we allow modules
    to register the attribute with the same name, possibly with
    a different size.
  - To implement this, deregister logic was implemented, which is
    triggered when a module is destroyed.