### PR TITLE
Fix Update module updating at an incorrect offset

### DIFF
--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -20,14 +20,13 @@ void Update::ProcessBatch(bess::PacketBatch *batch) {
 
     uint64_t mask = field->mask;
     uint64_t value = field->value;
-    int16_t offset = field->offset;
+    int16_t offset = field->offset;   // could be < 0
 
     for (int j = 0; j < cnt; j++) {
       bess::Packet *snb = batch->pkts()[j];
       char *head = snb->head_data<char *>();
 
-      uint64_t *p = reinterpret_cast<uint64_t *>(head) + offset;
-
+      uint64_t *p = reinterpret_cast<uint64_t *>(head + offset);
       *p = (*p & mask) | value;
     }
   }


### PR DESCRIPTION
it should update packets at `offset`, not `offset * sizeof(uint64_t)`