### PR TITLE
Remove memcpy_sloppy

### DIFF
--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -316,7 +316,7 @@ bess::Packet *FlowGen::FillPacket(struct flow *f) {
   pkt->set_total_len(size);
   pkt->set_data_len(size);
 
-  memcpy_sloppy(p, templ_, size);
+  rte_memcpy(p, templ_, size);
 
   tcp_flags = f->first ? /* SYN */ 0x02 : /* ACK */ 0x10;
 

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -99,7 +99,7 @@ inline void Rewrite::DoRewrite(bess::PacketBatch *batch) {
     pkt->set_total_len(size);
     pkt->set_data_len(size);
 
-    memcpy_sloppy(ptr, templates_[start + i], size);
+    rte_memcpy(ptr, templates_[start + i], size);
   }
 
   next_turn_ = (start + cnt) % num_templates_;

--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -92,24 +92,6 @@ static inline int is_err_or_null(const void *ptr) {
 #define STORE_BARRIER() INST_BARRIER()
 #define FULL_BARRIER() asm volatile("mfence" ::: "memory")
 
-/* src/dst addresses and their sizes must be a multiple of SIMD register size */
-static inline void memcpy_sloppy(void *__restrict__ dst,
-                                 const void *__restrict__ src, size_t n) {
-#if __AVX2__
-  typedef __m256i block_t;
-#else
-  typedef __m128i block_t;
-#endif
-  block_t *__restrict__ d = (block_t *)dst;
-  const block_t *__restrict__ s = (const block_t *)src;
-
-  int bytes_left = n;
-  while (bytes_left > 0) {
-    *d++ = *s++;
-    bytes_left -= sizeof(block_t);
-  }
-}
-
 // Put this in the declarations for a class to be uncopyable.
 #define DISALLOW_COPY(TypeName) TypeName(const TypeName &) = delete
 // Put this in the declarations for a class to be unassignable.


### PR DESCRIPTION
As seen in 623771a9 memcpy_sloppy can cause some issues, and it is only used in two modules with uncertain benefits when
compared to rte_memcpy or other memcpy. This commit eliminates the function and all callers.