### PR TITLE
Minor changes to NAT

### DIFF
--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -270,8 +270,8 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
     record.internal_flow = flow;
     record.external_flow = ext_flow;
 
-    flow_hash_.insert({flow, record});
-    flow_hash_.insert({ext_flow.ReverseFlow(), record});
+    flow_hash_.emplace(flow, record);
+    flow_hash_.emplace(ext_flow.ReverseFlow(), record);
 
     stamp_flow(ip, l4, ext_flow);
   }

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -181,7 +181,7 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
 
     struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
     struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
-    int ip_bytes = (ip->header_length) << 2;
+    size_t ip_bytes = (ip->header_length) << 2;
 
     void *l4 = reinterpret_cast<uint8_t *>(ip) + ip_bytes;
 
@@ -248,6 +248,12 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
           next_expiry_ = std::min(next_expiry_, record.time + TIME_OUT_NS);
         }
       }
+    }
+
+    // Still not available ports, then drop
+    if (available_ports_.empty()) {
+      out_gates[i] = DROP_GATE;
+      continue;
     }
 
     uint16_t new_port = available_ports_.back();


### PR DESCRIPTION
- Replace `rdtsc()` with `ctx.current_ns()`
- Use `emplace()` instead of `insert()`
- Drop packets if there is no available port after GC