### PR TITLE
nat: avoid unecessary gc attempts

### DIFF
--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -102,6 +102,7 @@ class NAT final : public Module {
   std::vector<uint16_t> available_ports_;
   std::unordered_map<Flow, FlowRecord &, FlowHash> flow_hash_;
   std::vector<FlowRecord> flow_vec_;
+  uint64_t next_expiry_;
   Random rng_;
 };
 


### PR DESCRIPTION
I think we'll see a non-negligible performance hit as the number of flows entering the NAT increases beyond `MAX_PORT - MIN_PORT` by GCing the current way. We can avoid doing unnecessary work by calculating the earliest we can expect there to be a free port the first time we enter the GC section of the code. Then future attempts to GC will only happen that point or later, when we know we'll find something.