### PR TITLE
bessctl: fix show tc

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -412,56 +412,80 @@ class BESSControlImpl final : public BESSControl::Service {
   }
   Status ListTcs(ServerContext*, const ListTcsRequest* request,
                  ListTcsResponse* response) override {
-    unsigned int wid_filter = MAX_WORKERS;
+    int wid_filter;
+    int i;
 
     wid_filter = request->wid();
-    if (wid_filter >= MAX_WORKERS) {
+    if (wid_filter >= num_workers) {
       return return_with_error(
-          response, EINVAL, "'wid' must be between 0 and %d", MAX_WORKERS - 1);
+          response, EINVAL, "'wid' must be between 0 and %d", num_workers - 1);
     }
 
-    if (!is_worker_active(wid_filter)) {
-      return return_with_error(response, EINVAL, "worker:%d does not exist",
-                               wid_filter);
+    if (wid_filter < 0) {
+      i = 0;
+      wid_filter = num_workers - 1;
+    } else {
+      i = wid_filter;
     }
 
-    for (const auto& pair : TrafficClassBuilder::all_tcs()) {
-      bess::TrafficClass* c = pair.second;
+    struct traverse_arg {
+      ListTcsResponse* response;
+      int wid;
+    };
 
-      ListTcsResponse_TrafficClassStatus* status =
-          response->add_classes_status();
-
-      if (c->parent()) {
-        status->set_parent(c->parent()->name());
+    for (; i <= wid_filter; i++) {
+      const bess::TrafficClass* root = workers[i]->scheduler()->root();
+      if (!root) {
+        return return_with_error(response, ENOENT, "worker:%d has no root tc",
+                                 i);
       }
 
-      status->mutable_class_()->set_name(c->name());
-      status->mutable_class_()->set_blocked(c->blocked());
+      struct traverse_arg arg__ = {response, i};
 
-      if (c->policy() >= 0 && c->policy() < bess::NUM_POLICIES) {
-        status->mutable_class_()->set_policy(
-            bess::TrafficPolicyName[c->policy()]);
-      } else {
-        status->mutable_class_()->set_policy("invalid");
-      }
+      root->Traverse(
+          [](const bess::TrafficClass* c, void* arg) {
+            struct traverse_arg* arg_ =
+                reinterpret_cast<struct traverse_arg*>(arg);
 
-      if (c->policy() == bess::POLICY_LEAF) {
-        status->set_tasks(
-            reinterpret_cast<bess::LeafTrafficClass*>(c)->tasks().size());
-      }
+            ListTcsResponse_TrafficClassStatus* status =
+                arg_->response->add_classes_status();
 
-      status->mutable_class_()->set_wid(wid_filter);
+            if (c->parent()) {
+              status->set_parent(c->parent()->name());
+            }
 
-      if (c->policy() == bess::POLICY_RATE_LIMIT) {
-        bess::RateLimitTrafficClass* rl =
-            reinterpret_cast<bess::RateLimitTrafficClass*>(c);
-        std::string resource = bess::ResourceName.at(rl->resource());
-        int64_t limit = rl->limit();
-        int64_t max_burst = rl->max_burst();
-        status->mutable_class_()->mutable_limit()->insert({resource, limit});
-        status->mutable_class_()->mutable_max_burst()->insert(
-            {resource, max_burst});
-      }
+            status->mutable_class_()->set_name(c->name());
+            status->mutable_class_()->set_blocked(c->blocked());
+
+            if (c->policy() >= 0 && c->policy() < bess::NUM_POLICIES) {
+              status->mutable_class_()->set_policy(
+                  bess::TrafficPolicyName[c->policy()]);
+            } else {
+              status->mutable_class_()->set_policy("invalid");
+            }
+
+            if (c->policy() == bess::POLICY_LEAF) {
+              status->set_tasks(
+                  reinterpret_cast<const bess::LeafTrafficClass*>(c)
+                      ->tasks()
+                      .size());
+            }
+
+            status->mutable_class_()->set_wid(arg_->wid);
+
+            if (c->policy() == bess::POLICY_RATE_LIMIT) {
+              const bess::RateLimitTrafficClass* rl =
+                  reinterpret_cast<const bess::RateLimitTrafficClass*>(c);
+              std::string resource = bess::ResourceName.at(rl->resource());
+              int64_t limit = rl->limit();
+              int64_t max_burst = rl->max_burst();
+              status->mutable_class_()->mutable_limit()->insert(
+                  {resource, limit});
+              status->mutable_class_()->mutable_max_burst()->insert(
+                  {resource, max_burst});
+            }
+          },
+          static_cast<void*>(&arg__));
     }
 
     return Status::OK;

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -244,8 +244,9 @@ class PriorityTrafficClass final : public TrafficClass {
 
   const std::vector<ChildData> &children() const { return children_; }
 
+  void Traverse(TravereseTcFn f, void *arg) const override;
+
   size_t Size() const;
-  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -306,8 +307,9 @@ class WeightedFairTrafficClass final : public TrafficClass {
     return blocked_children_;
   }
 
+  void Traverse(TravereseTcFn f, void *arg) const override;
+
   size_t Size() const;
-  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -352,8 +354,9 @@ class RoundRobinTrafficClass final : public TrafficClass {
     return blocked_children_;
   }
 
+  void Traverse(TravereseTcFn f, void *arg) const override;
+
   size_t Size() const;
-  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -411,8 +414,9 @@ class RateLimitTrafficClass final : public TrafficClass {
 
   TrafficClass *child() const { return child_; }
 
+  void Traverse(TravereseTcFn f, void *arg) const override;
+
   size_t Size() const;
-  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -21,7 +21,7 @@ namespace bess {
 #define DEFAULT_PRIORITY 0xFFFFFFFFu
 
 #define USAGE_AMPLIFIER_POW 32
- 
+
 // Share is defined relatively, so 1024 should be large enough
 #define STRIDE1 (1 << 20)
 
@@ -58,6 +58,9 @@ class WeightedFairTrafficClass;
 class RoundRobinTrafficClass;
 class RateLimitTrafficClass;
 class LeafTrafficClass;
+class TrafficClass;
+
+typedef void (*TravereseTcFn)(const TrafficClass *, void *);
 
 enum TrafficPolicy {
   POLICY_PRIORITY = 0,
@@ -119,7 +122,15 @@ class TrafficClass {
  public:
   virtual ~TrafficClass() {}
 
-  size_t Size() const { return 1; }
+  virtual void Traverse(TravereseTcFn f, void *arg) const { f(this, arg); }
+
+  size_t Size() const {
+    size_t sz = 0;
+    Traverse([](const TrafficClass *,
+                void *arg) { *reinterpret_cast<size_t *>(arg) += 1; },
+             static_cast<void *>(&sz));
+    return sz;
+  }
 
   // Returns the root of the tree this class belongs to.
   // Expensive in that it is recursive, so do not call from
@@ -234,6 +245,7 @@ class PriorityTrafficClass final : public TrafficClass {
   const std::vector<ChildData> &children() const { return children_; }
 
   size_t Size() const;
+  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -295,6 +307,7 @@ class WeightedFairTrafficClass final : public TrafficClass {
   }
 
   size_t Size() const;
+  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -340,6 +353,7 @@ class RoundRobinTrafficClass final : public TrafficClass {
   }
 
   size_t Size() const;
+  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -398,6 +412,7 @@ class RateLimitTrafficClass final : public TrafficClass {
   TrafficClass *child() const { return child_; }
 
   size_t Size() const;
+  void Traverse(TravereseTcFn f, void *arg) const;
 
  private:
   friend Scheduler;
@@ -435,6 +450,9 @@ class LeafTrafficClass final : public TrafficClass {
 
   // Direct access to the tasks vector, for testing only.
   std::vector<Task *> &tasks() { return tasks_; }
+
+  // Regular accessor for everyone else
+  const std::vector<Task *> &tasks() const { return tasks_; }
 
   // Executes tasks for a leaf TrafficClass.
   inline struct task_result RunTasks() {
@@ -477,8 +495,6 @@ class LeafTrafficClass final : public TrafficClass {
     ACCUMULATE(stats_.usage, usage);
     parent_->FinishAndAccountTowardsRoot(sched, this, usage, tsc);
   }
-
-  size_t Size() const;
 
  private:
   friend Scheduler;

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -246,8 +246,6 @@ class PriorityTrafficClass final : public TrafficClass {
 
   void Traverse(TravereseTcFn f, void *arg) const override;
 
-  size_t Size() const;
-
  private:
   friend Scheduler;
 
@@ -309,8 +307,6 @@ class WeightedFairTrafficClass final : public TrafficClass {
 
   void Traverse(TravereseTcFn f, void *arg) const override;
 
-  size_t Size() const;
-
  private:
   friend Scheduler;
 
@@ -355,8 +351,6 @@ class RoundRobinTrafficClass final : public TrafficClass {
   }
 
   void Traverse(TravereseTcFn f, void *arg) const override;
-
-  size_t Size() const;
 
  private:
   friend Scheduler;
@@ -415,8 +409,6 @@ class RateLimitTrafficClass final : public TrafficClass {
   TrafficClass *child() const { return child_; }
 
   void Traverse(TravereseTcFn f, void *arg) const override;
-
-  size_t Size() const;
 
  private:
   friend Scheduler;

--- a/core/traffic_class_test.cc
+++ b/core/traffic_class_test.cc
@@ -19,6 +19,7 @@ namespace bess {
 TEST(CreateTree, Leaf) {
   TrafficClass *c = CT("leaf", {LEAF});
   ASSERT_TRUE(c != nullptr);
+  ASSERT_EQ(1, c->Size());
   EXPECT_EQ(POLICY_LEAF, c->policy());
 
   TrafficClassBuilder::ClearAll();
@@ -28,6 +29,7 @@ TEST(CreateTree, Leaf) {
 TEST(CreateTree, PriorityRootAndLeaf) {
   std::unique_ptr<TrafficClass> tree(
       CT("root", {PRIORITY}, {{PRIORITY, 10, CT("leaf", {LEAF})}}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(tree != nullptr);
   EXPECT_EQ(POLICY_PRIORITY, tree->policy());
@@ -56,6 +58,7 @@ TEST(CreateTree, WeightedFairRootAndLeaf) {
   std::unique_ptr<TrafficClass> tree(
       CT("root", {WEIGHTED_FAIR, RESOURCE_CYCLE},
          {{WEIGHTED_FAIR, 10, CT("leaf", {LEAF})}}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(tree != nullptr);
   EXPECT_EQ(POLICY_WEIGHTED_FAIR, tree->policy());
@@ -81,6 +84,7 @@ TEST(CreateTree, WeightedFairRootAndLeaf) {
 TEST(CreateTree, RoundRobinRootAndLeaf) {
   std::unique_ptr<TrafficClass> tree(
       CT("root", {ROUND_ROBIN}, {{ROUND_ROBIN, CT("leaf", {LEAF})}}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(tree != nullptr);
   EXPECT_EQ(POLICY_ROUND_ROBIN, tree->policy());
@@ -104,6 +108,7 @@ TEST(CreateTree, RateLimitRootAndLeaf) {
   std::unique_ptr<TrafficClass> tree(CT("root",
                                         {RATE_LIMIT, RESOURCE_CYCLE, 10, 15},
                                         {RATE_LIMIT, CT("leaf", {LEAF})}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(tree != nullptr);
   EXPECT_EQ(POLICY_RATE_LIMIT, tree->policy());
@@ -123,6 +128,7 @@ TEST(CreateTree, RateLimitRootAndLeaf) {
 // repeatedly.
 TEST(SchedulerNext, BasicTreePriority) {
   Scheduler s(CT("root", {PRIORITY}, {{PRIORITY, 10, CT("leaf", {LEAF})}}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(s.root() != nullptr);
   EXPECT_EQ(POLICY_PRIORITY, s.root()->policy());
@@ -155,6 +161,7 @@ TEST(SchedulerNext, BasicTreePriority) {
 TEST(SchedulerNext, BasicTreeWeightedFair) {
   Scheduler s(CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
                  {{WEIGHTED_FAIR, 2, CT("leaf", {LEAF})}}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(s.root() != nullptr);
   EXPECT_EQ(POLICY_WEIGHTED_FAIR, s.root()->policy());
@@ -188,6 +195,7 @@ TEST(SchedulerNext, BasicTreeWeightedFair) {
 // repeatedly.
 TEST(SchedulerNext, BasicTreeRoundRobin) {
   Scheduler s(CT("root", {ROUND_ROBIN}, {{ROUND_ROBIN, CT("leaf", {LEAF})}}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(s.root() != nullptr);
   EXPECT_EQ(POLICY_ROUND_ROBIN, s.root()->policy());
@@ -220,6 +228,7 @@ TEST(SchedulerNext, BasicTreeRoundRobin) {
 TEST(SchedulerNext, BasicTreeRateLimit) {
   Scheduler s(CT("root", {RATE_LIMIT, RESOURCE_COUNT, 50, 100},
                  {RATE_LIMIT, CT("leaf", {LEAF})}));
+  ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_TRUE(s.root() != nullptr);
   EXPECT_EQ(POLICY_RATE_LIMIT, s.root()->policy());
@@ -251,6 +260,7 @@ TEST(SchedulerNext, TwoLeavesWeightedFairOneBlocked) {
   Scheduler s(CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
                  {{WEIGHTED_FAIR, 1, CT("leaf_1", {LEAF})},
                   {WEIGHTED_FAIR, 2, CT("leaf_2", {LEAF})}}));
+  ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
 
   LeafTrafficClass *leaf_1 =
       static_cast<LeafTrafficClass *>(TrafficClassBuilder::Find("leaf_1"));
@@ -280,6 +290,7 @@ TEST(ScheduleOnce, TwoLeavesWeightedFair) {
   Scheduler s(CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
                  {{WEIGHTED_FAIR, 2, CT("leaf_1", {LEAF})},
                   {WEIGHTED_FAIR, 5, CT("leaf_2", {LEAF})}}));
+  ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
 
   LeafTrafficClass *leaf_1 =
       static_cast<LeafTrafficClass *>(TrafficClassBuilder::Find("leaf_1"));
@@ -331,6 +342,7 @@ TEST(ScheduleOnce, TwoLeavesWeightedFair) {
 TEST(ScheduleOnce, TwoLeavesPriority) {
   Scheduler s(CT("root", {PRIORITY}, {{PRIORITY, 0, CT("leaf_1", {LEAF})},
                                       {PRIORITY, 1, CT("leaf_2", {LEAF})}}));
+  ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
 
   LeafTrafficClass *leaf_1 =
       static_cast<LeafTrafficClass *>(TrafficClassBuilder::Find("leaf_1"));
@@ -374,6 +386,7 @@ TEST(ScheduleOnce, TwoLeavesPriority) {
 TEST(ScheduleOnce, TwoLeavesRoundRobin) {
   Scheduler s(CT("root", {ROUND_ROBIN}, {{ROUND_ROBIN, CT("leaf_1", {LEAF})},
                                          {ROUND_ROBIN, CT("leaf_2", {LEAF})}}));
+  ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
 
   LeafTrafficClass *leaf_1 =
       static_cast<LeafTrafficClass *>(TrafficClassBuilder::Find("leaf_1"));
@@ -428,6 +441,7 @@ TEST(ScheduleOnce, LeavesWeightedFairAndRoundRobin) {
                                          {ROUND_ROBIN, CT("leaf_2a", {LEAF})},
                                          {ROUND_ROBIN, CT("leaf_2b", {LEAF})},
                                      })}}));
+  ASSERT_EQ(7, TrafficClassBuilder::Find("root")->Size());
 
   std::map<std::string, LeafTrafficClass *> leaves;
   for (auto &leaf_name : {"leaf_1a", "leaf_1b", "leaf_2a", "leaf_2b"}) {
@@ -483,6 +497,7 @@ TEST(RateLimit, BasicBlockUnblock) {
                            {RATE_LIMIT, CT("leaf_1", {LEAF})})},
           {ROUND_ROBIN, CT("limit_2", {RATE_LIMIT, RESOURCE_COUNT, 1, 0},
                            {RATE_LIMIT, CT("leaf_2", {LEAF})})}}));
+  ASSERT_EQ(5, TrafficClassBuilder::Find("root")->Size());
   RoundRobinTrafficClass *rr =
       static_cast<RoundRobinTrafficClass *>(TrafficClassBuilder::Find("root"));
   ASSERT_TRUE(rr != nullptr);

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -356,10 +356,9 @@ class BESS(object):
 
         return self._request(self.stub.AttachTask, request)
 
-    def list_tcs(self, wid=None):
+    def list_tcs(self, wid=-1):
         request = bess_msg.ListTcsRequest()
-        if wid is not None:
-            request.wid = wid
+        request.wid = wid
 
         return self._request(self.stub.ListTcs, request)
 


### PR DESCRIPTION
This patch fixes `show tc` to correctly report which tcs belong to which workers. It also changes `show tc` to report tcs for all workers when no worker is specified.