### PR TITLE
Rename all Deinit to DeInit

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -280,7 +280,7 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
   p->queue_size[PACKET_DIR_OUT] = size_out_q;
 
   ctx.SetNonWorker();
-  *perr = p->Init(arg);
+  *perr = p->InitWithGenericArg(arg);
   if (perr->err() != 0) {
     return nullptr;
   }

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -323,6 +323,8 @@ class BESSControlImpl final : public BESSControl::Service {
       return return_with_error(response, EBUSY, "There is a running worker");
     }
 
+    LOG(INFO) << "*** ResetAll requested ***";
+
     status = ResetModules(context, request, response);
     if (response->error().err() != 0) {
       return status;

--- a/core/drivers/pcap.h
+++ b/core/drivers/pcap.h
@@ -15,11 +15,11 @@ class PCAPPort final : public Port {
  public:
   pb_error_t Init(const bess::pb::PCAPPortArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
   // PCAP has no notion of queue so unlike parent (port.cc) quid is ignored.
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
   // Ditto above: quid is ignored.
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   void GatherData(unsigned char *data, bess::Packet *pkt);

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -21,7 +21,7 @@ class PMDPort final : public Port {
   /*!
   * Binds to device; call this after Init()
   */
-  virtual void InitDriver();
+  virtual void InitDriver() override;
 
   /*!
    * Initialize the port. Doesn't actually bind to the device, just grabs all
@@ -42,7 +42,7 @@ class PMDPort final : public Port {
   /*!
    * Release the device.
    */
-  virtual void DeInit();
+  virtual void DeInit() override;
 
   /*!
    * Copies rte port statistics into queue_stats datastructure (see port.h).
@@ -51,7 +51,7 @@ class PMDPort final : public Port {
    * * bool reset : if true, reset DPDK local statistics and return (do not
    * collect stats).
    */
-  virtual void CollectStats(bool reset);
+  virtual void CollectStats(bool reset) override;
 
   /*!
    * Receives packets from the device.
@@ -68,7 +68,7 @@ class PMDPort final : public Port {
    * RETURNS:
    * * Total number of packets received (<=cnt)
    */
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
   /*!
    * Sends packets out on the device.
@@ -85,7 +85,7 @@ class PMDPort final : public Port {
    * RETURNS:
    * * Total number of packets sent (<=cnt).
    */
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   /*!

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -41,7 +41,7 @@ class UnixSocketPort final : public Port {
   /*!
    * Close the socket / shut down the port.
    */
-  virtual void DeInit();
+  virtual void DeInit() override;
 
   /*!
    * Receives packets from the device.
@@ -58,7 +58,7 @@ class UnixSocketPort final : public Port {
    * RETURNS:
    * * Total number of packets received (<=cnt)
    */
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
   /*!
    * Sends packets out on the device.
@@ -75,7 +75,7 @@ class UnixSocketPort final : public Port {
    * RETURNS:
    * * Total number of packets sent (<=cnt).
    */
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
   /*!
    * Waits for a client to connect to the socket.

--- a/core/drivers/vport.h
+++ b/core/drivers/vport.h
@@ -7,13 +7,14 @@
 class VPort final : public Port {
  public:
   VPort() : fd_(), bar_(), map_(), netns_fd_(), container_pid_() {}
-  virtual void InitDriver();
+  virtual void InitDriver() override;
 
   pb_error_t Init(const bess::pb::VPortArg &arg);
-  void DeInit();
+  virtual void DeInit() override;
 
-  int RecvPackets(queue_t qid, bess::Packet **pkts, int max_cnt);
-  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int RecvPackets(queue_t qid, bess::Packet **pkts,
+                          int max_cnt) override;
+  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   struct queue {

--- a/core/module.cc
+++ b/core/module.cc
@@ -54,7 +54,7 @@ bool ModuleBuilder::AddModule(Module *m) {
 
 int ModuleBuilder::DestroyModule(Module *m, bool erase) {
   int ret;
-  m->Deinit();
+  m->DeInit();
 
   // disconnect from upstream modules.
   for (size_t i = 0; i < m->igates.size(); i++) {
@@ -203,6 +203,8 @@ pb_error_t Module::InitWithGenericArg(const google::protobuf::Any &arg) {
 pb_error_t Module::Init(const bess::pb::EmptyArg &) {
   return pb_errno(0);
 }
+
+void Module::DeInit() {}
 
 struct task_result Module::RunTask(void *) {
   CHECK(0);  // You must override this function

--- a/core/module.h
+++ b/core/module.h
@@ -160,7 +160,7 @@ class Module {
   virtual ~Module() {}
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
-  virtual void Deinit() {}
+  virtual void DeInit();
 
   virtual struct task_result RunTask(void *arg);
   virtual void ProcessBatch(bess::PacketBatch *batch);

--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -1118,7 +1118,7 @@ pb_error_t BPF::Init(const bess::pb::BPFArg &arg) {
   return response.error();
 }
 
-void BPF::Deinit() {
+void BPF::DeInit() {
   for (int i = 0; i < n_filters_; i++) {
     munmap(reinterpret_cast<void *>(filters_[i].func), filters_[i].mmap_size);
     free(filters_[i].exp);
@@ -1174,7 +1174,7 @@ pb_cmd_response_t BPF::CommandAdd(const bess::pb::BPFArg &arg) {
 }
 
 pb_cmd_response_t BPF::CommandClear(const bess::pb::EmptyArg &) {
-  Deinit();
+  DeInit();
   pb_cmd_response_t response;
   set_cmd_response_error(&response, pb_errno(0));
   return response;

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -21,11 +21,11 @@ class BPF final : public Module {
  public:
   static const gate_idx_t kNumOGates = MAX_GATES;
 
-  
+
   static const Commands cmds;
 
   pb_error_t Init(const bess::pb::BPFArg &arg);
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -21,13 +21,12 @@ class BPF final : public Module {
  public:
   static const gate_idx_t kNumOGates = MAX_GATES;
 
-
   static const Commands cmds;
 
   pb_error_t Init(const bess::pb::BPFArg &arg);
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::BPFArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/buffer.cc
+++ b/core/modules/buffer.cc
@@ -1,6 +1,6 @@
 #include "buffer.h"
 
-void Buffer::Deinit() {
+void Buffer::DeInit() {
   bess::PacketBatch *buf = &buf_;
 
   if (buf->cnt()) {

--- a/core/modules/buffer.h
+++ b/core/modules/buffer.h
@@ -8,9 +8,9 @@ class Buffer final : public Module {
  public:
   Buffer() : Module(), buf_() {}
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
   bess::PacketBatch buf_;

--- a/core/modules/buffer.h
+++ b/core/modules/buffer.h
@@ -8,7 +8,7 @@ class Buffer final : public Module {
  public:
   Buffer() : Module(), buf_() {}
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -11,7 +11,7 @@ class Bypass final : public Module {
   static const gate_idx_t kNumIGates = MAX_GATES;
   static const gate_idx_t kNumOGates = MAX_GATES;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_BYPASS_H_

--- a/core/modules/dump.h
+++ b/core/modules/dump.h
@@ -8,7 +8,7 @@ class Dump final : public Module {
  public:
   pb_error_t Init(const bess::pb::DumpArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandSetInterval(const bess::pb::DumpArg &arg);
 

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -92,7 +92,7 @@ pb_error_t ExactMatch::Init(const bess::pb::ExactMatchArg &arg) {
   return pb_errno(0);
 }
 
-void ExactMatch::Deinit() {
+void ExactMatch::DeInit() {
   ht_.Close();
 }
 

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -126,7 +126,7 @@ class ExactMatch final : public Module {
         fields_(),
         ht_() {}
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -126,11 +126,11 @@ class ExactMatch final : public Module {
         fields_(),
         ht_() {}
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
   pb_error_t Init(const bess::pb::ExactMatchArg &arg);
   pb_cmd_response_t CommandAdd(const bess::pb::ExactMatchCommandAddArg &arg);

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -300,7 +300,7 @@ pb_error_t FlowGen::Init(const bess::pb::FlowGenArg &arg) {
   return pb_errno(0);
 }
 
-void FlowGen::Deinit() {
+void FlowGen::DeInit() {
   mem_free(flows_);
   delete templ_;
 }

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -52,7 +52,7 @@ class FlowGen final : public Module {
 
   pb_error_t Init(const bess::pb::FlowGenArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual struct task_result RunTask(void *arg);
 

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -52,11 +52,11 @@ class FlowGen final : public Module {
 
   pb_error_t Init(const bess::pb::FlowGenArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg);
+  virtual struct task_result RunTask(void *arg) override;
 
-  std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
  private:
   inline double NewFlowPkts();

--- a/core/modules/generic_decap.h
+++ b/core/modules/generic_decap.h
@@ -10,7 +10,7 @@ class GenericDecap final : public Module {
 
   pb_error_t Init(const bess::pb::GenericDecapArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
   int decap_size_;

--- a/core/modules/hash_lb.h
+++ b/core/modules/hash_lb.h
@@ -23,7 +23,7 @@ class HashLB final : public Module {
 
   pb_error_t Init(const bess::pb::HashLBArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandSetMode(
       const bess::pb::HashLBCommandSetModeArg &arg);

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -8,7 +8,7 @@ class IPEncap final : public Module {
  public:
   pb_error_t Init(const bess::pb::IPEncapArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_IPENCAP_H_

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -35,7 +35,7 @@ pb_error_t IPLookup::Init(const bess::pb::EmptyArg &) {
   return pb_errno(0);
 }
 
-void IPLookup::Deinit() {
+void IPLookup::DeInit() {
   rte_lpm_free(lpm_);
 }
 

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -14,9 +14,9 @@ class IPLookup final : public Module {
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::IPLookupCommandAddArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -14,7 +14,7 @@ class IPLookup final : public Module {
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -549,7 +549,7 @@ pb_error_t L2Forward::Init(const bess::pb::L2ForwardArg &arg) {
   return pb_errno(0);
 }
 
-void L2Forward::Deinit() {
+void L2Forward::DeInit() {
   l2_deinit(&l2_table_);
 }
 

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -33,9 +33,9 @@ class L2Forward final : public Module {
 
   pb_error_t Init(const bess::pb::L2ForwardArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::L2ForwardCommandAddArg &arg);
   pb_cmd_response_t CommandDelete(

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -33,7 +33,7 @@ class L2Forward final : public Module {
 
   pb_error_t Init(const bess::pb::L2ForwardArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/macswap.h
+++ b/core/modules/macswap.h
@@ -5,7 +5,7 @@
 
 class MACSwap final : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_MACSWAP_H_

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -20,7 +20,7 @@ class Measure final : public Module {
 
   pb_error_t Init(const bess::pb::MeasureArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandGetSummary(const bess::pb::EmptyArg &arg);
 

--- a/core/modules/merge.h
+++ b/core/modules/merge.h
@@ -7,7 +7,7 @@ class Merge final : public Module {
  public:
   static const gate_idx_t kNumIGates = MAX_GATES;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_MERGE_H_

--- a/core/modules/noop.h
+++ b/core/modules/noop.h
@@ -8,7 +8,7 @@ class NoOP final : public Module {
  public:
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual struct task_result RunTask(void *arg);
+  virtual struct task_result RunTask(void *arg) override;
 
   static const gate_idx_t kNumIGates = 0;
   static const gate_idx_t kNumOGates = 0;

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -58,7 +58,7 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
   return pb_errno(0);
 }
 
-void PortInc::Deinit() {
+void PortInc::DeInit() {
   port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_INC,
                        nullptr, 0);
 }

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -15,7 +15,7 @@ class PortInc final : public Module {
 
   pb_error_t Init(const bess::pb::PortIncArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual struct task_result RunTask(void *arg);
 

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -15,11 +15,11 @@ class PortInc final : public Module {
 
   pb_error_t Init(const bess::pb::PortIncArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg);
+  virtual struct task_result RunTask(void *arg) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::PortIncCommandSetBurstArg &arg);

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -30,7 +30,7 @@ pb_error_t PortOut::Init(const bess::pb::PortOutArg &arg) {
   return pb_errno(0);
 }
 
-void PortOut::Deinit() {
+void PortOut::DeInit() {
   port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_OUT,
                        nullptr, 0);
 }

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -13,7 +13,7 @@ class PortOut final : public Module {
 
   pb_error_t Init(const bess::pb::PortOutArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -13,11 +13,11 @@ class PortOut final : public Module {
 
   pb_error_t Init(const bess::pb::PortOutArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
  private:
   Port *port_;

--- a/core/modules/queue.cc
+++ b/core/modules/queue.cc
@@ -86,7 +86,7 @@ pb_error_t Queue::Init(const bess::pb::QueueArg &arg) {
   return pb_errno(0);
 }
 
-void Queue::Deinit() {
+void Queue::DeInit() {
   bess::Packet *pkt;
 
   if (queue_) {

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -13,7 +13,7 @@ class Queue final : public Module {
 
   pb_error_t Init(const bess::pb::QueueArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual struct task_result RunTask(void *arg);
   virtual void ProcessBatch(bess::PacketBatch *batch);

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -13,12 +13,12 @@ class Queue final : public Module {
 
   pb_error_t Init(const bess::pb::QueueArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg);
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual struct task_result RunTask(void *arg) override;
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::QueueCommandSetBurstArg &arg);

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -48,7 +48,7 @@ pb_error_t QueueInc::Init(const bess::pb::QueueIncArg &arg) {
   return pb_errno(0);
 }
 
-void QueueInc::Deinit() {
+void QueueInc::DeInit() {
   port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_INC,
                        &qid_, 1);
 }

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -14,11 +14,11 @@ class QueueInc final : public Module {
   QueueInc() : Module(), port_(), qid_(), prefetch_(), burst_() {}
 
   pb_error_t Init(const bess::pb::QueueIncArg &arg);
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg);
+  virtual struct task_result RunTask(void *arg) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::QueueIncCommandSetBurstArg &arg);

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -14,7 +14,7 @@ class QueueInc final : public Module {
   QueueInc() : Module(), port_(), qid_(), prefetch_(), burst_() {}
 
   pb_error_t Init(const bess::pb::QueueIncArg &arg);
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual struct task_result RunTask(void *arg);
 

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -29,7 +29,7 @@ pb_error_t QueueOut::Init(const bess::pb::QueueOutArg &arg) {
   return pb_errno(0);
 }
 
-void QueueOut::Deinit() {
+void QueueOut::DeInit() {
   port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_OUT,
                        &qid_, 1);
 }

--- a/core/modules/queue_out.h
+++ b/core/modules/queue_out.h
@@ -13,7 +13,7 @@ class QueueOut final : public Module {
 
   pb_error_t Init(const bess::pb::QueueOutArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/queue_out.h
+++ b/core/modules/queue_out.h
@@ -13,11 +13,11 @@ class QueueOut final : public Module {
 
   pb_error_t Init(const bess::pb::QueueOutArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
  private:
   Port *port_;

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -15,7 +15,7 @@ class RandomUpdate final : public Module {
 
   pb_error_t Init(const bess::pb::RandomUpdateArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::RandomUpdateArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/rewrite.h
+++ b/core/modules/rewrite.h
@@ -20,7 +20,7 @@ class Rewrite final : public Module {
 
   pb_error_t Init(const bess::pb::RewriteArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::RewriteArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/round_robin.h
+++ b/core/modules/round_robin.h
@@ -42,7 +42,7 @@ class RoundRobin final : public Module {
 
   pb_error_t Init(const bess::pb::RoundRobinArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   /*!
    * Switches the RoundRobin module between "batch" vs "packet" scheduling.

--- a/core/modules/sink.h
+++ b/core/modules/sink.h
@@ -7,7 +7,7 @@ class Sink final : public Module {
  public:
   static const gate_idx_t kNumOGates = 0;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_SINK_H_

--- a/core/modules/source.h
+++ b/core/modules/source.h
@@ -14,7 +14,7 @@ class Source final : public Module {
 
   pb_error_t Init(const bess::pb::SourceArg &arg);
 
-  virtual struct task_result RunTask(void *arg);
+  virtual struct task_result RunTask(void *arg) override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::SourceCommandSetBurstArg &arg);

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -5,7 +5,7 @@
 
 class Timestamp final : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_TIMESTAMP_H_

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -14,7 +14,7 @@ class Update final : public Module {
 
   pb_error_t Init(const bess::pb::UpdateArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::UpdateArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/vlan_pop.h
+++ b/core/modules/vlan_pop.h
@@ -5,7 +5,7 @@
 
 class VLANPop final : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VLANPOP_H_

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -12,9 +12,9 @@ class VLANPush final : public Module {
 
   pb_error_t Init(const bess::pb::VLANPushArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetTci(const bess::pb::VLANPushArg &arg);
 

--- a/core/modules/vlan_split.h
+++ b/core/modules/vlan_split.h
@@ -7,7 +7,7 @@ class VLANSplit final : public Module {
  public:
   static const gate_idx_t kNumOGates = 4096;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VLANSPLIT_H_

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -12,7 +12,7 @@ class VXLANEncap final : public Module {
 
   pb_error_t Init(const bess::pb::VXLANEncapArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
   uint16_t dstport_;

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -110,7 +110,7 @@ pb_error_t WildcardMatch::Init(const bess::pb::WildcardMatchArg &arg) {
   return pb_errno(0);
 }
 
-void WildcardMatch::Deinit() {
+void WildcardMatch::DeInit() {
   for (auto &tuple : tuples_) {
     tuple.ht.Close();
   }

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -57,11 +57,11 @@ class WildcardMatch final : public Module {
 
   pb_error_t Init(const bess::pb::WildcardMatchArg &arg);
 
-  virtual void DeInit();
+  virtual void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch);
+  virtual void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const;
+  virtual std::string GetDesc() const override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::WildcardMatchCommandAddArg &arg);
   pb_cmd_response_t CommandDelete(

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -57,7 +57,7 @@ class WildcardMatch final : public Module {
 
   pb_error_t Init(const bess::pb::WildcardMatchArg &arg);
 
-  virtual void Deinit();
+  virtual void DeInit();
 
   virtual void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/port.cc
+++ b/core/port.cc
@@ -130,7 +130,7 @@ const std::map<std::string, Port *> &PortBuilder::all_ports() {
 
 void Port::CollectStats(bool) {}
 
-pb_error_t Port::Init(const google::protobuf::Any &arg) {
+pb_error_t Port::InitWithGenericArg(const google::protobuf::Any &arg) {
   return port_builder_->RunInit(this, arg);
 }
 

--- a/core/port.cc
+++ b/core/port.cc
@@ -37,7 +37,7 @@ int PortBuilder::DestroyPort(Port *p) {
   }
 
   all_ports_.erase(p->name());
-  p->Deinit();
+  p->DeInit();
   delete p;
 
   return 0;

--- a/core/port.cc
+++ b/core/port.cc
@@ -138,6 +138,8 @@ pb_error_t Port::Init(const bess::pb::EmptyArg &) {
   return pb_errno(0);
 }
 
+void Port::DeInit() {}
+
 int Port::RecvPackets(queue_t, bess::Packet **, int) {
   return 0;
 }

--- a/core/port.h
+++ b/core/port.h
@@ -169,8 +169,6 @@ class Port {
 
   virtual ~Port() {}
 
-  pb_error_t Init(const google::protobuf::Any &arg);
-
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
   virtual void DeInit() {}
@@ -193,6 +191,8 @@ class Port {
 
  public:
   friend class PortBuilder;
+
+  pb_error_t InitWithGenericArg(const google::protobuf::Any &arg);
 
   // Fills in pointed-to structure with this port's stats.
   void GetPortStats(port_stats_t *stats);

--- a/core/port.h
+++ b/core/port.h
@@ -171,7 +171,7 @@ class Port {
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual void DeInit() {}
+  virtual void DeInit();
 
   // For one-time initialization of the port's "driver" (optional).
   virtual void InitDriver() {}

--- a/core/port.h
+++ b/core/port.h
@@ -173,7 +173,7 @@ class Port {
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual void Deinit() {}
+  virtual void DeInit() {}
 
   // For one-time initialization of the port's "driver" (optional).
   virtual void InitDriver() {}

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -76,7 +76,7 @@ TEST_F(PortTest, CreatePort) {
   bess::pb::EmptyArg arg_;
   google::protobuf::Any arg;
   arg.PackFrom(arg_);
-  pb_error_t err = p->Init(arg);
+  pb_error_t err = p->InitWithGenericArg(arg);
   EXPECT_EQ(42, err.err());
 }
 

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -15,7 +15,7 @@ class DummyPort : public Port {
 
   pb_error_t Init(const google::protobuf::Any &) { return pb_errno(42); }
 
-  virtual void Deinit() {
+  virtual void DeInit() {
     if (deinited_)
       *deinited_ = true;
   }


### PR DESCRIPTION
Some modules and port drivers uses `DeInit`, while others use `Deinit`. As a result, sometimes the `DeInit` function of the base class (`Module` and `Port`) gets called when it is not supposed to. This patch should fix #162.