### PR TITLE
fix divide by zero bug causing bpf.bess to crash

### DIFF
--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -45,6 +45,10 @@ pb_cmd_response_t Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {
   }
 
   num_templates_ = curr + arg.templates_size();
+  if(num_templates_ == 0){
+     set_cmd_response_error(&response, pb_errno(0));
+     return response;
+  }
 
   for (size_t i = num_templates_; i < kNumSlots; i++) {
     size_t j = i % num_templates_;


### PR DESCRIPTION
Summary says it all -- quick fix to the bpf.bess crash bug.