### PR TITLE
Fix incorrect port statistics for i40e interfaces

### DIFF
--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -359,6 +359,7 @@ void PMDPort::CollectStats(bool reset) {
 
   // i40e PMD driver doesn't support per-queue stats
   if (driver_ == "rte_i40e_pmd") {
+    // NOTE: if link is down, tx bytes won't increase
     port_stats[PACKET_DIR_INC].packets = stats.ipackets;
     port_stats[PACKET_DIR_INC].bytes = stats.ibytes;
     port_stats[PACKET_DIR_OUT].packets = stats.opackets;

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -258,6 +258,8 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
    * with minor tweaks */
   rte_eth_dev_info_get(ret_port_id, &dev_info);
 
+  driver_ = dev_info.driver_name;
+
   eth_rxconf = dev_info.default_rxconf;
 
   /* #36: em driver does not allow rx_drop_en enabled */
@@ -355,17 +357,25 @@ void PMDPort::CollectStats(bool reset) {
 
   port_stats[PACKET_DIR_INC].dropped = stats.imissed;
 
-  dir = PACKET_DIR_INC;
-  for (qid = 0; qid < num_queues[dir]; qid++) {
-    queue_stats[dir][qid].packets = stats.q_ipackets[qid];
-    queue_stats[dir][qid].bytes = stats.q_ibytes[qid];
-    queue_stats[dir][qid].dropped = stats.q_errors[qid];
-  }
+  // i40e PMD driver doesn't support per-queue stats
+  if (driver_ == "rte_i40e_pmd") {
+    port_stats[PACKET_DIR_INC].packets = stats.ipackets;
+    port_stats[PACKET_DIR_INC].bytes = stats.ibytes;
+    port_stats[PACKET_DIR_OUT].packets = stats.opackets;
+    port_stats[PACKET_DIR_OUT].bytes = stats.obytes;
+  } else {
+    dir = PACKET_DIR_INC;
+    for (qid = 0; qid < num_queues[dir]; qid++) {
+      queue_stats[dir][qid].packets = stats.q_ipackets[qid];
+      queue_stats[dir][qid].bytes = stats.q_ibytes[qid];
+      queue_stats[dir][qid].dropped = stats.q_errors[qid];
+    }
 
-  dir = PACKET_DIR_OUT;
-  for (qid = 0; qid < num_queues[dir]; qid++) {
-    queue_stats[dir][qid].packets = stats.q_opackets[qid];
-    queue_stats[dir][qid].bytes = stats.q_obytes[qid];
+    dir = PACKET_DIR_OUT;
+    for (qid = 0; qid < num_queues[dir]; qid++) {
+      queue_stats[dir][qid].packets = stats.q_opackets[qid];
+      queue_stats[dir][qid].bytes = stats.q_obytes[qid];
+    }
   }
 }
 

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -89,6 +89,10 @@ class PMDPort final : public Port {
    */
   int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
+  virtual uint64_t GetFlags() const override {
+    return DRIVER_FLAG_SELF_INC_STATS | DRIVER_FLAG_SELF_OUT_STATS;
+  }
+
  private:
   /*!
    * The DPDK port ID number (set after binding).

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -1,6 +1,8 @@
 #ifndef BESS_DRIVERS_PMD_H_
 #define BESS_DRIVERS_PMD_H_
 
+#include <string>
+
 #include <rte_config.h>
 #include <rte_errno.h>
 #include <rte_ethdev.h>
@@ -97,6 +99,8 @@ class PMDPort final : public Port {
    * True if device did not exist when bessd started and was later patched in.
    */
   bool hot_plugged_;
+
+  std::string driver_;    // ixgbe, i40e, ...
 };
 
 #endif  // BESS_DRIVERS_PMD_H_

--- a/core/port.h
+++ b/core/port.h
@@ -186,7 +186,7 @@ class Port {
   virtual size_t DefaultIncQueueSize() const { return kDefaultIncQueueSize; }
   virtual size_t DefaultOutQueueSize() const { return kDefaultOutQueueSize; }
 
-  virtual size_t GetFlags() const { return kFlags; }
+  virtual uint64_t GetFlags() const { return 0; }
 
   // -------------------------------------------------------------------------
 
@@ -223,8 +223,6 @@ class Port {
 
   static const size_t kDefaultIncQueueSize = 256;
   static const size_t kDefaultOutQueueSize = 256;
-
-  static const uint32_t kFlags = 0;
 
   DISALLOW_COPY_AND_ASSIGN(Port);
 


### PR DESCRIPTION
`show port` / `monitor port` did not show statistics counters for i40e PMD devices. There were two issues:

* i40e doesn't support per-queue stats, but only port-wide stats. The PMD driver only used per-queue stats.
* While we do not need to accumulate counters with PMD drivers (since they have their own), it was doing that (thus wasting CPU cycles). This is regression of C++ porting.