### PR TITLE
A set of fixes in porting from C to C++

### DIFF
--- a/bessctl/conf/samples/loopback.bess
+++ b/bessctl/conf/samples/loopback.bess
@@ -7,5 +7,5 @@ print 'NOTE: not all DPDK ports support lookback mode'
 
 for i in range(dpdk_ports):
 		p = PMDPort(port_id=i, loopback=1, size_inc_q=qsize, size_out_q=qsize)
-		Source() -> PortOut(port='p')
+		Source() -> PortOut(port=p.name)
 		PortInc(port=p.name) -> Sink()

--- a/bessctl/conf/samples/macswap.bess
+++ b/bessctl/conf/samples/macswap.bess
@@ -3,4 +3,4 @@ print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)
-    PortInc(port=p) -> MACSwap() -> PortOut(port=p)
+    PortInc(port=p.name) -> MACSwap() -> PortOut(port=p.name)

--- a/bessctl/conf/samples/p2s.bess
+++ b/bessctl/conf/samples/p2s.bess
@@ -3,4 +3,4 @@ print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)
-    PortInc(port=p) -> Sink()
+    PortInc(port=p.name) -> Sink()

--- a/bessctl/conf/samples/s2p.bess
+++ b/bessctl/conf/samples/s2p.bess
@@ -3,4 +3,4 @@ print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)
-    Source() -> PortOut(port=p)
+    Source() -> PortOut(port=p.name)

--- a/bessctl/conf/samples/s2p2s.bess
+++ b/bessctl/conf/samples/s2p2s.bess
@@ -4,5 +4,5 @@ print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)
 
-    Source() -> PortOut(port=p)
-    PortInc(port=p) -> Sink()
+    Source() -> PortOut(port=p.name)
+    PortInc(port=p.name) -> Sink()

--- a/bessctl/conf/samples/vport.bess
+++ b/bessctl/conf/samples/vport.bess
@@ -4,5 +4,5 @@ v = VPort()
 
 p = PMDPort(port_id=0)
 
-PortInc(port=p) -> PortOut(port=v)
-PortInc(port=v) -> PortOut(port=p)
+PortInc(port=p.name) -> PortOut(port=v.name)
+PortInc(port=v.name) -> PortOut(port=p.name)

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -201,8 +201,9 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
 
   int i;
 
-  pb_error_t err = find_dpdk_port(arg.port_id(), arg.pci(), arg.vdev(),
-                                  &ret_port_id, &hot_plugged_);
+  pb_error_t err = find_dpdk_port(
+      arg.pci().length() != 0 ? DPDK_PORT_UNKNOWN : arg.port_id(), arg.pci(),
+      arg.vdev(), &ret_port_id, &hot_plugged_);
   if (err.err() != 0) {
     return err;
   }

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -38,50 +38,48 @@ void Measure::ProcessBatch(bess::PacketBatch *batch) {
     start_time_ = get_time();
   }
 
