### PR TITLE
Minor updates to gRPC client and server

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -15,7 +15,7 @@ try:
     from bess import *
 except ImportError:
     print >> sys.stderr, 'Cannot import the API module (libbess-python)'
-
+    raise
 
 class BESSCLI(cli.CLI):
     def __init__(self, bess, cmd_db, fin=sys.stdin,

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -5,7 +5,6 @@ import os.path
 import pprint
 import cStringIO
 import tempfile
-import socket
 
 import cli
 import commands
@@ -101,20 +100,6 @@ class BESSCLI(cli.CLI):
             return '<disconnected> $ '
 
 
-def connect_bess():
-    s = BESS()
-
-    try:
-        sock = socket.socket()
-        sock.connect(('localhost', BESS.DEF_PORT))
-        sock.close()
-        s.connect()
-    except socket.error as e:
-        pass
-        
-    return s
-
-
 def run_cli():
     try:
         hist_file = os.path.expanduser('~/.bess_history')
@@ -124,15 +109,27 @@ def run_cli():
         hist_file = None
         raise
 
-    s = connect_bess()
+    try:
+        s = BESS()
+        s.connect()
+    except BESS.APIError as e:
+        print >> sys.stderr, e.message, '(bessd daemon is not running?)'
+
     cli = BESSCLI(s, commands, history_file=hist_file)
     cli.loop()
 
 
 def run_cmds(instream):
-    s = connect_bess()
+    try:
+        s = BESS()
+        s.connect()
+    except BESS.APIError as e:
+        # show no error msg, since user might be about to launch the daemon
+        pass
+
     cli = BESSCLI(s, commands, fin=instream, history_file=None)
     cli.loop()
+
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -563,6 +563,9 @@ def daemon_start(cli, opts):
     else:
         _do_start(cli, opts)
 
+    if cli.interactive:
+        cli.fout.write('Done.\n')
+
 
 def is_pipeline_empty(cli):
     workers = cli.bess.list_workers().workers_status

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1,13 +1,15 @@
 #include "bessctl.h"
 
+#include <future>
+#include <map>
+#include <string>
+#include <thread>
+
 #include <glog/logging.h>
 #include <grpc++/server.h>
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
 #include <grpc/grpc.h>
-
-#include <map>
-#include <string>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -44,6 +46,8 @@ using bess::resource_share_t;
 using bess::PriorityTrafficClass;
 using bess::TrafficClassBuilder;
 using namespace bess::pb;
+
+static std::promise<void> exit_requested;
 
 template <typename T>
 static inline Status return_with_error(T* response, int code, const char* fmt,
@@ -1225,9 +1229,8 @@ class BESSControlImpl final : public BESSControl::Service {
       return return_with_error(response, EBUSY, "There is a running worker");
     }
     LOG(WARNING) << "Halt requested by a client\n";
-    exit(EXIT_SUCCESS);
+    exit_requested.set_value();
 
-    /* Never called */
     return Status::OK;
   }
 
@@ -1287,11 +1290,11 @@ static void reset_core_affinity() {
 
   CPU_ZERO(&set);
 
-  /* set all cores... */
+  // set all cores...
   for (i = 0; i < rte_lcore_count(); i++)
     CPU_SET(i, &set);
 
-  /* ...and then unset the ones where workers run */
+  // ...and then unset the ones where workers run
   for (i = 0; i < MAX_WORKERS; i++)
     if (is_worker_active(i))
       CPU_CLR(workers[i]->core(), &set);
@@ -1299,24 +1302,39 @@ static void reset_core_affinity() {
   rte_thread_set_affinity(&set);
 }
 
-void SetupControl() {
-  reset_core_affinity();
-  ctx.SetNonWorker();
-}
+// TODO: C++-ify
+static std::unique_ptr<Server> server;
+static BESSControlImpl service;
 
-void RunControl() {
-  BESSControlImpl service;
-  std::string server_address;
+void SetupControl() {
   ServerBuilder builder;
 
+  reset_core_affinity();
+  ctx.SetNonWorker();
+
   if (FLAGS_p) {
-    server_address = bess::utils::Format("127.0.0.1:%d", FLAGS_p);
+    std::string server_address = bess::utils::Format("127.0.0.1:%d", FLAGS_p);
+    LOG(INFO) << "Server listening on " << server_address;
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   }
 
   builder.RegisterService(&service);
-  std::unique_ptr<Server> server(builder.BuildAndStart());
+  server = builder.BuildAndStart();
+}
 
-  LOG(INFO) << "Server listening on " << server_address;
-  server->Wait();
+void RunControl() {
+  auto serve_func = []() {
+    server->Wait();
+    LOG(INFO) << "Terminating gRPC server";
+  };
+
+  std::thread grpc_server_thread(serve_func);
+
+  auto f = exit_requested.get_future();
+  f.wait();
+
+  server->Shutdown();
+  grpc_server_thread.join();
+
+  delete server.release();
 }

--- a/core/main.cc
+++ b/core/main.cc
@@ -60,5 +60,7 @@ int main(int argc, char *argv[]) {
   rte_eal_mp_wait_lcore();
   bess::close_mempool();
 
+  LOG(INFO) << "BESS daemon has been gracefully shut down";
+
   return 0;
 }

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -57,27 +57,27 @@ class BESS(object):
     def connect(self, host='localhost', port=DEF_PORT):
         if self.is_connected():
             raise self.APIError('Already connected')
+
         self.peer = (host, port)
         self.channel = grpc.insecure_channel('%s:%d' % (host, port))
         self.channel.subscribe(self._update_status, try_to_connect=True)
         self.stub = service_pb2.BESSControlStub(self.channel)
 
         while not self.is_connected():
+            if self.status in [grpc.ChannelConnectivity.TRANSIENT_FAILURE,
+                    grpc.ChannelConnectivity.SHUTDOWN]:
+                self.disconnect()
+                raise self.APIError('Connection to %s:%d failed' % (host, port))
             time.sleep(0.1)
 
-    def clear_connection(self):
-        self.channel.unsubscribe(self._update_status)
+    def disconnect(self):
+        if self.is_connected():
+            self.channel.unsubscribe(self._update_status)
+
         self.status = None
         self.stub = None
         self.channel = None
         self.peer = None
-
-    def disconnect(self):
-        if self.is_connected():
-            self.clear_connection()
-
-        while self.is_connected():
-            time.sleep(0.1)
 
     def set_debug(self, flag):
         self.debug = flag
@@ -123,7 +123,7 @@ class BESS(object):
         while self.is_connected():
             time.sleep(0.1)
 
-        self.clear_connection()
+        self.disconnect()
 
     def reset_all(self):
         return self._request('ResetAll')


### PR DESCRIPTION
It addresses the following issues in the current code:

- 145f434: if "daemon start" fails for whatever reason, bessctl gets stuck in an infinite loop
- 050e2ed: SetupControl returns before the listening socket is ready. As a result, bessctl's "daemon start" and bessd may race.
- 95c0343: when bessctl makes an initial connection to bessd, a low-level socket is used to probe its availability, not with grpc
- 1e09387: even if grpcio python module is not available, no explicit error message is shown