### PR TITLE
misc bessctl/protobuf fixes

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -151,28 +151,43 @@ def get_var_attrs(cli, var_token, partial_word):
         elif var_token == 'WORKER_ID...':
             var_type = 'wid+'
             var_desc = 'one or more worker IDs'
-            var_candidates = [str(m.wid)
-                              for m in cli.bess.list_workers().workers_status]
+            try:
+                var_candidates = [str(m.wid) for m in \
+                                  cli.bess.list_workers().workers_status]
+            except:
+                pass
 
         elif var_token == 'DRIVER':
             var_type = 'name'
             var_desc = 'name of a port driver'
-            var_candidates = cli.bess.list_drivers().driver_names
+            try:
+                var_candidates = cli.bess.list_drivers().driver_names
+            except:
+                pass
 
         elif var_token == 'DRIVER...':
             var_type = 'name'
             var_desc = 'one or more port driver names'
-            var_candidates = cli.bess.list_drivers().driver_names
+            try:
+                var_candidates = cli.bess.list_drivers().driver_names
+            except:
+                pass
 
         elif var_token == 'MCLASS':
             var_type = 'name'
             var_desc = 'name of a module class'
-            var_candidates = cli.bess.list_mclasses().names
+            try:
+                var_candidates = cli.bess.list_mclasses().names
+            except:
+                pass
 
         elif var_token == 'MCLASS...':
             var_type = 'name+'
             var_desc = 'one or more module class names'
-            var_candidates = cli.bess.list_mclasses().names
+            try:
+                var_candidates = cli.bess.list_mclasses().names
+            except:
+                pass
 
         elif var_token == '[NEW_MODULE]':
             var_type = 'name'
@@ -181,12 +196,20 @@ def get_var_attrs(cli, var_token, partial_word):
         elif var_token == 'MODULE':
             var_type = 'name'
             var_desc = 'name of an existing module instance'
-            var_candidates = [m.name for m in cli.bess.list_modules().modules]
+            try:
+                var_candidates = [m.name for m in \
+                                  cli.bess.list_modules().modules]
+            except:
+                pass
 
         elif var_token == 'MODULE...':
             var_type = 'name+'
             var_desc = 'one or more module names'
-            var_candidates = [m.name for m in cli.bess.list_modules().modules]
+            try:
+                var_candidates = [m.name for m in \
+                                  cli.bess.list_modules().modules]
+            except:
+                pass
 
         elif var_token == 'MODULE_CMD':
             var_type = 'name'
@@ -199,17 +222,27 @@ def get_var_attrs(cli, var_token, partial_word):
         elif var_token == 'PORT':
             var_type = 'name'
             var_desc = 'name of a port'
-            var_candidates = [p.name for p in cli.bess.list_ports().ports]
+            try:
+                var_candidates = [p.name for p in cli.bess.list_ports().ports]
+            except:
+                pass
 
         elif var_token == 'PORT...':
             var_type = 'name+'
             var_desc = 'one or more port names'
-            var_candidates = [p.name for p in cli.bess.list_ports().ports]
+            try:
+                var_candidates = [p.name for p in cli.bess.list_ports().ports]
+            except:
+                pass
 
         elif var_token == 'TC...':
             var_type = 'name+'
             var_desc = 'one or more traffic class names'
-            var_candidates = [getattr(c, 'class').name for c in cli.bess.list_tcs().classes_status]
+            try:
+                var_candidates = [getattr(c, 'class').name \
+                                  for c in cli.bess.list_tcs().classes_status]
+            except:
+                pass
 
         elif var_token == 'CONF':
             var_type = 'confname'

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1443,7 +1443,7 @@ def _monitor_tcs(cli, *tcs):
         else:
             cpp = 0
 
-        cli.fout.write('%-20s%12.3f%12d%12.3f%12.3f%12.3f%12.3f\n' %
+        cli.fout.write('%-20s%12.3f%12d%12.3f%12.3f%12d%12d\n' %
                        (tc,
                         delta.cycles / 1e6,
                         delta.count,

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -110,6 +110,10 @@ void PMDPort::InitDriver() {
   }
 }
 
+// Find a port attached to DPDK by its integral id.
+// returns 0 and sets *ret_port_id to "port_id" if the port is valid and
+// available.
+// returns > 0 on error.
 static pb_error_t find_dpdk_port_by_id(dpdk_port_t port_id,
                                        dpdk_port_t *ret_port_id) {
   if (port_id >= RTE_MAX_ETHPORTS) {
@@ -123,6 +127,11 @@ static pb_error_t find_dpdk_port_by_id(dpdk_port_t port_id,
   return pb_errno(0);
 }
 
+// Find a port attached to DPDK by its PCI address.
+// returns 0 and sets *ret_port_id to the port_id of the port at PCI address
+// "pci" if it is valid and available. *ret_hot_plugged is set to true if the
+// device was attached to DPDK as a result of calling this function.
+// returns > 0 on error.
 static pb_error_t find_dpdk_port_by_pci_addr(const std::string &pci,
                                              dpdk_port_t *ret_port_id,
                                              bool *ret_hot_plugged) {
@@ -173,6 +182,11 @@ static pb_error_t find_dpdk_port_by_pci_addr(const std::string &pci,
   return pb_errno(0);
 }
 
+// Find a DPDK vdev by name.
+// returns 0 and sets *ret_port_id to the port_id of "vdev" if it is valid and
+// available. *ret_hot_plugged is set to true if the device was attached to
+// DPDK as a result of calling this function.
+// returns > 0 on error.
 static pb_error_t find_dpdk_vdev(const std::string &vdev,
                                  dpdk_port_t *ret_port_id,
                                  bool *ret_hot_plugged) {

--- a/protobuf/port_msg.proto
+++ b/protobuf/port_msg.proto
@@ -8,9 +8,11 @@ message PCAPPortArg {
 
 message PMDPortArg {
   bool loopback = 1;
-  uint64 port_id = 2;
-  string pci = 3;
-  string vdev = 4;
+  oneof port {
+    uint64 port_id = 2;
+    string pci = 3;
+    string vdev = 4;
+  }
 }
 
 message UnixSocketPortArg {


### PR DESCRIPTION
Addressing

- Change PMDPortArg proto to only take oneof {port_id, pci, vdev}
- “monitor tc” numbers pkts/sched and cycles/p always end with “.000”
- Tab completion for certain command breaks bessctl when bessd isn’t running