### PR TITLE
Change build.py to accept lib locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 cscope.*
 *.vim
 core/extra.mk
+core/extra.dpdk.mk
 
 # VM images
 *.img

--- a/build.py
+++ b/build.py
@@ -166,19 +166,20 @@ def check_mlx():
         set_config(DPDK_FINAL_CONFIG, 'CONFIG_RTE_LIBRTE_MLX4_PMD', 'n')
         set_config(DPDK_FINAL_CONFIG, 'CONFIG_RTE_LIBRTE_MLX5_PMD', 'n')
 
-def generate_extra_mk():
+def generate_dpdk_extra_mk():
     global extra_libs
-    global cxx_flags
-    global ld_flags
 
-    with open('core/extra.mk', 'w') as fp:
+    with open('core/extra.dpdk.mk', 'w') as fp:
         fp.write('LIBS += %s\n' % \
                 ' '.join(map(lambda lib: '-l' + lib, extra_libs)))
-        fp.write('CFLAGS += %s\n' % \
-                ' '.join(cxx_flags))
+
+def generate_extra_mk():
+    global cxx_flags
+    global ld_flags
+    with open('core/extra.mk', 'w') as fp:
         fp.write('CXXFLAGS += %s\n' % \
                 ' '.join(cxx_flags))
-        fp.write('LD_FLAGS += %s\n' % \
+        fp.write('LDFLAGS += %s\n' % \
                 ' '.join(cxx_flags))
 
 def download_dpdk():
@@ -201,7 +202,7 @@ def configure_dpdk():
 
         check_mlx()
 
-        generate_extra_mk()
+        generate_dpdk_extra_mk()
 
         cmd('cp -f %s %s' % (DPDK_FINAL_CONFIG, DPDK_ORIG_CONFIG))
         cmd('make -C %s config T=%s' % (DPDK_DIR, DPDK_TARGET))
@@ -239,6 +240,8 @@ def build_bess():
 
     if not os.path.exists('%s/build' % DPDK_DIR):
         build_dpdk()
+
+    generate_extra_mk()
 
     print 'Generating protobuf codes for libbess-python...'
     cmd('protoc protobuf/*.proto \
@@ -293,8 +296,8 @@ def print_usage(parser):
 
 def update_benchmark_path(path):
     print 'Specified benchmark path %s' % path
-    cxx_flags.extend(['-I', '%s/include'%(path)])
-    ld_flags.extend(['-L', '%s/lib'%(path)])
+    cxx_flags.extend(['-I%s/include'%(path)])
+    ld_flags.extend(['-L%s/lib'%(path)])
 
 
 def main():

--- a/build.py
+++ b/build.py
@@ -281,10 +281,8 @@ def do_dist_clean():
     print 'Removing 3rd-party libraries...'
     cmd('rm -rf %s %s' % (DPDK_FILE, DPDK_DIR))
 
-def print_usage():
-    print >> sys.stderr, \
-            'Usage: %s [all|dpdk|bess|kmod|clean|dist_clean|help]' % \
-            sys.argv[0]
+def print_usage(parser):
+    parser.print_help(file=sys.stderr)
     sys.exit(2)
 
 def update_benchmark_path(path):
@@ -316,10 +314,10 @@ def main():
     elif args.action == 'dist_clean':
         do_dist_clean()
     elif args.action == 'help':
-        print_usage()
+        print_usage(parser)
     else:
         print >> sys.stderr, 'Error - unknown command "%s".' % sys.argv[1]
-        print_usage()
+        print_usage(parser)
 
 if __name__ == '__main__':
     main()

--- a/build.py
+++ b/build.py
@@ -180,7 +180,7 @@ def generate_extra_mk():
         fp.write('CXXFLAGS += %s\n' % \
                 ' '.join(cxx_flags))
         fp.write('LDFLAGS += %s\n' % \
-                ' '.join(cxx_flags))
+                ' '.join(ld_flags))
 
 def download_dpdk():
     try:

--- a/build.py
+++ b/build.py
@@ -294,8 +294,9 @@ def main():
     os.chdir(BESS_DIR)
     parser = argparse.ArgumentParser(description = 'Build Bess')
     parser.add_argument('action', metavar='action', nargs='?', default='all', \
-            help='Action is one of all, dpdk, bess, kmod, clean, dist_clean, help')
-    parser.add_argument('--with-benchmark', dest='benchmark_path', nargs=1, help='Location of benchmark library')
+        help='Action is one of all, dpdk, bess, kmod, clean, dist_clean, help')
+    parser.add_argument('--with-benchmark', dest='benchmark_path', nargs=1, \
+            help='Location of benchmark library')
     args = parser.parse_args()
 
     if args.benchmark_path:

--- a/core/Makefile
+++ b/core/Makefile
@@ -77,6 +77,7 @@ ifdef COVERAGE
 endif
 
 
+-include extra.dpdk.mk
 -include extra.mk
 
 PROTO_DIR = ../protobuf


### PR DESCRIPTION
This changes build.py so that one can specify where Google Benchmark library is stored.

This change only adds a flag for one library, but it can easily be extended to others. I mostly did this because I am personally a bit weirded out by cloning the repository and running `make install`. I think it might be good to have similar stuff for gRPC (which needs to be built manually at the moment), protoc, and a few others. I can do that later, mostly wanted to test the waters to see if this was something others were OK with.

By the way, during development I noticed that `build.py` does not check `protoc` version, so it will get pretty far with old protobuf installations, but then fail in the Python bit. 