### PR TITLE
Canonicalize C++ code as per style guide

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1,12 +1,13 @@
 #include "bessctl.h"
 
-#include <map>
-
 #include <glog/logging.h>
 #include <grpc++/server.h>
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
 #include <grpc/grpc.h>
+
+#include <map>
+#include <string>
 
 #include "gate.h"
 #include "hooks/track.h"
@@ -491,9 +492,9 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     if (!is_worker_active(wid)) {
-      if (num_workers == 0 && wid == 0)
+      if (num_workers == 0 && wid == 0) {
         launch_worker(wid, FLAGS_c);
-      else {
+      } else {
         return return_with_error(response, EINVAL, "worker:%d does not exist",
                                  wid);
       }
@@ -891,7 +892,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
     response->set_desc(m->GetDesc());
 
-    // TODO: Dump!
+    // TODO(clan): Dump!
 
     collect_igates(m, response);
     collect_ogates(m, response);

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -132,9 +132,8 @@ void WritePidfile(int fd, pid_t pid) {
     PLOG(FATAL) << "lseek(pidfile, 0, SEEK_SET)";
   }
 
-  char buf[BUFSIZ];
-  int pidlen = snprintf(buf, BUFSIZ, "%d\n", pid);
-  if (write(fd, buf, pidlen) < 0) {
+  std::string pid_str = std::to_string(pid) + "\n";
+  if (write(fd, pid_str.data(), pid_str.size() + 1) < 0) {
     PLOG(FATAL) << "write(pidfile, pid)";
   }
   fsync(fd);

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -5,15 +5,17 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <glog/logging.h>
+
+#include <algorithm>
 #include <cerrno>
 #include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <string>
 #include <tuple>
-
-#include <glog/logging.h>
 
 #include "debug.h"
 #include "opts.h"
@@ -48,7 +50,7 @@ class StreambufLogger : public std::streambuf {
   StreambufLogger(std::ostream &stream, google::LogSeverity severity)
       : stream_(stream), log_level_(severity) {
     org_streambuf_ = stream_.rdbuf(this);
-  };
+  }
 
   // Restores the original streambuf
   virtual ~StreambufLogger() { stream_.rdbuf(org_streambuf_); }
@@ -131,7 +133,7 @@ void WritePidfile(int fd, pid_t pid) {
   }
 
   char buf[BUFSIZ];
-  int pidlen = sprintf(buf, "%d\n", pid);
+  int pidlen = snprintf(buf, BUFSIZ, "%d\n", pid);
   if (write(fd, buf, pidlen) < 0) {
     PLOG(FATAL) << "write(pidfile, pid)";
   }
@@ -149,7 +151,8 @@ std::tuple<bool, pid_t> ReadPidfile(int fd) {
     if (readlen < 0) {
       PLOG(ERROR) << "read(pidfile=" << FLAGS_i << ")";
     } else {
-      LOG(ERROR) << "read(pidfile=" << FLAGS_i << ")" << " at EOF";
+      LOG(ERROR) << "read(pidfile=" << FLAGS_i << ")"
+                 << " at EOF";
     }
 
     return std::make_tuple(false, 0);
@@ -240,7 +243,7 @@ int CheckUniqueInstance(const std::string &pidfile_path) {
 }
 
 static void CloseStdStreams() {
-	int fd = open("/dev/null", O_RDWR, 0);
+  int fd = open("/dev/null", O_RDWR, 0);
   if (fd < 0) {
     PLOG(ERROR) << "Cannot open /dev/null";
     return;
@@ -257,9 +260,9 @@ static void CloseStdStreams() {
   cookie_io_functions_t stdout_funcs = {
       .read = nullptr,
       .write = [](void *, const char *data, size_t len) -> ssize_t {
-				LOG(INFO) << std::string(data, len);
-				return len;
-			},
+        LOG(INFO) << std::string(data, len);
+        return len;
+      },
       .seek = nullptr,
       .close = nullptr,
   };
@@ -267,9 +270,9 @@ static void CloseStdStreams() {
   cookie_io_functions_t stderr_funcs = {
       .read = nullptr,
       .write = [](void *, const char *data, size_t len) -> ssize_t {
-				LOG(WARNING) << std::string(data, len);
-				return len;
-			},
+        LOG(WARNING) << std::string(data, len);
+        return len;
+      },
       .seek = nullptr,
       .close = nullptr,
   };
@@ -289,8 +292,8 @@ static void CloseStdStreams() {
   setvbuf(stderr, NULL, _IOLBF, 0);
 
   // Redirect stdout output to LOG(INFO) and stderr output to LOG(WARNING)
-	static StreambufLogger stdout_buf(std::cout, google::GLOG_INFO);
-	static StreambufLogger stderr_buf(std::cerr, google::GLOG_WARNING);
+  static StreambufLogger stdout_buf(std::cout, google::GLOG_INFO);
+  static StreambufLogger stderr_buf(std::cerr, google::GLOG_WARNING);
 
   // For whatever reason if fd happens to be assigned 0, 1, or 2, do not close
   // it since it now points to our custom handler

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -3,6 +3,7 @@
 #ifndef BESS_BESSD_H_
 #define BESS_BESSD_H_
 
+#include <string>
 #include <tuple>
 
 namespace bess {

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -3,17 +3,17 @@
 #include <syslog.h>
 #include <unistd.h>
 
-#include <cassert>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <string>
-
 #include <glog/logging.h>
 #include <rte_config.h>
 #include <rte_cycles.h>
 #include <rte_eal.h>
 #include <rte_ethdev.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
 
 #include "utils/time.h"
 #include "worker.h"
@@ -82,16 +82,19 @@ static void init_eal(const char *prog_name, int mb_per_socket,
 
   FILE *org_stdout;
 
-  sprintf(opt_master_lcore, "%d", RTE_MAX_LCORE - 1);
-  sprintf(opt_lcore_bitmap, "%d@%d", RTE_MAX_LCORE - 1, 0);
+  snprintf(opt_master_lcore, sizeof(opt_master_lcore), "%d", RTE_MAX_LCORE - 1);
+  snprintf(opt_lcore_bitmap, sizeof(opt_lcore_bitmap), "%d@%d",
+           RTE_MAX_LCORE - 1, 0);
 
   if (mb_per_socket <= 0) {
     mb_per_socket = 2048;
   }
 
-  sprintf(opt_socket_mem, "%d", mb_per_socket);
+  snprintf(opt_socket_mem, sizeof(opt_socket_mem), "%d", mb_per_socket);
   for (i = 1; i < numa_count; i++) {
-    sprintf(opt_socket_mem + strlen(opt_socket_mem), ",%d", mb_per_socket);
+    auto len = strlen(opt_socket_mem);
+    snprintf(opt_socket_mem + len, sizeof(opt_socket_mem) - len, ",%d",
+             mb_per_socket);
   }
 
   rte_argv[rte_argc++] = prog_name;
@@ -108,7 +111,8 @@ static void init_eal(const char *prog_name, int mb_per_socket,
     rte_argv[rte_argc++] = opt_socket_mem;
   }
   if (!no_huge && multi_instance) {
-    sprintf(opt_file_prefix, "rte%lld", (long long)getpid());
+    snprintf(opt_file_prefix, sizeof(opt_file_prefix), "rte%lld",
+             (long long)getpid());
     /* Casting to long long isn't guaranteed by POSIX to not lose
      * any information, but should be okay for Linux and BSDs for
      * the foreseeable future. */

--- a/core/drivers/pcap.h
+++ b/core/drivers/pcap.h
@@ -15,11 +15,11 @@ class PCAPPort final : public Port {
  public:
   pb_error_t Init(const bess::pb::PCAPPortArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
   // PCAP has no notion of queue so unlike parent (port.cc) quid is ignored.
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
   // Ditto above: quid is ignored.
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   void GatherData(unsigned char *data, bess::Packet *pkt);

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -21,7 +21,7 @@ class PMDPort final : public Port {
   /*!
   * Binds to device; call this after Init()
   */
-  virtual void InitDriver() override;
+  void InitDriver() override;
 
   /*!
    * Initialize the port. Doesn't actually bind to the device, just grabs all
@@ -42,7 +42,7 @@ class PMDPort final : public Port {
   /*!
    * Release the device.
    */
-  virtual void DeInit() override;
+  void DeInit() override;
 
   /*!
    * Copies rte port statistics into queue_stats datastructure (see port.h).
@@ -51,7 +51,7 @@ class PMDPort final : public Port {
    * * bool reset : if true, reset DPDK local statistics and return (do not
    * collect stats).
    */
-  virtual void CollectStats(bool reset) override;
+  void CollectStats(bool reset) override;
 
   /*!
    * Receives packets from the device.
@@ -68,7 +68,7 @@ class PMDPort final : public Port {
    * RETURNS:
    * * Total number of packets received (<=cnt)
    */
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
   /*!
    * Sends packets out on the device.
@@ -85,7 +85,7 @@ class PMDPort final : public Port {
    * RETURNS:
    * * Total number of packets sent (<=cnt).
    */
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   /*!

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -41,7 +41,7 @@ class UnixSocketPort final : public Port {
   /*!
    * Close the socket / shut down the port.
    */
-  virtual void DeInit() override;
+  void DeInit() override;
 
   /*!
    * Receives packets from the device.
@@ -58,7 +58,7 @@ class UnixSocketPort final : public Port {
    * RETURNS:
    * * Total number of packets received (<=cnt)
    */
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
   /*!
    * Sends packets out on the device.
@@ -75,7 +75,7 @@ class UnixSocketPort final : public Port {
    * RETURNS:
    * * Total number of packets sent (<=cnt).
    */
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
   /*!
    * Waits for a client to connect to the socket.

--- a/core/drivers/vport.h
+++ b/core/drivers/vport.h
@@ -7,14 +7,14 @@
 class VPort final : public Port {
  public:
   VPort() : fd_(), bar_(), map_(), netns_fd_(), container_pid_() {}
-  virtual void InitDriver() override;
+  void InitDriver() override;
 
   pb_error_t Init(const bess::pb::VPortArg &arg);
-  virtual void DeInit() override;
+  void DeInit() override;
 
   virtual int RecvPackets(queue_t qid, bess::Packet **pkts,
                           int max_cnt) override;
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   struct queue {

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -1,6 +1,7 @@
 #include "gate.h"
 
 #include <algorithm>
+#include <string>
 
 namespace bess {
 
@@ -51,4 +52,4 @@ void IGate::RemoveOgate(const OGate *og) {
     }
   }
 }
-}
+}  // namespace bess

--- a/core/gate.h
+++ b/core/gate.h
@@ -1,6 +1,7 @@
 #ifndef BESS_GATE_H_
 #define BESS_GATE_H_
 
+#include <string>
 #include <vector>
 
 #include "pktbatch.h"
@@ -31,7 +32,8 @@ class Gate;
 // can attach/detach them at runtime.
 class GateHook {
  public:
-  GateHook(const std::string &name, uint16_t priority = 0, Gate *gate = nullptr)
+  explicit GateHook(const std::string &name, uint16_t priority = 0,
+                    Gate *gate = nullptr)
       : gate_(gate), name_(name), priority_(priority) {}
 
   virtual ~GateHook() {}

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -88,4 +88,4 @@ TEST_F(IOGateTest, IGate) {
   ig->RemoveOgate(og);
   ASSERT_EQ(0, ig->ogates_upstream().size());
 }
-}
+}  // namespace bess

--- a/core/mem_alloc.cc
+++ b/core/mem_alloc.cc
@@ -8,10 +8,10 @@
 
 #if MEM_ALLOC_PROVIDER == LIBC
 
+#include <malloc.h>
+
 #include <cstdlib>
 #include <cstring>
-
-#include <malloc.h>
 
 void *mem_alloc(size_t size) {
   return calloc(1, size);
@@ -45,7 +45,9 @@ void *mem_realloc(void *ptr, size_t size) {
   return rte_realloc(ptr, size, /* align= */ 0);
 }
 
-void mem_free(void *ptr) { rte_free(ptr); }
+void mem_free(void *ptr) {
+  rte_free(ptr);
+}
 
 #else
 

--- a/core/message.cc
+++ b/core/message.cc
@@ -1,5 +1,7 @@
 #include "message.h"
 
+#include <string>
+
 #include "utils/format.h"
 
 pb_error_t pb_error_details(int code, const char *details, const char *fmt,

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -1,10 +1,10 @@
 #include "metadata.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <functional>
 #include <queue>
-
-#include <glog/logging.h>
 
 #include "mem_alloc.h"
 #include "module.h"
@@ -61,7 +61,8 @@ static inline attr_id_t get_attr_id(const struct Attribute *attr) {
 
 class ScopeComponentComp {
  public:
-  ScopeComponentComp(const bool &revparam = false) : reverse_(revparam) {}
+  explicit ScopeComponentComp(const bool &revparam = false)
+      : reverse_(revparam) {}
 
   bool operator()(const ScopeComponent *lhs, const ScopeComponent *rhs) const {
     if (reverse_) {
@@ -369,7 +370,7 @@ void Pipeline::LogAllScopes() const {
   for (size_t i = 0; i < scope_components_.size(); i++) {
     VLOG(1) << "scope component for " << scope_components_[i].size()
             << "-byte attr " << scope_components_[i].attr_id() << " at offset "
-            << (int)scope_components_[i].offset() << ": {";
+            << static_cast<int>(scope_components_[i].offset()) << ": {";
 
     for (const auto &it : scope_components_[i].modules()) {
       VLOG(1) << it->name();

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -52,11 +52,7 @@ struct Attribute {
 
   std::string name;
   size_t size;  // in bytes
-  enum class AccessMode {
-    kRead = 0,
-    kWrite,
-    kUpdate
-  } mode;
+  enum class AccessMode { kRead = 0, kWrite, kUpdate } mode;
   mutable int scope_id;
 };
 
@@ -74,32 +70,32 @@ class ScopeComponent {
         modules_(),
         degree_() {}
 
-  ~ScopeComponent(){};
+  ~ScopeComponent() {}
 
-  const attr_id_t &attr_id() const { return attr_id_; };
-  void set_attr_id(attr_id_t id) { attr_id_ = id; };
+  const attr_id_t &attr_id() const { return attr_id_; }
+  void set_attr_id(attr_id_t id) { attr_id_ = id; }
 
-  int size() const { return size_; };
-  void set_size(int size) { size_ = size; };
+  int size() const { return size_; }
+  void set_size(int size) { size_ = size; }
 
-  mt_offset_t offset() const { return offset_; };
-  void set_offset(mt_offset_t offset) { offset_ = offset; };
+  mt_offset_t offset() const { return offset_; }
+  void set_offset(mt_offset_t offset) { offset_ = offset; }
 
-  scope_id_t scope_id() const { return scope_id_; };
-  void set_scope_id(scope_id_t id) { scope_id_ = id; };
+  scope_id_t scope_id() const { return scope_id_; }
+  void set_scope_id(scope_id_t id) { scope_id_ = id; }
 
-  bool assigned() const { return assigned_; };
-  void set_assigned(bool assigned) { assigned_ = assigned; };
+  bool assigned() const { return assigned_; }
+  void set_assigned(bool assigned) { assigned_ = assigned; }
 
-  bool invalid() const { return invalid_; };
-  void set_invalid(bool invalid) { invalid_ = invalid; };
+  bool invalid() const { return invalid_; }
+  void set_invalid(bool invalid) { invalid_ = invalid; }
 
-  const std::set<Module *> &modules() const { return modules_; };
-  void add_module(Module *m) { modules_.insert(m); };
-  void clear_modules() { modules_.clear(); };
+  const std::set<Module *> &modules() const { return modules_; }
+  void add_module(Module *m) { modules_.insert(m); }
+  void clear_modules() { modules_.clear(); }
 
-  int degree() const { return degree_; };
-  void incr_degree() { degree_++; };
+  int degree() const { return degree_; }
+  void incr_degree() { degree_++; }
 
   bool DisjointFrom(const ScopeComponent &rhs);
 
@@ -183,8 +179,7 @@ class Pipeline {
   // count(=int) represents how many modules registered the attribute, and the
   // attribute is deregistered once it reaches back to 0.
   // Those modules should agree on the same size(=size_t).
-  std::map<std::string, std::tuple<size_t, int> >
-      registered_attrs_;
+  std::map<std::string, std::tuple<size_t, int> > registered_attrs_;
 };
 
 extern bess::metadata::Pipeline default_pipeline;

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -1,9 +1,9 @@
 #include "metadata.h"
 
+#include <gtest/gtest.h>
+
 #include <cstdlib>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include "module.h"
 
@@ -37,7 +37,7 @@ Module *create_foo(const std::string name = "") {
 
   return m;
 }
-}
+}  // namespace
 
 namespace bess {
 namespace metadata {
@@ -103,7 +103,7 @@ TEST_F(MetadataTest, DisconnectedFails) {
   ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, Attribute::AccessMode::kWrite));
   ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, Attribute::AccessMode::kRead));
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
-  ASSERT_TRUE(m1->attr_offsets[0] < 0);
+  ASSERT_LT(m1->attr_offsets[0], 0);
 }
 
 TEST_F(MetadataTest, SingleAttrSimplePipe) {
@@ -114,7 +114,7 @@ TEST_F(MetadataTest, SingleAttrSimplePipe) {
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
   // Check that m0 was assigned a valid offset
-  ASSERT_TRUE(m1->attr_offsets[0] >= 0);
+  ASSERT_GE(m1->attr_offsets[0], 0);
 
   // Check that m0 and m1 agree on where to read/write a
   ASSERT_EQ(m0->attr_offsets[0], m1->attr_offsets[0]);

--- a/core/module.cc
+++ b/core/module.cc
@@ -4,10 +4,10 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <sstream>
-
-#include <glog/logging.h>
 
 #include "gate.h"
 #include "hooks/tcpdump.h"

--- a/core/module.h
+++ b/core/module.h
@@ -292,7 +292,7 @@ inline void Module::RunChooseModule(gate_idx_t ogate_idx,
   }
 
   ctx.set_current_igate(ogate->igate_idx());
-  (reinterpret_cast<Module *>(ogate->arg()))->ProcessBatch(batch);
+  (static_cast<Module *>(ogate->arg()))->ProcessBatch(batch);
 }
 
 inline void Module::RunNextModule(bess::PacketBatch *batch) {

--- a/core/module_bench.cc
+++ b/core/module_bench.cc
@@ -9,7 +9,7 @@ namespace {
 
 class DummySourceModule : public Module {
  public:
-  virtual struct task_result RunTask(void *arg) override;
+  struct task_result RunTask(void *arg) override;
 };
 
 [[gnu::noinline]] struct task_result DummySourceModule::RunTask(void *arg) {
@@ -38,7 +38,7 @@ class DummySourceModule : public Module {
 
 class DummyRelayModule : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 [[gnu::noinline]] void DummyRelayModule::ProcessBatch(
@@ -49,7 +49,7 @@ class DummyRelayModule : public Module {
 // Simple harness for testing the Module class.
 class ModuleFixture : public benchmark::Fixture {
  protected:
-  virtual void SetUp(benchmark::State &state) override {
+  void SetUp(benchmark::State &state) override {
     const int chain_length = state.range(0);
 
     ADD_MODULE(DummySourceModule, "src", "the most sophisticated modue ever");
@@ -79,7 +79,7 @@ class ModuleFixture : public benchmark::Fixture {
     }
   }
 
-  virtual void TearDown(benchmark::State &) override {
+  void TearDown(benchmark::State &) override {
     ModuleBuilder::DestroyAllModules();
     ModuleBuilder::all_module_builders_holder(true);
   }

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -155,7 +155,7 @@ TEST_F(ModuleTester, RunCommand) {
     response = m->RunCommand("foo", arg);
     EXPECT_EQ(0, response.error().err());
   }
-  EXPECT_EQ(10, (reinterpret_cast<AcmeModule *>(m))->n);
+  EXPECT_EQ(10, (static_cast<AcmeModule *>(m))->n);
 
   response = m->RunCommand("bar", arg);
   EXPECT_EQ(ENOTSUP, response.error().err());

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -155,7 +155,7 @@ TEST_F(ModuleTester, RunCommand) {
     response = m->RunCommand("foo", arg);
     EXPECT_EQ(0, response.error().err());
   }
-  EXPECT_EQ(10, ((AcmeModule *)m)->n);
+  EXPECT_EQ(10, (reinterpret_cast<AcmeModule *>(m))->n);
 
   response = m->RunCommand("bar", arg);
   EXPECT_EQ(ENOTSUP, response.error().err());

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -24,9 +24,9 @@ class BPF final : public Module {
   static const Commands cmds;
 
   pb_error_t Init(const bess::pb::BPFArg &arg);
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::BPFArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/buffer.h
+++ b/core/modules/buffer.h
@@ -8,9 +8,9 @@ class Buffer final : public Module {
  public:
   Buffer() : Module(), buf_() {}
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
   bess::PacketBatch buf_;

--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -11,7 +11,7 @@ class Bypass final : public Module {
   static const gate_idx_t kNumIGates = MAX_GATES;
   static const gate_idx_t kNumOGates = MAX_GATES;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_BYPASS_H_

--- a/core/modules/dump.h
+++ b/core/modules/dump.h
@@ -8,7 +8,7 @@ class Dump final : public Module {
  public:
   pb_error_t Init(const bess::pb::DumpArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandSetInterval(const bess::pb::DumpArg &arg);
 

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -126,11 +126,11 @@ class ExactMatch final : public Module {
         fields_(),
         ht_() {}
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
   pb_error_t Init(const bess::pb::ExactMatchArg &arg);
   pb_cmd_response_t CommandAdd(const bess::pb::ExactMatchCommandAddArg &arg);

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -57,11 +57,11 @@ class FlowGen final : public Module {
 
   pb_error_t Init(const bess::pb::FlowGenArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg) override;
+  struct task_result RunTask(void *arg) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
  private:
   inline double NewFlowPkts();

--- a/core/modules/generic_decap.h
+++ b/core/modules/generic_decap.h
@@ -10,7 +10,7 @@ class GenericDecap final : public Module {
 
   pb_error_t Init(const bess::pb::GenericDecapArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
   int decap_size_;

--- a/core/modules/hash_lb.h
+++ b/core/modules/hash_lb.h
@@ -23,7 +23,7 @@ class HashLB final : public Module {
 
   pb_error_t Init(const bess::pb::HashLBArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandSetMode(
       const bess::pb::HashLBCommandSetModeArg &arg);

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -8,7 +8,7 @@ class IPEncap final : public Module {
  public:
   pb_error_t Init(const bess::pb::IPEncapArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_IPENCAP_H_

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -14,9 +14,9 @@ class IPLookup final : public Module {
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::IPLookupCommandAddArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -33,9 +33,9 @@ class L2Forward final : public Module {
 
   pb_error_t Init(const bess::pb::L2ForwardArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::L2ForwardCommandAddArg &arg);
   pb_cmd_response_t CommandDelete(

--- a/core/modules/macswap.h
+++ b/core/modules/macswap.h
@@ -5,7 +5,7 @@
 
 class MACSwap final : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_MACSWAP_H_

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -20,7 +20,7 @@ class Measure final : public Module {
 
   pb_error_t Init(const bess::pb::MeasureArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandGetSummary(const bess::pb::EmptyArg &arg);
 

--- a/core/modules/merge.h
+++ b/core/modules/merge.h
@@ -7,7 +7,7 @@ class Merge final : public Module {
  public:
   static const gate_idx_t kNumIGates = MAX_GATES;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_MERGE_H_

--- a/core/modules/noop.h
+++ b/core/modules/noop.h
@@ -8,7 +8,7 @@ class NoOP final : public Module {
  public:
   pb_error_t Init(const bess::pb::EmptyArg &arg);
 
-  virtual struct task_result RunTask(void *arg) override;
+  struct task_result RunTask(void *arg) override;
 
   static const gate_idx_t kNumIGates = 0;
   static const gate_idx_t kNumOGates = 0;

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -15,11 +15,11 @@ class PortInc final : public Module {
 
   pb_error_t Init(const bess::pb::PortIncArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg) override;
+  struct task_result RunTask(void *arg) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::PortIncCommandSetBurstArg &arg);

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -13,11 +13,11 @@ class PortOut final : public Module {
 
   pb_error_t Init(const bess::pb::PortOutArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
  private:
   Port *port_;

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -13,12 +13,12 @@ class Queue final : public Module {
 
   pb_error_t Init(const bess::pb::QueueArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg) override;
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  struct task_result RunTask(void *arg) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::QueueCommandSetBurstArg &arg);

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -14,11 +14,11 @@ class QueueInc final : public Module {
   QueueInc() : Module(), port_(), qid_(), prefetch_(), burst_() {}
 
   pb_error_t Init(const bess::pb::QueueIncArg &arg);
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual struct task_result RunTask(void *arg) override;
+  struct task_result RunTask(void *arg) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::QueueIncCommandSetBurstArg &arg);

--- a/core/modules/queue_out.h
+++ b/core/modules/queue_out.h
@@ -13,11 +13,11 @@ class QueueOut final : public Module {
 
   pb_error_t Init(const bess::pb::QueueOutArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
  private:
   Port *port_;

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -15,7 +15,7 @@ class RandomUpdate final : public Module {
 
   pb_error_t Init(const bess::pb::RandomUpdateArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::RandomUpdateArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/rewrite.h
+++ b/core/modules/rewrite.h
@@ -20,7 +20,7 @@ class Rewrite final : public Module {
 
   pb_error_t Init(const bess::pb::RewriteArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::RewriteArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/round_robin.h
+++ b/core/modules/round_robin.h
@@ -42,7 +42,7 @@ class RoundRobin final : public Module {
 
   pb_error_t Init(const bess::pb::RoundRobinArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   /*!
    * Switches the RoundRobin module between "batch" vs "packet" scheduling.

--- a/core/modules/sink.h
+++ b/core/modules/sink.h
@@ -7,7 +7,7 @@ class Sink final : public Module {
  public:
   static const gate_idx_t kNumOGates = 0;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_SINK_H_

--- a/core/modules/source.h
+++ b/core/modules/source.h
@@ -14,7 +14,7 @@ class Source final : public Module {
 
   pb_error_t Init(const bess::pb::SourceArg &arg);
 
-  virtual struct task_result RunTask(void *arg) override;
+  struct task_result RunTask(void *arg) override;
 
   pb_cmd_response_t CommandSetBurst(
       const bess::pb::SourceCommandSetBurstArg &arg);

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -5,7 +5,7 @@
 
 class Timestamp final : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_TIMESTAMP_H_

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -14,7 +14,7 @@ class Update final : public Module {
 
   pb_error_t Init(const bess::pb::UpdateArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::UpdateArg &arg);
   pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/vlan_pop.h
+++ b/core/modules/vlan_pop.h
@@ -5,7 +5,7 @@
 
 class VLANPop final : public Module {
  public:
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VLANPOP_H_

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -12,9 +12,9 @@ class VLANPush final : public Module {
 
   pb_error_t Init(const bess::pb::VLANPushArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
   pb_cmd_response_t CommandSetTci(const bess::pb::VLANPushArg &arg);
 

--- a/core/modules/vlan_split.h
+++ b/core/modules/vlan_split.h
@@ -7,7 +7,7 @@ class VLANSplit final : public Module {
  public:
   static const gate_idx_t kNumOGates = 4096;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VLANSPLIT_H_

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -12,7 +12,7 @@ class VXLANEncap final : public Module {
 
   pb_error_t Init(const bess::pb::VXLANEncapArg &arg);
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
   uint16_t dstport_;

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -57,11 +57,11 @@ class WildcardMatch final : public Module {
 
   pb_error_t Init(const bess::pb::WildcardMatchArg &arg);
 
-  virtual void DeInit() override;
+  void DeInit() override;
 
-  virtual void ProcessBatch(bess::PacketBatch *batch) override;
+  void ProcessBatch(bess::PacketBatch *batch) override;
 
-  virtual std::string GetDesc() const override;
+  std::string GetDesc() const override;
 
   pb_cmd_response_t CommandAdd(const bess::pb::WildcardMatchCommandAddArg &arg);
   pb_cmd_response_t CommandDelete(

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -1,8 +1,8 @@
 #include "opts.h"
 
-#include <cstdint>
-
 #include <glog/logging.h>
+
+#include <cstdint>
 
 #include "worker.h"
 

--- a/core/packet.h
+++ b/core/packet.h
@@ -1,12 +1,14 @@
 #ifndef BESS_PACKET_H_
 #define BESS_PACKET_H_
 
-#include <cassert>
-#include <type_traits>
-
 #include <rte_atomic.h>
 #include <rte_config.h>
 #include <rte_mbuf.h>
+
+#include <algorithm>
+#include <cassert>
+#include <string>
+#include <type_traits>
 
 #include "metadata.h"
 #include "worker.h"
@@ -364,7 +366,8 @@ int Packet::Alloc(Packet **pkts, size_t cnt, uint16_t len) {
   int ret;
   size_t i;
 
-  ret = rte_mempool_get_bulk(ctx.pframe_pool(), (void **)pkts, cnt);
+  ret = rte_mempool_get_bulk(ctx.pframe_pool(), reinterpret_cast<void **>(pkts),
+                             cnt);
   if (ret != 0)
     return 0;
 
@@ -396,7 +399,7 @@ void Packet::Free(Packet **pkts, int cnt) {
 
   /* NOTE: it seems that zeroing the refcnt of mbufs is not necessary.
    *   (allocators will reset them) */
-  rte_mempool_put_bulk(pool, (void **)pkts, cnt);
+  rte_mempool_put_bulk(pool, reinterpret_cast<void **>(pkts), cnt);
   return;
 
 slow_path:

--- a/core/packet_avx.h
+++ b/core/packet_avx.h
@@ -22,7 +22,8 @@ int Packet::Alloc(Packet **pkts, size_t cnt, uint16_t len) {
    * rss 			0 	(32 bits) */
   rxdesc_fields = _mm_setr_epi32(0, len, len, 0);
 
-  ret = rte_mempool_get_bulk(ctx.pframe_pool(), (void **)pkts, cnt);
+  ret = rte_mempool_get_bulk(ctx.pframe_pool(), reinterpret_cast<void **>(pkts),
+                             cnt);
   if (ret != 0)
     return 0;
 
@@ -120,7 +121,7 @@ void Packet::Free(Packet **pkts, int cnt) {
 
   /* NOTE: it seems that zeroing the refcnt of mbufs is not necessary.
    *   (allocators will reset them) */
-  rte_mempool_put_bulk(_pool, (void **)pkts, cnt);
+  rte_mempool_put_bulk(_pool, reinterpret_cast<void **>(pkts), cnt);
   return;
 
 slow_path:

--- a/core/pktbatch.h
+++ b/core/pktbatch.h
@@ -28,7 +28,9 @@ class PacketBatch {
     int cnt = src->cnt_;
 
     cnt_ = cnt;
-    rte_memcpy((void *)pkts_, (void *)src->pkts_, cnt * sizeof(Packet *));
+    rte_memcpy(reinterpret_cast<void *>(pkts_),
+               reinterpret_cast<const void *>(src->pkts_),
+               cnt * sizeof(Packet *));
   }
 
   static const size_t kMaxBurst = 32;

--- a/core/port.cc
+++ b/core/port.cc
@@ -1,5 +1,7 @@
 #include "port.h"
 
+#include <glog/logging.h>
+
 #include <cassert>
 #include <cctype>
 #include <cerrno>
@@ -8,8 +10,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-
-#include <glog/logging.h>
 
 #include "mem_alloc.h"
 #include "message.h"

--- a/core/port.h
+++ b/core/port.h
@@ -1,13 +1,14 @@
 #ifndef BESS_PORT_H_
 #define BESS_PORT_H_
 
+#include <glog/logging.h>
+#include <gtest/gtest_prod.h>
+
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
-
-#include <glog/logging.h>
-#include <gtest/gtest_prod.h>
+#include <string>
 
 #include "message.h"
 #include "packet.h"
@@ -57,7 +58,7 @@ using port_init_func_t = pb_func_t<pb_error_t, Port, google::protobuf::Any>;
 
 template <typename T, typename P>
 static inline port_init_func_t PORT_INIT_FUNC(pb_error_t (P::*fn)(const T &)) {
-  return [=](Port *p, const google::protobuf::Any &arg) -> pb_error_t {
+  return [fn](Port *p, const google::protobuf::Any &arg) {
     T arg_;
     arg.UnpackTo(&arg_);
     auto base_fn = std::mem_fn(fn);
@@ -204,7 +205,7 @@ class Port {
   void ReleaseQueues(const struct module *m, packet_dir_t dir,
                      const queue_t *queues, int num);
 
-  const std::string &name() const { return name_; };
+  const std::string &name() const { return name_; }
 
   const PortBuilder *port_builder() const { return port_builder_; }
 

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -2,10 +2,10 @@
 
 #include "port.h"
 
+#include <gtest/gtest.h>
+
 #include <memory>
 #include <string>
-
-#include <gtest/gtest.h>
 
 class DummyPort : public Port {
  public:

--- a/core/snbuf.h
+++ b/core/snbuf.h
@@ -1,10 +1,10 @@
 #ifndef BESS_SNBUF_H_
 #define BESS_SNBUF_H_
 
-#include <cassert>
-
 #include <rte_config.h>
 #include <rte_mbuf.h>
+
+#include <cassert>
 
 #include "metadata.h"
 #include "worker.h"
@@ -114,7 +114,8 @@ static inline int snb_alloc_bulk(snb_array_t snbs, int cnt, uint16_t len) {
   int ret;
   int i;
 
-  ret = rte_mempool_get_bulk(ctx.pframe_pool(), (void **)snbs, cnt);
+  ret = rte_mempool_get_bulk(ctx.pframe_pool(), reinterpret_cast<void **>(snbs),
+                             cnt);
   if (ret != 0) {
     return 0;
   }
@@ -147,7 +148,7 @@ static inline void snb_free_bulk(snb_array_t snbs, int cnt) {
 
   /* NOTE: it seems that zeroing the refcnt of mbufs is not necessary.
    *   (allocators will reset them) */
-  rte_mempool_put_bulk(pool, (void **)snbs, cnt);
+  rte_mempool_put_bulk(pool, reinterpret_cast<void **>(snbs), cnt);
   return;
 
 slow_path:
@@ -193,7 +194,7 @@ static inline void snb_trim(struct snbuf *snb, uint16_t to_remove) {
   int ret;
 
   ret = rte_pktmbuf_trim(&snb->mbuf, to_remove);
-  DCHECK(ret == 0);
+  DCHECK_EQ(ret, 0);
 }
 
 static inline struct snbuf *snb_copy(struct snbuf *src) {

--- a/core/snbuf_avx.h
+++ b/core/snbuf_avx.h
@@ -22,7 +22,8 @@ static inline int snb_alloc_bulk(snb_array_t snbs, int cnt, uint16_t len) {
    * rss 			0 	(32 bits) */
   rxdesc_fields = _mm_setr_epi32(0, len, len, 0);
 
-  ret = rte_mempool_get_bulk(ctx.pframe_pool(), (void **)snbs, cnt);
+  ret = rte_mempool_get_bulk(ctx.pframe_pool(), reinterpret_cast<void **>(snbs),
+                             cnt);
   if (ret != 0) {
     return 0;
   }
@@ -122,7 +123,7 @@ static inline void snb_free_bulk(snb_array_t snbs, int cnt) {
 
   /* NOTE: it seems that zeroing the refcnt of mbufs is not necessary.
    *   (allocators will reset them) */
-  rte_mempool_put_bulk(_pool, (void **)snbs, cnt);
+  rte_mempool_put_bulk(_pool, reinterpret_cast<void **>(snbs), cnt);
   return;
 
 slow_path:

--- a/core/task.cc
+++ b/core/task.cc
@@ -1,8 +1,8 @@
 #include "task.h"
 
-#include <cassert>
-
 #include <glog/logging.h>
+
+#include <cassert>
 
 #include "mem_alloc.h"
 #include "module.h"
@@ -10,7 +10,8 @@
 #include "traffic_class.h"
 #include "worker.h"
 
-Task::Task(Module *m, void *arg, bess::LeafTrafficClass *c) : m_(m), arg_(arg), c_(c) {
+Task::Task(Module *m, void *arg, bess::LeafTrafficClass *c)
+    : m_(m), arg_(arg), c_(c) {
   CHECK(c) << "Tasks must always be attached to a leaf traffic class.";
   if (c_) {
     c_->AddTask(this);

--- a/core/task.h
+++ b/core/task.h
@@ -1,8 +1,9 @@
 #ifndef BESS_TASK_H_
 #define BESS_TASK_H_
 
-#include "gate.h"
 #include <cstdint>
+
+#include "gate.h"
 
 typedef uint16_t task_id_t;
 

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -45,14 +45,14 @@ void PriorityTrafficClass::UnblockTowardsRoot(uint64_t tsc) {
       break;
     }
   }
-  TrafficClass::UnblockTowardsRootSetBlocked(tsc, first_runnable_ >= num_children);
+  TrafficClass::UnblockTowardsRootSetBlocked(tsc,
+                                             first_runnable_ >= num_children);
 }
 
-void PriorityTrafficClass::FinishAndAccountTowardsRoot(
-    Scheduler *sched,
-    TrafficClass *child,
-    resource_arr_t usage,
-    uint64_t tsc) {
+void PriorityTrafficClass::FinishAndAccountTowardsRoot(Scheduler *sched,
+                                                       TrafficClass *child,
+                                                       resource_arr_t usage,
+                                                       uint64_t tsc) {
   ACCUMULATE(stats_.usage, usage);
 
   if (child->blocked_) {
@@ -63,7 +63,7 @@ void PriorityTrafficClass::FinishAndAccountTowardsRoot(
       ++first_runnable_;
     }
     blocked_ = (first_runnable_ == num_children);
-  } 
+  }
   if (!parent_) {
     return;
   }
@@ -78,7 +78,8 @@ size_t PriorityTrafficClass::Size() const {
   return sz;
 }
 
-bool WeightedFairTrafficClass::AddChild(TrafficClass *child, resource_share_t share) {
+bool WeightedFairTrafficClass::AddChild(TrafficClass *child,
+                                        resource_share_t share) {
   if (child->parent_) {
     return false;
   }
@@ -119,14 +120,14 @@ void WeightedFairTrafficClass::UnblockTowardsRoot(uint64_t tsc) {
   TrafficClass::UnblockTowardsRootSetBlocked(tsc, children_.empty());
 }
 
-void WeightedFairTrafficClass::FinishAndAccountTowardsRoot(
-    Scheduler *sched,
-    TrafficClass *child,
-    resource_arr_t usage,
-    uint64_t tsc) {
+void WeightedFairTrafficClass::FinishAndAccountTowardsRoot(Scheduler *sched,
+                                                           TrafficClass *child,
+                                                           resource_arr_t usage,
+                                                           uint64_t tsc) {
   ACCUMULATE(stats_.usage, usage);
 
-  //DCHECK_EQ(item.c_, child) << "Child that we picked should be at the front of priority queue.";
+  // DCHECK_EQ(item.c_, child) << "Child that we picked should be at the front
+  // of priority queue.";
   if (child->blocked_) {
     auto item = children_.top();
     children_.pop();
@@ -147,7 +148,8 @@ void WeightedFairTrafficClass::FinishAndAccountTowardsRoot(
 
 size_t WeightedFairTrafficClass::Size() const {
   size_t sz = 1;
-  const auto *childs = reinterpret_cast<const std::vector<ChildData>*>(&children_);
+  const auto *childs =
+      reinterpret_cast<const std::vector<ChildData> *>(&children_);
   for (auto child = childs->cbegin(); child != childs->cend(); ++child) {
     sz += child->c_->Size();
   }
@@ -192,11 +194,10 @@ void RoundRobinTrafficClass::UnblockTowardsRoot(uint64_t tsc) {
   TrafficClass::UnblockTowardsRootSetBlocked(tsc, children_.empty());
 }
 
-void RoundRobinTrafficClass::FinishAndAccountTowardsRoot(
-    Scheduler *sched,
-    TrafficClass *child,
-    resource_arr_t usage,
-    uint64_t tsc) {
+void RoundRobinTrafficClass::FinishAndAccountTowardsRoot(Scheduler *sched,
+                                                         TrafficClass *child,
+                                                         resource_arr_t usage,
+                                                         uint64_t tsc) {
   ACCUMULATE(stats_.usage, usage);
   if (child->blocked_) {
     children_.erase(children_.begin() + next_child_);
@@ -219,7 +220,8 @@ void RoundRobinTrafficClass::FinishAndAccountTowardsRoot(
 
 size_t RoundRobinTrafficClass::Size() const {
   size_t sz = 1;
-  const auto *childs = reinterpret_cast<const std::vector<TrafficClass*>*>(&children_);
+  const auto *childs =
+      reinterpret_cast<const std::vector<TrafficClass *> *>(&children_);
   for (auto child = childs->cbegin(); child != childs->cend(); ++child) {
     sz += (*child)->Size();
   }
@@ -253,11 +255,10 @@ void RateLimitTrafficClass::UnblockTowardsRoot(uint64_t tsc) {
   TrafficClass::UnblockTowardsRootSetBlocked(tsc, blocked);
 }
 
-void RateLimitTrafficClass::FinishAndAccountTowardsRoot(
-    Scheduler *sched,
-    TrafficClass *child,
-    resource_arr_t usage,
-    uint64_t tsc) {
+void RateLimitTrafficClass::FinishAndAccountTowardsRoot(Scheduler *sched,
+                                                        TrafficClass *child,
+                                                        resource_arr_t usage,
+                                                        uint64_t tsc) {
   ACCUMULATE(stats_.usage, usage);
   last_tsc_ = tsc;
   uint64_t elapsed_cycles = tsc - last_tsc_;
@@ -270,7 +271,7 @@ void RateLimitTrafficClass::FinishAndAccountTowardsRoot(
     tokens_ = 0;
     blocked_ = true;
     ++stats_.cnt_throttled;
-    throttle_expiration_ = tsc+wait_tsc;
+    throttle_expiration_ = tsc + wait_tsc;
 
     sched->AddThrottled(this);
   } else {

--- a/core/worker.h
+++ b/core/worker.h
@@ -1,11 +1,12 @@
 #ifndef BESS_WORKER_H_
 #define BESS_WORKER_H_
 
+#include <glog/logging.h>
+
 #include <cstdint>
+#include <string>
 #include <thread>
 #include <type_traits>
-
-#include <glog/logging.h>
 
 #include "gate.h"
 #include "pktbatch.h"
@@ -40,7 +41,6 @@ typedef enum {
   WORKER_FINISHED,
 } worker_status_t;
 
-
 namespace bess {
 class Scheduler;
 }  // namespace bess
@@ -48,8 +48,8 @@ class Scheduler;
 class Worker {
  public:
   static const bess::TrafficPolicy kDefaultRootPolicy;
-  static const std::string kRootClassNamePrefix;
-  static const std::string kDefaultLeafClassNamePrefix;
+  static const char *kRootClassNamePrefix;
+  static const char *kDefaultLeafClassNamePrefix;
 
   /* ----------------------------------------------------------------------
    * functions below are invoked by non-worker threads (the master)
@@ -79,9 +79,7 @@ class Worker {
     return pframe_pool_;
   }
 
-  bess::Scheduler *scheduler() {
-    return scheduler_;
-  }
+  bess::Scheduler *scheduler() { return scheduler_; }
 
   uint64_t silent_drops() { return silent_drops_; }
   void set_silent_drops(uint64_t drops) { silent_drops_ = drops; }


### PR DESCRIPTION
- Fix warnings from cpplint that are not false positives. 
- Run clang-format