### PR TITLE
Specify module params only if they are not default

### DIFF
--- a/core/module.cc
+++ b/core/module.cc
@@ -15,6 +15,9 @@
 #include "mem_alloc.h"
 #include "utils/pcap.h"
 
+const Commands<Module> Module::cmds;
+const PbCommands Module::pb_cmds;
+
 std::map<std::string, Module *> ModuleBuilder::all_modules_;
 
 // FIXME: move somewhere else?

--- a/core/module.h
+++ b/core/module.h
@@ -217,6 +217,12 @@ class Module {
   virtual std::string GetDesc() const { return ""; };
   virtual struct snobj *GetDump() const { return snobj_nil(); }
 
+  static const gate_idx_t kNumIGates = 1;
+  static const gate_idx_t kNumOGates = 1;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   // -------------------------------------------------------------------------
 
  public:

--- a/core/module.h
+++ b/core/module.h
@@ -87,8 +87,8 @@ class ModuleBuilder {
       std::function<pb_error_t(Module *, const google::protobuf::Any &)>
           init_func)
       : module_generator_(module_generator),
-        kNumIGates(igates),
-        kNumOGates(ogates),
+        num_igates_(igates),
+        num_ogates_(ogates),
         class_name_(class_name),
         name_template_(name_template),
         help_text_(help_text),
@@ -122,8 +122,8 @@ class ModuleBuilder {
 
   static const std::map<std::string, Module *> &all_modules();
 
-  gate_idx_t NumIGates() const { return kNumIGates; }
-  gate_idx_t NumOGates() const { return kNumOGates; }
+  gate_idx_t NumIGates() const { return num_igates_; }
+  gate_idx_t NumOGates() const { return num_ogates_; }
 
   const std::string &class_name() const { return class_name_; };
   const std::string &name_template() const { return name_template_; };
@@ -175,19 +175,19 @@ class ModuleBuilder {
   }
 
  private:
-  std::function<Module *()> module_generator_;
+  const std::function<Module *()> module_generator_;
 
   static std::map<std::string, Module *> all_modules_;
 
-  gate_idx_t kNumIGates;
-  gate_idx_t kNumOGates;
+  const gate_idx_t num_igates_;
+  const gate_idx_t num_ogates_;
 
-  std::string class_name_;
-  std::string name_template_;
-  std::string help_text_;
-  Commands<Module> cmds_;
-  PbCommands pb_cmds_;
-  module_init_func_t init_func_;
+  const std::string class_name_;
+  const std::string name_template_;
+  const std::string help_text_;
+  const Commands<Module> cmds_;
+  const PbCommands pb_cmds_;
+  const module_init_func_t init_func_;
 };
 
 class Module {

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -19,6 +19,11 @@ struct filter {
 
 class BPF : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   virtual struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::BPFArg &arg);
   virtual void Deinit();
@@ -30,12 +35,6 @@ class BPF : public Module {
 
   pb_cmd_response_t CommandAddPb(const bess::pb::BPFArg &arg);
   pb_cmd_response_t CommandClearPb(const bess::pb::EmptyArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   struct filter filters_[MAX_FILTERS + 1] = {};

--- a/core/modules/buffer.cc
+++ b/core/modules/buffer.cc
@@ -1,8 +1,5 @@
 #include "buffer.h"
 
-const Commands<Module> Buffer::cmds = {};
-const PbCommands Buffer::pb_cmds = {};
-
 void Buffer::Deinit() {
   struct pkt_batch *buf = &buf_;
 

--- a/core/modules/buffer.h
+++ b/core/modules/buffer.h
@@ -12,12 +12,6 @@ class Buffer : public Module {
 
   virtual void ProcessBatch(struct pkt_batch *batch);
 
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
-
  private:
   struct pkt_batch buf_;
 };

--- a/core/modules/bypass.cc
+++ b/core/modules/bypass.cc
@@ -1,8 +1,5 @@
 #include "bypass.h"
 
-const Commands<Module> Bypass::cmds = {};
-const PbCommands Bypass::pb_cmds = {};
-
 void Bypass::ProcessBatch(struct pkt_batch *batch) {
   RunChooseModule(get_igate(), batch);
 }

--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -8,13 +8,10 @@
 
 class Bypass : public Module {
  public:
-  virtual void ProcessBatch(struct pkt_batch *batch);
-
   static const gate_idx_t kNumIGates = MAX_GATES;
   static const gate_idx_t kNumOGates = MAX_GATES;
 
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
+  virtual void ProcessBatch(struct pkt_batch *batch);
 };
 
 #endif  // BESS_MODULES_BYPASS_H_

--- a/core/modules/dump.h
+++ b/core/modules/dump.h
@@ -14,9 +14,6 @@ class Dump : public Module {
   struct snobj *CommandSetInterval(struct snobj *arg);
   pb_cmd_response_t CommandSetIntervalPb(const bess::pb::DumpArg &arg);
 
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
   static const Commands<Module> cmds;
   static const PbCommands pb_cmds;
 

--- a/core/modules/ether_encap.cc
+++ b/core/modules/ether_encap.cc
@@ -9,9 +9,6 @@ enum {
   ATTR_R_ETHER_TYPE,
 };
 
-const Commands<Module> EtherEncap::cmds = {};
-const PbCommands EtherEncap::pb_cmds = {};
-
 struct snobj *EtherEncap::Init(struct snobj *arg [[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 

--- a/core/modules/ether_encap.h
+++ b/core/modules/ether_encap.h
@@ -10,12 +10,6 @@ class EtherEncap : public Module {
   pb_error_t InitPb(const bess::pb::EtherEncapArg &arg);
 
   void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_ETHERENCAP_H_

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -113,8 +113,10 @@ struct EmField {
 
 class ExactMatch : public Module {
  public:
-  static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
 
   ExactMatch()
       : Module(),
@@ -137,9 +139,6 @@ class ExactMatch : public Module {
   struct snobj *CommandDelete(struct snobj *arg);
   struct snobj *CommandClear(struct snobj *arg);
   struct snobj *CommandSetDefaultGate(struct snobj *arg);
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
   pb_error_t InitPb(const bess::pb::ExactMatchArg &arg);
   pb_cmd_response_t CommandAddPb(const bess::pb::ExactMatchCommandAddArg &arg);

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -41,9 +41,6 @@ static inline double scaled_pareto_variate(double inversed_alpha, double mean,
   return 1.0 + (x - 1.0) / (mean - 1.0) * (desired_mean - 1.0);
 }
 
-const Commands<Module> FlowGen::cmds = {};
-const PbCommands FlowGen::pb_cmds = {};
-
 inline double FlowGen::NewFlowPkts() {
   switch (duration_) {
     case DURATION_UNIFORM:

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -14,9 +14,6 @@ typedef std::priority_queue<Event, std::vector<Event>,
 
 class FlowGen : public Module {
  public:
-  static const gate_idx_t kNumIGates = 0;
-  static const gate_idx_t kNumOGates = 1;
-
   enum Arrival {
     ARRIVAL_UNIFORM = 0,
     ARRIVAL_EXPONENTIAL,
@@ -26,6 +23,8 @@ class FlowGen : public Module {
     DURATION_UNIFORM = 0,
     DURATION_PARETO,
   };
+
+  static const gate_idx_t kNumIGates = 0;
 
   FlowGen()
       : Module(),
@@ -59,9 +58,6 @@ class FlowGen : public Module {
 
   std::string GetDesc() const;
   struct snobj *GetDump() const;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   inline double NewFlowPkts();

--- a/core/modules/generic_decap.cc
+++ b/core/modules/generic_decap.cc
@@ -1,8 +1,5 @@
 #include "generic_decap.h"
 
-const Commands<Module> GenericDecap::cmds = {};
-const PbCommands GenericDecap::pb_cmds = {};
-
 pb_error_t GenericDecap::InitPb(const bess::pb::GenericDecapArg &arg) {
   if (arg.bytes() == 0) {
     return pb_errno(0);

--- a/core/modules/generic_decap.h
+++ b/core/modules/generic_decap.h
@@ -6,18 +6,12 @@
 
 class GenericDecap : public Module {
  public:
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
   GenericDecap() : Module(), decap_size_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::GenericDecapArg &arg);
 
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   int decap_size_;

--- a/core/modules/generic_encap.cc
+++ b/core/modules/generic_encap.cc
@@ -9,9 +9,6 @@ static_assert(MAX_FIELD_SIZE <= sizeof(uint64_t),
 #error this code assumes little endian architecture (x86)
 #endif
 
-const Commands<Module> GenericEncap::cmds = {};
-const PbCommands GenericEncap::pb_cmds = {};
-
 pb_error_t GenericEncap::AddFieldOne(
     const bess::pb::GenericEncapArg_Field &field, struct Field *f, int idx) {
   f->size = field.size();

--- a/core/modules/generic_encap.h
+++ b/core/modules/generic_encap.h
@@ -16,18 +16,12 @@ struct Field {
 
 class GenericEncap : public Module {
  public:
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
   GenericEncap() : Module(), encap_size_(), num_fields_(), fields_() {}
 
   struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::GenericEncapArg &arg);
 
   void ProcessBatch(struct pkt_batch *batch);
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   struct snobj *AddFieldOne(struct snobj *field, struct Field *f, int idx);

--- a/core/modules/hash_lb.h
+++ b/core/modules/hash_lb.h
@@ -15,6 +15,11 @@ enum LbMode {
 
 class HashLB : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   HashLB() : Module(), gates_(), num_gates_(), mode_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -29,12 +34,6 @@ class HashLB : public Module {
       const bess::pb::HashLBCommandSetModeArg &arg);
   pb_cmd_response_t CommandSetGatesPb(
       const bess::pb::HashLBCommandSetGatesArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   void LbL2(struct pkt_batch *batch, gate_idx_t *ogates);

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -12,9 +12,6 @@ enum {
   ATTR_W_ETHER_TYPE,
 };
 
-const Commands<Module> IPEncap::cmds = {};
-const PbCommands IPEncap::pb_cmds = {};
-
 struct snobj *IPEncap::Init(struct snobj *arg [[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -10,12 +10,6 @@ class IPEncap : public Module {
   pb_error_t InitPb(const bess::pb::IPEncapArg &arg);
 
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_IPENCAP_H_

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -6,6 +6,11 @@
 
 class IPLookup : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   IPLookup() : Module(), lpm_(), default_gate_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -20,12 +25,6 @@ class IPLookup : public Module {
 
   pb_cmd_response_t CommandAddPb(const bess::pb::IPLookupCommandAddArg &arg);
   pb_cmd_response_t CommandClearPb(const bess::pb::EmptyArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   struct rte_lpm *lpm_;

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -25,6 +25,11 @@ struct l2_table {
 
 class L2Forward : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   L2Forward() : Module(), l2_table_(), default_gate_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -49,12 +54,6 @@ class L2Forward : public Module {
       const bess::pb::L2ForwardCommandLookupArg &arg);
   pb_cmd_response_t CommandPopulatePb(
       const bess::pb::L2ForwardCommandPopulateArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   struct l2_table l2_table_;

--- a/core/modules/macswap.cc
+++ b/core/modules/macswap.cc
@@ -2,9 +2,6 @@
 
 #include <rte_ether.h>
 
-const Commands<Module> MACSwap::cmds = {};
-const PbCommands MACSwap::pb_cmds = {};
-
 void MACSwap::ProcessBatch(struct pkt_batch *batch) {
   int cnt = batch->cnt;
 

--- a/core/modules/macswap.h
+++ b/core/modules/macswap.h
@@ -6,12 +6,6 @@
 class MACSwap : public Module {
  public:
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_MACSWAP_H_

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -7,6 +7,9 @@
 
 class Measure : public Module {
  public:
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   Measure()
       : Module(),
         hist_(),
@@ -23,12 +26,6 @@ class Measure : public Module {
 
   struct snobj *CommandGetSummary(struct snobj *arg);
   pb_cmd_response_t CommandGetSummaryPb(const bess::pb::EmptyArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   struct histogram hist_;

--- a/core/modules/merge.cc
+++ b/core/modules/merge.cc
@@ -1,8 +1,5 @@
 #include "merge.h"
 
-const Commands<Module> Merge::cmds = {};
-const PbCommands Merge::pb_cmds = {};
-
 void Merge::ProcessBatch(struct pkt_batch *batch) {
   RunNextModule(batch);
 }

--- a/core/modules/merge.h
+++ b/core/modules/merge.h
@@ -6,12 +6,8 @@
 class Merge : public Module {
  public:
   static const gate_idx_t kNumIGates = MAX_GATES;
-  static const gate_idx_t kNumOGates = 1;
 
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_MERGE_H_

--- a/core/modules/mttest.cc
+++ b/core/modules/mttest.cc
@@ -2,9 +2,6 @@
 
 #include <glog/logging.h>
 
-const Commands<Module> MetadataTest::cmds = {};
-const PbCommands MetadataTest::pb_cmds = {};
-
 pb_error_t MetadataTest::AddAttributes(
     const google::protobuf::Map<std::string, int64_t> &attributes,
     Attribute::AccessMode mode) {

--- a/core/modules/mttest.h
+++ b/core/modules/mttest.h
@@ -8,16 +8,13 @@ using bess::metadata::Attribute;
 
 class MetadataTest : public Module {
  public:
+  static const gate_idx_t kNumIGates = MAX_GATES;
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
   struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::MetadataTestArg &arg);
 
   void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = MAX_GATES;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   struct snobj *AddAttributes(struct snobj *attrs,

--- a/core/modules/noop.cc
+++ b/core/modules/noop.cc
@@ -1,8 +1,5 @@
 #include "noop.h"
 
-const Commands<Module> NoOP::cmds = {};
-const PbCommands NoOP::pb_cmds = {};
-
 struct snobj *NoOP::Init(struct snobj *) {
   task_id_t tid;
 

--- a/core/modules/noop.h
+++ b/core/modules/noop.h
@@ -13,9 +13,6 @@ class NoOP : public Module {
 
   static const gate_idx_t kNumIGates = 0;
   static const gate_idx_t kNumOGates = 0;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_NOOP_H_

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -7,6 +7,11 @@
 
 class PortInc : public Module {
  public:
+  static const gate_idx_t kNumIGates = 0;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   PortInc() : Module(), port_(), prefetch_(), burst_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -22,17 +27,12 @@ class PortInc : public Module {
   pb_cmd_response_t CommandSetBurstPb(
       const bess::pb::PortIncCommandSetBurstArg &arg);
 
-  static const gate_idx_t kNumIGates = 0;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
-
  private:
-  Port *port_ = {};
-  int prefetch_ = {};
-  int burst_ = {};
   pb_error_t SetBurst(int64_t burst);
+
+  Port *port_;
+  int prefetch_;
+  int burst_;
 };
 
 #endif  // BESS_MODULES_PORTINC_H_

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -1,9 +1,6 @@
 #include "port_out.h"
 #include "../utils/format.h"
 
-const Commands<Module> PortOut::cmds = {};
-const PbCommands PortOut::pb_cmds = {};
-
 pb_error_t PortOut::InitPb(const bess::pb::PortOutArg &arg) {
   const char *port_name;
   int ret;

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -7,6 +7,8 @@
 
 class PortOut : public Module {
  public:
+  static const gate_idx_t kNumOGates = 0;
+
   PortOut() : Module(), port_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -17,12 +19,6 @@ class PortOut : public Module {
   virtual void ProcessBatch(struct pkt_batch *batch);
 
   virtual std::string GetDesc() const;
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 0;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   Port *port_;

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -7,6 +7,9 @@
 
 class Queue : public Module {
  public:
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   Queue() : Module(), queue_(), prefetch_(), burst_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -26,12 +29,6 @@ class Queue : public Module {
       const bess::pb::QueueCommandSetBurstArg &arg);
   pb_cmd_response_t CommandSetSizePb(
       const bess::pb::QueueCommandSetSizeArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   int Resize(int slots);

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -7,6 +7,11 @@
 
 class QueueInc : public Module {
  public:
+  static const gate_idx_t kNumIGates = 0;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   QueueInc() : Module(), port_(), qid_(), prefetch_(), burst_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -20,12 +25,6 @@ class QueueInc : public Module {
   struct snobj *CommandSetBurst(struct snobj *arg);
   pb_cmd_response_t CommandSetBurstPb(
       const bess::pb::QueueIncCommandSetBurstArg &arg);
-
-  static const gate_idx_t kNumIGates = 0;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   Port *port_;

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -3,9 +3,6 @@
 #include "../port.h"
 #include "../utils/format.h"
 
-const Commands<Module> QueueOut::cmds = {};
-const PbCommands QueueOut::pb_cmds = {};
-
 pb_error_t QueueOut::InitPb(const bess::pb::QueueOutArg &arg) {
   const char *port_name;
   int ret;

--- a/core/modules/queue_out.h
+++ b/core/modules/queue_out.h
@@ -7,6 +7,8 @@
 
 class QueueOut : public Module {
  public:
+  static const gate_idx_t kNumOGates = 0;
+
   QueueOut() : Module(), port_(), qid_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -17,12 +19,6 @@ class QueueOut : public Module {
   virtual void ProcessBatch(struct pkt_batch *batch);
 
   virtual std::string GetDesc() const;
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 0;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   Port *port_;

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -9,6 +9,9 @@
 
 class RandomUpdate : public Module {
  public:
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   RandomUpdate() : Module(), num_vars_(), vars_(), rng_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -23,14 +26,8 @@ class RandomUpdate : public Module {
       const bess::pb::RandomUpdateArg &arg);
   pb_cmd_response_t CommandClearPb(const bess::pb::EmptyArg &arg);
 
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
-
  private:
-  int num_vars_ = {};
+  int num_vars_;
 
   struct {
     uint32_t mask; /* bits with 1 won't be updated */

--- a/core/modules/rewrite.h
+++ b/core/modules/rewrite.h
@@ -9,6 +9,9 @@
 
 class Rewrite : public Module {
  public:
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   Rewrite()
       : Module(),
         next_turn_(),
@@ -26,12 +29,6 @@ class Rewrite : public Module {
 
   pb_cmd_response_t CommandAddPb(const bess::pb::RewriteArg &arg);
   pb_cmd_response_t CommandClearPb(const bess::pb::EmptyArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   inline void DoRewrite(struct pkt_batch *batch);

--- a/core/modules/round_robin.h
+++ b/core/modules/round_robin.h
@@ -33,6 +33,11 @@
 */
 class RoundRobin : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   RoundRobin()
       : Module(), gates_(), ngates_(), current_gate_(), per_packet_() {}
 
@@ -40,12 +45,6 @@ class RoundRobin : public Module {
   pb_error_t InitPb(const bess::pb::RoundRobinArg &arg);
 
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
   /*!
    * Switches the RoundRobin module between "batch" vs "packet" scheduling.

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -33,9 +33,6 @@ static void CopyFromValue(struct pkt_batch *batch, const struct Attr *attr,
   }
 }
 
-const Commands<Module> SetMetadata::cmds = {};
-const PbCommands SetMetadata::pb_cmds = {};
-
 pb_error_t SetMetadata::AddAttrOne(
     const bess::pb::SetMetadataArg_Attribute &attr) {
   std::string name;

--- a/core/modules/set_metadata.h
+++ b/core/modules/set_metadata.h
@@ -23,12 +23,6 @@ class SetMetadata : public Module {
 
   void ProcessBatch(struct pkt_batch *batch);
 
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
-
  private:
   struct snobj *AddAttrOne(struct snobj *attr);
   pb_error_t AddAttrOne(const bess::pb::SetMetadataArg_Attribute &attr);

--- a/core/modules/sink.cc
+++ b/core/modules/sink.cc
@@ -1,8 +1,5 @@
 #include "sink.h"
 
-const Commands<Module> Sink::cmds = {};
-const PbCommands Sink::pb_cmds = {};
-
 void Sink::ProcessBatch(struct pkt_batch *batch) {
   snb_free_bulk(batch->pkts, batch->cnt);
 }

--- a/core/modules/sink.h
+++ b/core/modules/sink.h
@@ -5,13 +5,9 @@
 
 class Sink : public Module {
  public:
-  virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = 0;
 
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
+  virtual void ProcessBatch(struct pkt_batch *batch);
 };
 
 #endif  // BESS_MODULES_SINK_H_

--- a/core/modules/source.h
+++ b/core/modules/source.h
@@ -6,6 +6,11 @@
 
 class Source : public Module {
  public:
+  static const gate_idx_t kNumIGates = 0;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   Source() : Module(), pkt_size_(), burst_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -20,12 +25,6 @@ class Source : public Module {
       const bess::pb::SourceCommandSetBurstArg &arg);
   pb_cmd_response_t CommandSetPktSizePb(
       const bess::pb::SourceCommandSetPktSizeArg &arg);
-
-  static const gate_idx_t kNumIGates = 0;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   int pkt_size_;

--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -14,9 +14,6 @@ static inline int is_valid_gate(gate_idx_t gate) {
   return (gate < MAX_GATES || gate == DROP_GATE);
 }
 
-const Commands<Module> Split::cmds = {};
-const PbCommands Split::pb_cmds = {};
-
 pb_error_t Split::InitPb(const bess::pb::SplitArg &arg) {
   size_ = arg.size();
   if (size_ < 1 || size_ > MAX_SIZE) {

--- a/core/modules/split.h
+++ b/core/modules/split.h
@@ -6,18 +6,14 @@
 
 class Split : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
   Split() : Module(), mask_(), attr_id_(), offset_(), size_() {}
 
   struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::SplitArg &arg);
 
   void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   uint64_t mask_;

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -16,9 +16,6 @@ static inline void timestamp_packet(struct snbuf *pkt, uint64_t time) {
   *ts = time;
 }
 
-const Commands<Module> Timestamp::cmds = {};
-const PbCommands Timestamp::pb_cmds = {};
-
 void Timestamp::ProcessBatch(struct pkt_batch *batch) {
   uint64_t time = get_time();
 

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -6,12 +6,6 @@
 class Timestamp : public Module {
  public:
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_TIMESTAMP_H_

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -8,6 +8,9 @@
 
 class Update : public Module {
  public:
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   Update() : Module(), num_fields_(), fields_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -21,14 +24,8 @@ class Update : public Module {
   pb_cmd_response_t CommandAddPb(const bess::pb::UpdateArg &arg);
   pb_cmd_response_t CommandClearPb(const bess::pb::EmptyArg &arg);
 
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
-
  private:
-  int num_fields_ = {};
+  int num_fields_;
 
   struct {
     uint64_t mask;  /* bits with 1 won't be updated */

--- a/core/modules/vlan_pop.cc
+++ b/core/modules/vlan_pop.cc
@@ -2,9 +2,6 @@
 
 #include <rte_byteorder.h>
 
-const Commands<Module> VLANPop::cmds = {};
-const PbCommands VLANPop::pb_cmds = {};
-
 void VLANPop::ProcessBatch(struct pkt_batch *batch) {
   int cnt = batch->cnt;
 

--- a/core/modules/vlan_pop.h
+++ b/core/modules/vlan_pop.h
@@ -6,12 +6,6 @@
 class VLANPop : public Module {
  public:
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_VLANPOP_H_

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -6,6 +6,9 @@
 
 class VLANPush : public Module {
  public:
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   VLANPush() : Module(), vlan_tag_(), qinq_tag_() {}
 
   virtual struct snobj *Init(struct snobj *arg);
@@ -17,12 +20,6 @@ class VLANPush : public Module {
 
   struct snobj *CommandSetTci(struct snobj *arg);
   pb_cmd_response_t CommandSetTciPb(const bess::pb::VLANPushArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   /* network order */

--- a/core/modules/vlan_split.cc
+++ b/core/modules/vlan_split.cc
@@ -2,9 +2,6 @@
 
 #include <rte_byteorder.h>
 
-const Commands<Module> VLANSplit::cmds = {};
-const PbCommands VLANSplit::pb_cmds = {};
-
 void VLANSplit::ProcessBatch(struct pkt_batch *batch) {
   gate_idx_t vid[MAX_PKT_BURST];
   int cnt = batch->cnt;

--- a/core/modules/vlan_split.h
+++ b/core/modules/vlan_split.h
@@ -5,13 +5,9 @@
 
 class VLANSplit : public Module {
  public:
-  static const gate_idx_t kNumIGates = 1;
   static const gate_idx_t kNumOGates = 4096;
 
   virtual void ProcessBatch(struct pkt_batch *batch);
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_VLANSPLIT_H_

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -14,9 +14,6 @@ enum {
   ATTR_W_TUN_ID,
 };
 
-const Commands<Module> VXLANDecap::cmds = {};
-const PbCommands VXLANDecap::pb_cmds = {};
-
 struct snobj *VXLANDecap::Init(struct snobj *arg [[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 

--- a/core/modules/vxlan_decap.h
+++ b/core/modules/vxlan_decap.h
@@ -8,14 +8,8 @@ class VXLANDecap : public Module {
  public:
   virtual struct snobj *Init(struct snobj *arg);
   pb_error_t InitPb(const bess::pb::VXLANDecapArg &arg);
- 
+
   void ProcessBatch(struct pkt_batch *batch);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 };
 
 #endif  // BESS_MODULES_VXLANDECAP_H_

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -18,9 +18,6 @@ enum {
   ATTR_W_IP_PROTO,
 };
 
-const Commands<Module> VXLANEncap::cmds = {};
-const PbCommands VXLANEncap::pb_cmds = {};
-
 pb_error_t VXLANEncap::InitPb(const bess::pb::VXLANEncapArg &arg) {
   auto dstport = arg.dstport();
   if (dstport == 0) {

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -15,12 +15,6 @@ class VXLANEncap : public Module {
 
   virtual void ProcessBatch(struct pkt_batch *batch);
 
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = 1;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
-
  private:
   uint16_t dstport_;
 };

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -44,6 +44,11 @@ struct wm_hkey_t {
 
 class WildcardMatch : public Module {
  public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands<Module> cmds;
+  static const PbCommands pb_cmds;
+
   WildcardMatch()
       : Module(),
         default_gate_(),
@@ -76,12 +81,6 @@ class WildcardMatch : public Module {
   pb_cmd_response_t CommandClearPb(const bess::pb::EmptyArg &arg);
   pb_cmd_response_t CommandSetDefaultGatePb(
       const bess::pb::WildcardMatchCommandSetDefaultGateArg &arg);
-
-  static const gate_idx_t kNumIGates = 1;
-  static const gate_idx_t kNumOGates = MAX_GATES;
-
-  static const Commands<Module> cmds;
-  static const PbCommands pb_cmds;
 
  private:
   static int wm_keycmp(const void *key, const void *key_stored,


### PR DESCRIPTION
Added default parameters to Module: no command, one input gate, and one output gate. This configuration works for most common modules. If derived modules use the default parameters they do not need to overload them, allowing the code short and tidy.

Will merge #136 once this one is merged.