### PR TITLE
Add -fPIC to DPDK cflags

### DIFF
--- a/build.py
+++ b/build.py
@@ -27,7 +27,7 @@ else:
 DPDK_DIR = '%s/%s' % (DEPS_DIR, DPDK_VER)
 DPDK_URL = '%s/%s.tar.gz' % (DPDK_REPO, DPDK_VER)
 DPDK_FILE = '%s/%s.tar.gz' % (DEPS_DIR, DPDK_VER)
-DPDK_CFLAGS = '"-g -w"'
+DPDK_CFLAGS = '"-g -w -fPIC"'
 DPDK_ORIG_CONFIG = '%s/config/common_linuxapp' % DPDK_DIR
 DPDK_BASE_CONFIG = '%s/%s_common_linuxapp' % (DEPS_DIR, DPDK_VER)
 DPDK_FINAL_CONFIG = '%s/%s_common_linuxapp_final' % (DEPS_DIR, DPDK_VER)


### PR DESCRIPTION
The Google testing infrastructure (and NetBricks when that becomes useful) link to some of the static libraries in
.so. Without passing in -fPIC to DPDK this causes build problems on some machines (I had it on a machine with gcc
version 5.4.0 20160609 (Debian 5.4.0-4) LD 2.26 and Linux 4.6.0), which is fixed by passing in -fPIC. Additionally this
should have no impact on the binaries.