### PR TITLE
Add module benchmark

### DIFF
--- a/core/module.h
+++ b/core/module.h
@@ -351,7 +351,7 @@ void _trace_after_call(void);
 #endif
 
 static inline gate_idx_t get_igate() {
-  return ctx.igate_stack_top();
+  return ctx.current_igate();
 }
 
 template <typename T>

--- a/core/module_bench.cc
+++ b/core/module_bench.cc
@@ -1,0 +1,113 @@
+#include "module.h"
+
+#include <benchmark/benchmark.h>
+#include <glog/logging.h>
+
+namespace {
+
+class DummySourceModule : public Module {
+ public:
+   virtual struct task_result RunTask(void *arg) override;
+};
+
+[[gnu::noinline]] struct task_result DummySourceModule::RunTask(void *arg) {
+  const size_t batch_size = reinterpret_cast<size_t>(arg);
+  struct pkt_batch batch;
+
+  struct snbuf pkts[MAX_PKT_BURST];
+
+  batch_clear(&batch);
+  for (size_t i = 0; i < batch_size; i++) {
+    struct snbuf *pkt = &pkts[i];
+
+    // this fake packet must not be freed
+    rte_mbuf_refcnt_set(&pkt->mbuf, 2);  
+
+    // not chained
+    pkt->mbuf.next = nullptr;
+
+    batch_add(&batch, pkt);
+  }
+
+  RunNextModule(&batch);
+
+  return {.packets = static_cast<uint64_t>(batch_size), .bits = 0};
+}
+
+class DummyRelayModule : public Module {
+ public:
+   virtual void ProcessBatch(struct pkt_batch *batch) override;
+};
+
+[[gnu::noinline]] void DummyRelayModule::ProcessBatch(struct pkt_batch *batch) {
+  RunNextModule(batch);
+}
+
+// Simple harness for testing the Module class.
+class ModuleFixture : public benchmark::Fixture {
+ protected:
+  virtual void SetUp(benchmark::State &state) override {
+    const int chain_length = state.range(0);
+
+    ADD_MODULE(DummySourceModule, "src", "the most sophisticated modue ever");
+    ADD_MODULE(DummyRelayModule, "relay", "the most sophisticated modue ever");
+    assert(__module__DummySourceModule);
+    assert(__module__DummyRelayModule);
+
+    const auto &builders = ModuleBuilder::all_module_builders();
+    const auto &builder_src = builders.find("DummySourceModule")->second;
+    const auto &builder_relay = builders.find("DummyRelayModule")->second;
+    Module *last;
+
+    src_ = builder_src.CreateModule("src0", &bess::metadata::default_pipeline);
+    last = src_;
+
+    for (int i = 0; i < chain_length; i++) {
+      Module *relay = builder_relay.CreateModule("relay" + std::to_string(i),
+          &bess::metadata::default_pipeline);
+      relays.push_back(relay);
+      int ret = last->ConnectModules(0, relay, 0);
+      assert(ret == 0);
+      last = relay;
+    }
+  }
+
+  virtual void TearDown(benchmark::State &) override {
+    ModuleBuilder::DestroyAllModules();
+    ModuleBuilder::all_module_builders_holder(true);
+  }
+
+   Module *src_;
+   std::vector<Module *> relays;
+};
+
+}  // namespace (unnamed)
+
+BENCHMARK_DEFINE_F(ModuleFixture, Chain)(benchmark::State &state) {
+  const size_t batch_size = MAX_PKT_BURST;
+
+  struct task t;
+  t.m = src_;
+  t.arg = reinterpret_cast<void *>(batch_size);
+
+  while (state.KeepRunning()) {
+    struct task_result ret = task_scheduled(&t);
+    assert(ret.packets == batch_size);
+  }
+
+  state.SetItemsProcessed(state.iterations() * batch_size);
+}
+
+BENCHMARK_REGISTER_F(ModuleFixture, Chain)
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(4)
+    ->Arg(5)
+    ->Arg(6)
+    ->Arg(7)
+    ->Arg(8)
+    ->Arg(9)
+    ->Arg(10);
+
+BENCHMARK_MAIN()

--- a/core/task.cc
+++ b/core/task.cc
@@ -20,8 +20,6 @@ struct task_result task_scheduled(struct task *t) {
     bess::OGate *ogate = reinterpret_cast<bess::OGate *>(task.gate);
     struct pkt_batch *next_packets = &(task.batch);
 
-    ctx.push_igate(ogate->igate_idx());
-
     for (auto &hook : ogate->hooks()) {
       hook->ProcessBatch(next_packets);
     }
@@ -30,9 +28,8 @@ struct task_result task_scheduled(struct task *t) {
       hook->ProcessBatch(next_packets);
     }
 
+    ctx.set_current_igate(ogate->igate_idx());
     ((Module *)ogate->arg())->ProcessBatch(next_packets);
-
-    ctx.pop_igate();
   }
 
   return ret;

--- a/core/tc_bench.cc
+++ b/core/tc_bench.cc
@@ -7,8 +7,6 @@
 #include <benchmark/benchmark.h>
 #include <glog/logging.h>
 
