### PR TITLE
Okay, I think this is the fix... (fingers crossed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 
 install:
   - sudo apt-get install -y python
+  - pip install grpcio scapy
   - ln -s /build/dpdk-16.07 deps
   - docker pull $IMAGE
 
@@ -36,6 +37,7 @@ script:
   - ./container_build.py bess
   - ./container_build.py kmod_buildtest
   - core/all_test
+  - ./sanity_check.sh
 
 after_success:
   - "[[ ${COVERAGE:-0} != 0 ]] && bash <(curl -s https://codecov.io/bash)"

--- a/core/Makefile
+++ b/core/Makefile
@@ -75,7 +75,9 @@ endif
 ifdef DEBUG
     CXXFLAGS += --coverage -DNDEBUG -O1
     LDFLAGS += --coverage
-else
+else ifeq "$(CXX)" "g++-6"
+    CXXFLAGS += -O2
+else 
     CXXFLAGS += -Ofast
 endif
 


### PR DESCRIPTION
So, turns out g++6 + O3/Ofast makes weird and untraceable things happen that I can't figure out. Things crash in BESS when they're enabled (particularly queue.bess) so I changed the Makefile to use -O2 if CXX is set to g++-6. Now that this works, Travis can run sanity_check.sh and all tests pass.