-  if (static_cast<int>(HISTO_TIME_TO_SEC(time - start_time_)) < warmup_) {
+  if (static_cast<int>(HISTO_TIME_TO_SEC(time - start_time_)) >= warmup_) {
     RunNextModule(batch);
-    return;
-  }
+    pkt_cnt_ += batch->cnt();
 
-  pkt_cnt_ += batch->cnt();
+    for (int i = 0; i < batch->cnt(); i++) {
+      uint64_t pkt_time;
+      if (get_measure_packet(batch->pkts()[i], &pkt_time)) {
+        uint64_t diff;
 
-  for (int i = 0; i < batch->cnt(); i++) {
-    uint64_t pkt_time;
-    if (get_measure_packet(batch->pkts()[i], &pkt_time)) {
-      uint64_t diff;
+        if (time >= pkt_time) {
+          diff = time - pkt_time;
+        } else {
+          continue;
+        }
 
-      if (time >= pkt_time) {
-        diff = time - pkt_time;
-      } else {
-        continue;
+        bytes_cnt_ += batch->pkts()[i]->total_len();
+        total_latency_ += diff;
+
+        record_latency(&hist_, diff);
       }
-
-      bytes_cnt_ += batch->pkts()[i]->total_len();
-      total_latency_ += diff;
-
-      record_latency(&hist_, diff);
     }
+    RunNextModule(batch);
   }
-}
 
-pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
-  uint64_t pkt_total = pkt_cnt_;
-  uint64_t byte_total = bytes_cnt_;
-  uint64_t bits = (byte_total + pkt_total * 24) * 8;
+  pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
+    uint64_t pkt_total = pkt_cnt_;
+    uint64_t byte_total = bytes_cnt_;
+    uint64_t bits = (byte_total + pkt_total * 24) * 8;
 
-  pb_cmd_response_t response;
+    pb_cmd_response_t response;
 
-  bess::pb::MeasureCommandGetSummaryResponse r;
-  r.set_timestamp(get_epoch_time());
-  r.set_packets(pkt_total);
-  r.set_bits(bits);
-  r.set_total_latency_ns(total_latency_ * 100);
+    bess::pb::MeasureCommandGetSummaryResponse r;
+    r.set_timestamp(get_epoch_time());
+    r.set_packets(pkt_total);
+    r.set_bits(bits);
+    r.set_total_latency_ns(total_latency_ * 100);
 
-  response.mutable_error()->set_err(0);
-  response.mutable_other()->PackFrom(r);
+    response.mutable_error()->set_err(0);
+    response.mutable_other()->PackFrom(r);
 
-  return response;
-}
+    return response;
+  }
 
 ADD_MODULE(Measure, "measure",
            "measures packet latency (paired with Timestamp module)")

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -39,7 +39,6 @@ void Measure::ProcessBatch(bess::PacketBatch *batch) {
   }
 
   if (static_cast<int>(HISTO_TIME_TO_SEC(time - start_time_)) >= warmup_) {
-    RunNextModule(batch);
     pkt_cnt_ += batch->cnt();
 
     for (int i = 0; i < batch->cnt(); i++) {
@@ -59,27 +58,28 @@ void Measure::ProcessBatch(bess::PacketBatch *batch) {
         record_latency(&hist_, diff);
       }
     }
-    RunNextModule(batch);
   }
+  RunNextModule(batch);
+}
 
-  pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
-    uint64_t pkt_total = pkt_cnt_;
-    uint64_t byte_total = bytes_cnt_;
-    uint64_t bits = (byte_total + pkt_total * 24) * 8;
+pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
+  uint64_t pkt_total = pkt_cnt_;
+  uint64_t byte_total = bytes_cnt_;
+  uint64_t bits = (byte_total + pkt_total * 24) * 8;
 
-    pb_cmd_response_t response;
+  pb_cmd_response_t response;
 
-    bess::pb::MeasureCommandGetSummaryResponse r;
-    r.set_timestamp(get_epoch_time());
-    r.set_packets(pkt_total);
-    r.set_bits(bits);
-    r.set_total_latency_ns(total_latency_ * 100);
+  bess::pb::MeasureCommandGetSummaryResponse r;
+  r.set_timestamp(get_epoch_time());
+  r.set_packets(pkt_total);
+  r.set_bits(bits);
+  r.set_total_latency_ns(total_latency_ * 100);
 
-    response.mutable_error()->set_err(0);
-    response.mutable_other()->PackFrom(r);
+  response.mutable_error()->set_err(0);
+  response.mutable_other()->PackFrom(r);
 
-    return response;
-  }
+  return response;
+}
 
 ADD_MODULE(Measure, "measure",
            "measures packet latency (paired with Timestamp module)")

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -1,4 +1,6 @@
 #include "rewrite.h"
+#include <cstdio>
+#include <rte_memcpy.h>
 
 const Commands Rewrite::cmds = {
     {"add", "RewriteArg", MODULE_CMD_FUNC(&Rewrite::CommandAdd), 0},
@@ -71,13 +73,12 @@ inline void Rewrite::DoRewriteSingle(bess::PacketBatch *batch) {
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
-    char *ptr = static_cast<char *>(pkt->buffer()) + SNBUF_HEADROOM;
+    char *ptr = pkt->head_data<char *>();
 
-    pkt->set_data_off(SNBUF_HEADROOM);
     pkt->set_total_len(size);
     pkt->set_data_len(size);
 
-    memcpy_sloppy(ptr, templ, size);
+    rte_memcpy(ptr, templ, size);
   }
 }
 

