### PR TITLE
Increase min packet size in latency script so that timestamps do not get

### DIFF
--- a/bessctl/conf/perftest/pktgen_latency.bess
+++ b/bessctl/conf/perftest/pktgen_latency.bess
@@ -1,7 +1,7 @@
 import scapy.all as scapy
 import time
 
-pkt_size = int($SN_PKT_SIZE!'60')
+pkt_size = int($SN_PKT_SIZE!'100')
 num_ports = int($SN_PORTS!'1')
 num_cores = int($SN_CORES!num_ports)
 burst = int($SN_BURST!'32')

--- a/bessctl/conf/perftest/pktgen_latency.bess
+++ b/bessctl/conf/perftest/pktgen_latency.bess
@@ -7,7 +7,7 @@ num_cores = int($SN_CORES!num_ports)
 burst = int($SN_BURST!'32')
 mbps = int($SN_MBPS!'100')
 
-assert(60 <= pkt_size <= 1522)
+assert(63 <= pkt_size <= 1522)
 assert(1 <= num_ports <= 16)
 assert(1 <= num_cores <= 4)
 


### PR DESCRIPTION
truncated.