### PR TITLE
Various fixes to UrlFilter

### DIFF
--- a/bessctl/conf/samples/url_filter.bess
+++ b/bessctl/conf/samples/url_filter.bess
@@ -5,11 +5,11 @@ import scapy.all as scapy
 eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
 ip = scapy.IP(src='192.168.0.1', dst='10.0.0.1')
 tcp = scapy.TCP(sport=10001, dport=80, seq=12345)
-payload = 'GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n'
+payload = 'GET /pub/WWW/TheProject.html HTTP/1.1\r\nHost: www.google.com\r\n\r\n'
 pkt = str(eth/ip/tcp/payload)
 
-src::FlowGen(template=pkt, pps=2.2e6, flow_rate = 1e3, flow_duration = 10.0, \
-    arrival='uniform', duration='uniform', quick_rampup=True)
+src::FlowGen(template=pkt, pps=2.2e6, flow_rate=800, flow_duration=5.0, \
+    arrival='uniform', duration='uniform', quick_rampup=False)
 
 blacklist_rules = [{'host': 'www.%d.com' % i, 'path': '/'} for i in range(100)]
 filter::UrlFilter(blacklist=blacklist_rules)

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -218,8 +218,14 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
 
     TcpFlowReconstruct &buffer = flow_cache_.at(flow);
 
-    // If the reconstruct code indicates failure, treat it as a flow to drop.
-    bool matched = !buffer.InsertPacket(pkt);
+    // If the reconstruct code indicates failure, treat it as a flow to pass.
+    // No need to parse the headers if the reconstruct code tells us it failed.
+    bool success = buffer.InsertPacket(pkt);
+    if (!success) {
+      DLOG(WARNING) << "Reconstruction failure";
+      out_batches[0].add(pkt);
+      continue;
+    }
 
     // No need to parse the headers if the reconstruct code tells us it failed.
     if (!matched) {

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -227,33 +227,31 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
       continue;
     }
 
-    // No need to parse the headers if the reconstruct code tells us it failed.
-    if (!matched) {
-      struct phr_header headers[16];
-      size_t num_headers = 16, method_len, path_len;
-      int minor_version;
-      const char *method, *path;
-      int parse_result = phr_parse_request(
-          buffer.buf(), buffer.contiguous_len(), &method, &method_len, &path,
-          &path_len, &minor_version, headers, &num_headers, 0);
+    bool matched = false;
+    struct phr_header headers[16];
+    size_t num_headers = 16, method_len, path_len;
+    int minor_version;
+    const char *method, *path;
+    int parse_result = phr_parse_request(
+        buffer.buf(), buffer.contiguous_len(), &method, &method_len, &path,
+        &path_len, &minor_version, headers, &num_headers, 0);
 
-      // -2 means incomplete
-      if (parse_result > 0 || parse_result == -2) {
-        const std::string path_str(path, path_len);
+    // -2 means incomplete
+    if (parse_result > 0 || parse_result == -2) {
+      const std::string path_str(path, path_len);
 
-        // Look for the Host header
-        for (size_t j = 0; j < num_headers; ++j) {
-          if (strncmp(headers[j].name, HTTP_HEADER_HOST, headers[j].name_len) ==
-              0) {
-            const std::string host(headers[j].value, headers[j].value_len);
-            const auto rule_iterator = blacklist_.find(host);
+      // Look for the Host header
+      for (size_t j = 0; j < num_headers; ++j) {
+        if (strncmp(headers[j].name, HTTP_HEADER_HOST, headers[j].name_len) ==
+            0) {
+          const std::string host(headers[j].value, headers[j].value_len);
+          const auto rule_iterator = blacklist_.find(host);
 
-            if (rule_iterator != blacklist_.end() &&
-                rule_iterator->second.LookupKey(path_str)) {
-              // found a match
-              matched = true;
-              break;
-            }
+          if (rule_iterator != blacklist_.end() &&
+              rule_iterator->second.LookupKey(path_str)) {
+            // found a match
+            matched = true;
+            break;
           }
         }
       }

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -11,6 +11,7 @@
 
 #include "../module.h"
 #include "../module_msg.pb.h"
+#include "../packet.h"
 #include "../utils/tcp_flow_reconstruct.h"
 #include "../utils/trie.h"
 
@@ -58,6 +59,19 @@ struct FlowHash {
   }
 };
 
+class FlowRecord {
+ public:
+  FlowRecord() : buffer_(128), expiry_time_(0) {}
+
+  TcpFlowReconstruct &GetBuffer() { return buffer_; }
+  uint64_t ExpiryTime() { return expiry_time_; }
+  void SetExpiryTime(uint64_t time) { expiry_time_ = time; }
+
+ private:
+  TcpFlowReconstruct buffer_;
+  uint64_t expiry_time_;
+};
+
 // A module of HTTP URL filtering. Ends an HTTP connection if the Host field
 // matches the blacklist.
 // igate/ogate 0: traffic from internal network to external network
@@ -79,8 +93,7 @@ class UrlFilter final : public Module {
 
  private:
   std::unordered_map<std::string, Trie> blacklist_;
-  std::unordered_map<Flow, TcpFlowReconstruct, FlowHash> flow_cache_;
-  std::unordered_map<Flow, uint64_t, FlowHash> blocked_flows_;
+  std::unordered_map<Flow, FlowRecord, FlowHash> flow_cache_;
 };
 
 #endif  // BESS_MODULES_URL_FILTER_H_

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -78,12 +78,15 @@ class TcpFlowReconstruct {
     }
 
     if (!initialized_) {
+      DLOG(WARNING) << "Non-SYN received but not yet initialized.";
       return false;
     }
 
-    // Check if the sequence number is greater than SYN + 1. Wraparound is
-    // possible.
+    // Check if the sequence number is greater or equal than SYN + 1. Wraparound
+    // is possible.
     if ((int32_t)(seq - init_seq_) < 0) {
+      DLOG(WARNING) << "Sequence number not match. Initial seq: " << init_seq_
+                    << ", Seq: " << seq;
       return false;
     }
 


### PR DESCRIPTION
- Add logging
- Disable quick ramp up in the sample script
- Pass the packet if reconstruction is failed
- A few optimizations