### PR TITLE
If bessctl loop ended with an error, sys.exit(1)

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -62,7 +62,7 @@ class BESSCLI(cli.CLI):
             else:
                 err_code = '<unknown>'
 
-            self.fout.write('  BESS daemon response - errno=%d (%s: %s)\n' %
+            self.ferr.write('  BESS daemon response - errno=%d (%s: %s)\n' %
                             (e.err, err_code, os.strerror(e.err)))
 
             if e.details:
@@ -129,6 +129,12 @@ def run_cmds(instream):
 
     cli = BESSCLI(s, commands, fin=instream, history_file=None)
     cli.loop()
+
+    # end of loop due to error?
+    if cli.stop_loop:
+        if cli.last_cmd:
+            cli.ferr.write('  Command failed: %s\n' % cli.last_cmd)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -23,11 +23,14 @@ class CLI(object):
         pass
 
     def __init__(self, cmdlist, fin=sys.stdin,
-                 fout=sys.stdout, history_file=None):
+                 fout=sys.stdout, ferr=sys.stderr, history_file=None):
         self.cmdlist = cmdlist
         self.fin = fin
         self.fout = fout
+        self.ferr = ferr
         self.history_file = history_file
+
+        self.last_cmd = ''
 
         self.interactive = False
         self.rl = None
@@ -65,7 +68,7 @@ class CLI(object):
                              self.history_file)
 
     def err(self, msg):
-        self.fout.write('*** Error: %s\n' % msg)
+        self.ferr.write('*** Error: %s\n' % msg)
         if not self.interactive:
             self.stop_loop = True
 
@@ -321,14 +324,14 @@ class CLI(object):
         elif len(matched) >= 2:
             self.err('Ambiguous command "%s". Candidates:' % line.strip())
             for cmd, desc, _ in matched + matched_low:
-                self.fout.write('  %-50s%s\n' % (cmd, desc))
+                self.ferr.write('  %-50s%s\n' % (cmd, desc))
 
         elif len(matched) == 0:
             matched, matched_low = self.list_matched(line, ['partial'])
             if len(matched) > 0:
                 self.err('Incomplete command "%s". Candidates:' % line.strip())
                 for cmd, desc, _ in matched + matched_low:
-                    self.fout.write('  %-50s%s\n' % (cmd, desc))
+                    self.ferr.write('  %-50s%s\n' % (cmd, desc))
             else:
                 self.err('Unknown command "%s".' % line.strip())
 
@@ -388,6 +391,7 @@ class CLI(object):
         line = line.strip()
 
         if line:
+            self.last_cmd = line
             try:
                 try:
                     cmd = self.find_cmd(line + ' ')

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -670,12 +670,12 @@ def _do_run_file(cli, conf_file):
         errmsg = 'Unhandled exception in the configuration script'
 
         cli.err('%s (most recent call last)' % errmsg)
-        cli.fout.write(''.join(traceback.format_list(stack)))
+        cli.ferr.write(''.join(traceback.format_list(stack)))
 
         if isinstance(v, cli.bess.Error):
             raise
         else:
-            cli.fout.write(''.join(traceback.format_exception_only(t, v)))
+            cli.ferr.write(''.join(traceback.format_exception_only(t, v)))
             raise cli.HandledError()
     finally:
         cli.bess.resume_all()


### PR DESCRIPTION
This patch addresses Issue #230.
Also, added ferr output stream, which was separated from fout