-#include "utils/time.h"
-
 // Performs TC Scheduler init/deinit before/after each test.
 class TCFixture : public benchmark::Fixture {
  public:

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -20,7 +20,9 @@
 int num_workers = 0;
 std::thread worker_threads[MAX_WORKERS];
 Worker *volatile workers[MAX_WORKERS];
-thread_local Worker ctx;
+
+// See worker.h
+__thread Worker ctx;
 
 struct thread_arg {
   int wid;

--- a/core/worker.h
+++ b/core/worker.h
@@ -45,24 +45,6 @@ struct gate_task {
 
 class Worker {
  public:
-  Worker()
-      : status_(),
-        wid_(),
-        core_(),
-        socket_(),
-        fd_event_(),
-        pframe_pool_(),
-        s_(),
-        silent_drops_(),
-        current_tsc_(),
-        current_ns_(),
-        igate_stack_(),
-        stack_depth_(),
-        pending_gates_(),
-        splits_() {}
-
-  virtual ~Worker() {}
-
   /* ----------------------------------------------------------------------
    * functions below are invoked by non-worker threads (the master)
    * ---------------------------------------------------------------------- */
@@ -96,35 +78,21 @@ class Worker {
   }
 
   uint64_t silent_drops() { return silent_drops_; }
-  inline void set_silent_drops(uint64_t drops) { silent_drops_ = drops; }
-  inline void incr_silent_drops(uint64_t drops) { silent_drops_ += drops; }
+  void set_silent_drops(uint64_t drops) { silent_drops_ = drops; }
+  void incr_silent_drops(uint64_t drops) { silent_drops_ += drops; }
 
-  uint64_t current_tsc() { return current_tsc_; }
-  inline void set_current_tsc(uint64_t tsc) { current_tsc_ = tsc; }
+  uint64_t current_tsc() const { return current_tsc_; }
+  void set_current_tsc(uint64_t tsc) { current_tsc_ = tsc; }
 
-  uint64_t current_ns() { return current_ns_; }
-  inline void set_current_ns(uint64_t ns) { current_ns_ = ns; }
+  uint64_t current_ns() const { return current_ns_; }
+  void set_current_ns(uint64_t ns) { current_ns_ = ns; }
 
-  /* The current input gate index is not given as a function parameter.
-   * Modules should use get_igate() for access */
-  gate_idx_t *igate_stack() { return igate_stack_; }
-  int stack_depth() { return stack_depth_; }
-
-  inline gate_idx_t igate_stack_top() { return igate_stack_[stack_depth_ - 1]; }
-
-  inline void push_igate(gate_idx_t gate) {
-    igate_stack_[stack_depth_] = gate;
-    stack_depth_++;
-  }
-
-  inline gate_idx_t pop_igate() {
-    stack_depth_--;
-    return igate_stack_[stack_depth_];
-  }
+  gate_idx_t current_igate() const { return current_igate_; }
+  void set_current_igate(gate_idx_t idx) { current_igate_ = idx; }
 
   // Store gate+packets into tasks for worker to service.
   // Returns true on success.
-  inline bool push_ogate_and_packets(bess::Gate *gate, pkt_batch *batch) {
+  bool push_ogate_and_packets(bess::Gate *gate, pkt_batch *batch) {
     if (pending_gates_ > MAX_MODULES_PER_PATH * BRANCH_FACTOR) {
       LOG(ERROR) << "Gate servicing stack overrun -- loop in execution?";
       return false;
@@ -138,12 +106,12 @@ class Worker {
 
   // Retrieve next gate that this worker should serve packets to.
   // Do not call without checking gates_pending() first.
-  inline struct gate_task pop_ogate_and_packets() {
+  struct gate_task pop_ogate_and_packets() {
     pending_gates_--;
     return gate_servicing_stack_[pending_gates_];  // return value
   }
 
-  inline bool gates_pending() { return !(pending_gates_ == 0); }
+  bool gates_pending() { return !(pending_gates_ == 0); }
 
   /* better be the last field. it's huge */
   struct pkt_batch *splits() {
@@ -167,25 +135,26 @@ class Worker {
   uint64_t current_tsc_;
   uint64_t current_ns_;
 
-  /* The current input gate index is not given as a function parameter.
-   * Modules should use get_igate() for access */
-  gate_idx_t igate_stack_[MAX_MODULES_PER_PATH];
-  int stack_depth_;
-
   // Gates and packets that this worker should serve next.
   struct gate_task gate_servicing_stack_[MAX_MODULES_PER_PATH * BRANCH_FACTOR];
   int pending_gates_;
 
+  /* The current input gate index is not given as a function parameter.
+   * Modules should use get_igate() for access */
+  gate_idx_t current_igate_;
+
   /* better be the last field. it's huge */
   struct pkt_batch splits_[MAX_GATES + 1];
-
-  DISALLOW_COPY_AND_ASSIGN(Worker);
 };
 
 extern int num_workers;
 extern std::thread worker_threads[MAX_WORKERS];
 extern Worker *volatile workers[MAX_WORKERS];
-extern thread_local Worker ctx;
+
+// NOTE: Do not use "thread_local" here. It requires a function call every time
+// it is accessed. Use __thread instead, which incurs minimal runtime overhead.
+// Worker must be "trivial" type.
+extern __thread Worker ctx;
 
 /* ------------------------------------------------------------------------
  * functions below are invoked by non-worker threads (the master)


### PR DESCRIPTION
#130 introduced significant performance degradation: e.g., the throughput of samples/s2s.bess dropped about 35%. Before working on optimization, this PR adds benchmark tests regarding invocation of module code.