### PR TITLE
CLI.err() should not terminate process immediately

### DIFF
--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -67,7 +67,7 @@ class CLI(object):
     def err(self, msg):
         self.fout.write('*** Error: %s\n' % msg)
         if not self.interactive:
-            sys.exit(2)
+            self.stop_loop = True
 
     # If not a variable, simply return None
     # Otherwise, return (var_type, desc, candidates):


### PR DESCRIPTION
Instead, the current command need be gracefully terminated with further
actions properly performed (additional error messages, exception handling, etc.)