### PR TITLE
Fix bug when gates are appended out of order

### DIFF
--- a/core/module.cc
+++ b/core/module.cc
@@ -278,7 +278,7 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
   }
 
   if (ogate_idx >= ogates.size()) {
-    ogates.emplace_back();
+    ogates.resize(ogate_idx + 1, nullptr);
   }
 
   ogate = new bess::OGate(this, ogate_idx, m_next);
@@ -288,7 +288,7 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
   ogates[ogate_idx] = ogate;
 
   if (igate_idx >= m_next->igates.size()) {
-    m_next->igates.emplace_back();
+    m_next->igates.resize(igate_idx + 1, nullptr);
   }
 
   igate = new bess::IGate(m_next, igate_idx, m_next);


### PR DESCRIPTION
In the current code, for example, if output gates are added with indices 0, 1, 2, and 5, then the size of ogates will be 4 (not 6), and ogates[5] (which is not a valid memory area of ogates) will be written.

You can test the issue with samples/exactmatch.bess and samples/wildcardmatch.bess