### PR TITLE
Build bessd in parallel

### DIFF
--- a/build.py
+++ b/build.py
@@ -252,7 +252,7 @@ def build_bess():
     print 'Building BESS daemon...'
     cmd('bin/bessctl daemon stop 2> /dev/null || true')
     cmd('rm -f core/bessd')     # force relink as DPDK might have been rebuilt
-    cmd('make -C core')
+    cmd('make -C core -j`nproc`')
     cmd('ln -f -s ../core/bessd bin/bessd')
 
 def build_kmod():


### PR DESCRIPTION
Since the core/Makefile now does not do parallel build by default, we
add -j option to the build.py script