--- a/core/utils/histogram.cc
+++ b/core/utils/histogram.cc
@@ -1,0 +1,116 @@
+#include "histogram.h"
+#include <inttypes.h>
+#include <stdio.h>
+static const char* choose_unit_str(int TIMEUNIT) {
+  if (TIMEUNIT <= 1)
+    return "sec";
+  if (TIMEUNIT <= 1000)
+    return "msec";
+  if (TIMEUNIT <= 1000 * 1000)
+    return "usec";
+  // if(TIMEUNIT <= 1000*1000*1000)
+  return "nsec";
+}
+
+static int choose_unit_mult(int TIMEUNIT) {
+  if (TIMEUNIT <= 1)
+    return 1;
+  if (TIMEUNIT <= 1000)
+    return TIMEUNIT / 1000;
+  if (TIMEUNIT <= 1000 * 1000)
+    return TIMEUNIT / (1000 * 1000);
+  // if(TIMEUNIT <= 1000*1000*1000)
+  return TIMEUNIT / (1000 * 1000 * 1000);
+}
+
+void print_hist(struct histogram* hist) {
+  const int timeunit_mult = choose_unit_mult(HISTO_TIMEUNIT_MULT);
+  const char* timeunit_name = choose_unit_str(HISTO_TIMEUNIT_MULT);
+  printf("Unit: %lu %s\n", HISTO_TIME * timeunit_mult, timeunit_name);
+  histo_count_t* arr = hist->arr;
+  for (int i = 0; i < HISTO_BUCKETS; i++) {
+    size_t current_size = HISTO_BUCKET_VAL(arr + i);
+    if (current_size > 0)
+      printf(" <  %9lu %s: %16lu pkts  \n",
+             (i + 1) * HISTO_TIME * timeunit_mult, timeunit_name, current_size);
+  }
+  printf("above threshold %09lu pkts \n", hist->above_threshold);
+}
+
+// Add histogram b's observations into a, so that a contains all.
+struct histogram* combine_histograms(struct histogram* a, struct histogram* b) {
+  for (int i = 0; i < HISTO_BUCKETS; i++) {
+    *(a->arr + i) += (*(b->arr + i));
+  }
+  a->above_threshold += b->above_threshold;
+  return a;
+}
+
+void print_summary(struct histogram* hist) {
+  // NOTE: This is destructive.
+  uint64_t total = 0;
+  uint64_t count = 0;
+  uint64_t min = 0;
+  uint64_t max = 0;
+  int max_bucket = 0;
+  int found_min = 0;
+  const int timeunit_mult = choose_unit_mult(HISTO_TIMEUNIT_MULT);
+  const char* timeunit_name = choose_unit_str(HISTO_TIMEUNIT_MULT);
+  printf("   Unit: %lu %s\n", HISTO_TIME * timeunit_mult, timeunit_name);
+  printf("\n\nSummary Statistics\n");
+  printf("-----------------------------------------------------------\n");
+  histo_count_t* arr = hist->arr;
+  for (int i = 0; i < HISTO_BUCKETS; i++) {
+    size_t current_size = HISTO_BUCKET_VAL(arr + i);
+    uint64_t latency = (i + 1) * HISTO_TIME * timeunit_mult;
+    if (!found_min && current_size > 0) {
+      min = latency;
+      found_min = 1;
+    }
+    if (current_size > 0) {
+      max = latency;
+      max_bucket = i;
+    }
+    histo_count_t* bucket = arr + i;
+    uint64_t samples = HISTO_BUCKET_VAL(bucket);
+    count += samples;
+    *bucket = count;
+    total += (samples * latency);
+  }
+
+  if (count == 0) {
+    printf("No data recorded\n");
+    return;
+  }
+
+  uint64_t counts[] = {count / 100,
+                       count / 2,
+                       (count * 99) / 100,
+                       (count * 999) / 1000,
+                       (uint64_t)((double)count * (0.9999)),
+                       (uint64_t)((double)count * (0.99999)),
+                       (uint64_t)((double)count * (0.999999))};
+
+  uint64_t latencies[] = {0, 0, 0, 0, 0, 0, 0};
+
+  for (int i = 0; i < max_bucket; i++) {
+    uint64_t latency = (i + 1) * HISTO_TIME * timeunit_mult;
+    for (size_t j = 0; j < sizeof(counts) / sizeof(uint64_t); j++) {
+      if (HISTO_BUCKET_VAL(arr + i) < counts[j]) {
+        latencies[j] = latency;
+      }
+    }
+  }
+
+  printf("##   Min: %" PRIu64 " %s\n", min, timeunit_name);
+  printf("##   Avg: %" PRIu64 " %s\n", (total / count), timeunit_name);
+  printf("##   Max: %" PRIu64 " %s\n", max, timeunit_name);
+  printf("##   1%%ile: %" PRIu64 " %s\n", latencies[0], timeunit_name);
+  printf("##   50%%ile: %" PRIu64 " %s\n", latencies[1], timeunit_name);
+  printf("##   99%%ile: %" PRIu64 " %s\n", latencies[2], timeunit_name);
+  printf("##   99.9%%ile: %" PRIu64 " %s\n", latencies[3], timeunit_name);
+  printf("##   99.99%%ile: %" PRIu64 " %s\n", latencies[4], timeunit_name);
+  printf("##   99.999%%ile: %" PRIu64 " %s\n", latencies[5], timeunit_name);
+  printf("##   99.9999%%ile: %" PRIu64 " %s\n", latencies[6], timeunit_name);
+  printf("##   Total: %" PRIu64 "\n", count);
+}

