### PR TITLE
Resizing and specifying IP/portranges now works.

### DIFF
--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -185,6 +185,10 @@ message FlowGenArg {
   string arrival = 5;
   string duration = 6;
   bool quick_rampup = 7;
+  uint32 ip_src_range = 8;
+  uint32 ip_dst_range = 9;
+  uint32 port_src_range = 10;
+  uint32 port_dst_range = 11;
 }
 
 message GenericDecapArg {


### PR DESCRIPTION
THREE PRS IN ONE DAY HOLLA 

So here are two more changes to Flowgen:
(1) SYN and FIN packets are now payload-less, so as not to trigger much angst in our NFs.

(2) (And this will need some explaining) -> it now chooses a new <IP Src, IP Dst, Src Port, Dst Port> for each flow. The user can specify a "range" for these values that are an increment off the base packet_template. So for example, if the template says SRC IP = 10.0.0.1, and my Src Port Range is 4, It will generate flows with SRC IP \in {10.0.0.1, 10.0.0.2, 10.0.0.3, 10.0.0.4}.

Here's why this needs to be in Flowgen: with the other packetgen, we just do random updates to e.g, update the source IP or change the ports. But that doesn't retain the flow semantics -- doing it randomly breaks it -- everything from a flow has the same header, sequence numbers line up, etc. The rewriting needs to be consistent. 

Doing this with a "range" value is what the WindRiver packetgen does (one of the sample DPDK apps), so I literally just copied their idea.