--- a/core/utils/histogram.h
+++ b/core/utils/histogram.h
@@ -24,117 +24,6 @@ static inline uint64_t get_time() {
   return (uint64_t)(t * (HISTO_TIMEUNIT_MULT / HISTO_TIME) / tsc_hz);
 }
 
-#if 0
-static const char* choose_unit_str(int TIMEUNIT) {
-  if (TIMEUNIT <= 1) return "sec";
-  if (TIMEUNIT <= 1000) return "msec";
-  if (TIMEUNIT <= 1000 * 1000) return "usec";
-  // if(TIMEUNIT <= 1000*1000*1000)
-  return "nsec";
-}
-
-static int choose_unit_mult(int TIMEUNIT) {
-  if (TIMEUNIT <= 1) return 1;
-  if (TIMEUNIT <= 1000) return TIMEUNIT / 1000;
-  if (TIMEUNIT <= 1000 * 1000) return TIMEUNIT / (1000 * 1000);
-  // if(TIMEUNIT <= 1000*1000*1000)
-  return TIMEUNIT / (1000 * 1000 * 1000);
-}
-
-static void print_hist(struct histogram* hist) {
-  const int timeunit_mult = choose_unit_mult(HISTO_TIMEUNIT_MULT);
-  const char* timeunit_name = choose_unit_str(HISTO_TIMEUNIT_MULT);
-  printf("Unit: %lu %s\n", HISTO_TIME * timeunit_mult, timeunit_name);
-  histo_count_t* arr = hist->arr;
-  for (int i = 0; i < HISTO_BUCKETS; i++) {
-    size_t current_size = HISTO_BUCKET_VAL(arr + i);
-    if (current_size > 0)
-      printf(" <  %9lu %s: %16lu pkts  \n",
-             (i + 1) * HISTO_TIME * timeunit_mult, timeunit_name, current_size);
-  }
-  printf("above threshold %09lu pkts \n", hist->above_threshold);
-}
-
-// Add histogram b's observations into a, so that a contains all.
-static struct histogram* combine_histograms(struct histogram* a,
-                                            struct histogram* b) {
-  for (int i = 0; i < HISTO_BUCKETS; i++) {
-    *(a->arr + i) += (*(b->arr + i));
-  }
-  a->above_threshold += b->above_threshold;
-  return a;
-}
-
-static void print_summary(struct histogram* hist) {
-  // NOTE: This is destructive.
-  uint64_t total = 0;
-  uint64_t count = 0;
-  uint64_t min = 0;
-  uint64_t max = 0;
-  int max_bucket = 0;
-  int found_min = 0;
-  const int timeunit_mult = choose_unit_mult(HISTO_TIMEUNIT_MULT);
-  const char* timeunit_name = choose_unit_str(HISTO_TIMEUNIT_MULT);
-  printf("   Unit: %lu %s\n", HISTO_TIME * timeunit_mult, timeunit_name);
-  printf("\n\nSummary Statistics\n");
-  printf("-----------------------------------------------------------\n");
-  histo_count_t* arr = hist->arr;
-  for (int i = 0; i < HISTO_BUCKETS; i++) {
-    size_t current_size = HISTO_BUCKET_VAL(arr + i);
-    uint64_t latency = (i + 1) * HISTO_TIME * timeunit_mult;
-    if (!found_min && current_size > 0) {
-      min = latency;
-      found_min = 1;
-    }
-    if (current_size > 0) {
-      max = latency;
-      max_bucket = i;
-    }
-    histo_count_t* bucket = arr + i;
-    uint64_t samples = HISTO_BUCKET_VAL(bucket);
-    count += samples;
-    *bucket = count;
-    total += (samples * latency);
-  }
-
-  if (count == 0) {
-    printf("No data recorded\n");
-    return;
-  }
-
-  uint64_t counts[] = {count / 100,
-                       count / 2,
-                       (count * 99) / 100,
-                       (count * 999) / 1000,
-                       (uint64_t)((double)count * (0.9999)),
-                       (uint64_t)((double)count * (0.99999)),
-                       (uint64_t)((double)count * (0.999999))};
-
-  uint64_t latencies[] = {0, 0, 0, 0, 0, 0, 0};
-
-  for (int i = 0; i < max_bucket; i++) {
-    uint64_t latency = (i + 1) * HISTO_TIME * timeunit_mult;
-    for (size_t j = 0; j < sizeof(counts) / sizeof(uint64_t); j++) {
-      if (HISTO_BUCKET_VAL(arr + i) < counts[j]) {
-        latencies[j] = latency;
-      }
-    }
-  }
-
-  printf("##   Min: %" PRIu64 " %s\n", min, timeunit_name);
-  printf("##   Avg: %" PRIu64 " %s\n", (total / count), timeunit_name);
-  printf("##   Max: %" PRIu64 " %s\n", max, timeunit_name);
-  printf("##   1%%ile: %" PRIu64 " %s\n", latencies[0], timeunit_name);
-  printf("##   50%%ile: %" PRIu64 " %s\n", latencies[1], timeunit_name);
-  printf("##   99%%ile: %" PRIu64 " %s\n", latencies[2], timeunit_name);
-  printf("##   99.9%%ile: %" PRIu64 " %s\n", latencies[3], timeunit_name);
-  printf("##   99.99%%ile: %" PRIu64 " %s\n", latencies[4], timeunit_name);
-  printf("##   99.999%%ile: %" PRIu64 " %s\n", latencies[5], timeunit_name);
-  printf("##   99.9999%%ile: %" PRIu64 " %s\n", latencies[6], timeunit_name);
-  printf("##   Total: %" PRIu64 "\n", count);
-}
-#endif
-
 static inline void record_latency(struct histogram* hist, uint64_t latency) {
   if (latency >= HISTO_HARD_TIMEOUT) {
     hist->above_threshold++;
@@ -143,5 +32,8 @@ static inline void record_latency(struct histogram* hist, uint64_t latency) {
     HISTO_BUCKET_INC(bucket);
   }
 }
+void print_hist(struct histogram* hist);
+struct histogram* combine_histograms(struct histogram* a, struct histogram* b);
+void print_summary(struct histogram* hist);
 
 #endif  // BESS_UTILS_HISTOGRAM_H_


### PR DESCRIPTION
I can break this into smaller pull requests if that helps, but the code changes should be quite minimal. The main changes of interest are:

- PMD ports were unusable with PCI specs, this change reallows that. I don't think the solution is particularly elegant, but I had limited options because of choices made by protobuf.

- The rewrite module reliably segfaulted for me, fixed that by changing memcpy used.

- Measure did not forward most packets, so a minor fix for that module.

- The histogram bits in utils were unusable.