### PR TITLE
Add CuckooMap

### DIFF
--- a/core/utils/cuckoo_map.h
+++ b/core/utils/cuckoo_map.h
@@ -1,0 +1,342 @@
+/* Streamlined hash table implementation, with emphasis on lookup performance.
+ * Key and value sizes are fixed. Lookup is thread-safe, but update is not. */
+
+#ifndef BESS_UTILS_CUCKOOMAP_H_
+#define BESS_UTILS_CUCKOOMAP_H_
+
+#include <algorithm>
+#include <limits>
+#include <stack>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+
+#include "../mem_alloc.h"
+#include "common.h"
+
+namespace bess {
+namespace utils {
+
+// Hash function. Return size_t as the hash code.
+template <typename K>
+using HashFunc = size_t (*)(const K& key, size_t init_val);
+
+// Compare function. Return true if the lhs and rhs are identical.
+template <typename K>
+using EqFunc = bool (*)(const K& lhs, const K& rhs);
+
+template <typename K>
+static inline size_t DefaultHashFunc(const K& key, size_t) {
+  return std::hash<K>()(key);
+}
+
+template <typename K>
+static inline bool DefaultEqFunc(const K& lhs, const K& rhs) {
+  return lhs == rhs;
+}
+
+// Cuckoo HashMap implementation
+template <typename K, typename V, HashFunc<K> H = DefaultHashFunc,
+          EqFunc<K> E = DefaultEqFunc>
+class CuckooMap {
+ public:
+  typedef std::pair<K, V> Entry;
+
+  CuckooMap()
+      : bucket_mask_(kInitNumBucket - 1),
+        num_entries_(0),
+        buckets_(kInitNumBucket),
+        entries_(kInitNumEntries),
+        free_entry_indices_() {
+    for (int i = kInitNumEntries - 1; i >= 0; --i) {
+      free_entry_indices_.push(i);
+    }
+  }
+
+  // Not allowing copying for now
+  CuckooMap(CuckooMap&) = delete;
+  CuckooMap& operator=(CuckooMap&) = delete;
+
+  // Allow move
+  CuckooMap(CuckooMap&&) = default;
+  CuckooMap& operator=(CuckooMap&&) = default;
+
+  // Insert/update a key value pair
+  // Return the pointer to the inserted entry
+  Entry* Insert(const K& key, const V& value) {
+    size_t primary = Hash(key);
+
+    Entry* entry = GetHash(primary, key);
+    if (entry) {
+      entry->second = value;
+      return entry;
+    }
+
+    size_t secondary = HashSecondary(primary);
+
+    while ((entry = AddEntry(primary, secondary, key, value)) == nullptr) {
+      // expand the table as the last resort
+      ExpandBuckets();
+    }
+    return entry;
+  }
+
+  // Find the pointer to the stored value by the key.
+  // Return nullptr if not exist.
+  Entry* Find(const K& key) { return GetHash(Hash(key), key); }
+
+  // Remove the stored entry by the key
+  // Return false if not exist.
+  bool Remove(const K& key) {
+    size_t pri = Hash(key);
+    if (RemoveFromBucket(pri, pri & bucket_mask_, key)) {
+      return true;
+    }
+    size_t sec = HashSecondary(pri);
+    if (RemoveFromBucket(pri, sec & bucket_mask_, key)) {
+      return true;
+    }
+    return false;
+  }
+
+  // Return the number of stored entries
+  size_t Count() const { return num_entries_; }
+
+ private:
+  // Tunable macros
+  static const int kInitNumBucket = 4;
+  static const int kInitNumEntries = 16;
+  static const int kEntriesPerBucket = 4;  // 4-way set associative
+
+  // 4^kMaxCuckooPath buckets will be considered to make a empty slot,
+  // before giving up and expand the table.
+  // Higher number will yield better occupancy, but the worst case performance
+  // of insertion will grow exponentially, so be careful.
+  static const int kMaxCuckooPath = 3;
+
+  // non-tunable macros
+  static const size_t kHashInitval = UINT64_MAX;
+
+  struct Bucket {
+    size_t hash_values[kEntriesPerBucket];
+    size_t key_indices[kEntriesPerBucket];
+
+    Bucket() : hash_values(), key_indices() {}
+  };
+
+  // Push an unused entry index back to the  stack
+  void PushFreeKeyIndex(size_t idx) { free_entry_indices_.push(idx); }
+
+  // Pop a free entry index from stack and return the index
+  size_t PopFreeKeyIndex() {
+    if (free_entry_indices_.empty()) {
+      ExpandEntries();
+    }
+    size_t idx = free_entry_indices_.top();
+    free_entry_indices_.pop();
+    return idx;
+  }
+
+  // Try to add (key, value) to the bucket indexed by bucket_idx
+  // Return the pointer to the entry if success. Otherwise return nullptr.
+  Entry* AddToBucket(size_t bucket_idx, const K& key, const V& value) {
+    Bucket& bucket = buckets_[bucket_idx];
+    int slot_idx = FindSlot(bucket, 0);
+
+    if (slot_idx == -1) {
+      return nullptr;
+    }
+
+    size_t free_idx = PopFreeKeyIndex();
+
+    bucket.hash_values[slot_idx] = Hash(key);
+    bucket.key_indices[slot_idx] = free_idx;
+
+    Entry& entry = entries_[free_idx];
+    entry.first = key;
+    entry.second = value;
+
+    num_entries_++;
+    return &entry;
+  }
+
+  // Remove key from the bucket indexed by bucket_idx
+  // Return true if success.
+  bool RemoveFromBucket(size_t primary, size_t bucket_idx, const K& key) {
+    Bucket& bucket = buckets_[bucket_idx];
+
+    int slot_idx = FindSlot(bucket, primary);
+    if (slot_idx == -1) {
+      return false;
+    }
+
+    size_t idx = bucket.key_indices[slot_idx];
+    Entry& entry = entries_[idx];
+    if (E(entry.first, key)) {
+      bucket.hash_values[slot_idx] = 0;
+      entry = Entry();
+      PushFreeKeyIndex(idx);
+      num_entries_--;
+      return true;
+    }
+
+    return false;
+  }
+
+  // Remove key from the bucket indexed by bucket_idx
+  // Return the pointer to the entry if success. Otherwise return nullptr.
+  Entry* GetFromBucket(size_t primary, size_t bucket_idx, const K& key) {
+    Bucket& bucket = buckets_[bucket_idx];
+
+    int slot_idx = FindSlot(bucket, primary);
+    if (slot_idx == -1) {
+      return nullptr;
+    }
+
+    size_t idx = bucket.key_indices[slot_idx];
+    if (E(entries_[idx].first, key)) {
+      return &entries_[idx];
+    }
+
+    return nullptr;
+  }
+
+  // Try to add the entry (key, value)
+  // Return the pointer to the entry if success. Otherwise return nullptr.
+  Entry* AddEntry(size_t primary, size_t secondary, const K& key,
+                  const V& value) {
+    uint32_t primary_bucket_index, secondary_bucket_index;
+    Entry* entry = nullptr;
+  again:
+    primary_bucket_index = primary & bucket_mask_;
+    if ((entry = AddToBucket(primary_bucket_index, key, value)) != nullptr) {
+      return entry;
+    }
+
+    secondary_bucket_index = secondary & bucket_mask_;
+    if ((entry = AddToBucket(secondary_bucket_index, key, value)) != nullptr) {
+      return entry;
+    }
+
+    if (MakeSpace(primary_bucket_index, 0) >= 0) {
+      goto again;
+    }
+
+    if (MakeSpace(secondary_bucket_index, 0) >= 0) {
+      goto again;
+    }
+
+    return nullptr;
+  }
+
+  // Return the slot index in the bucket that matches the hash_value
+  // -1 if not found.
+  int FindSlot(const Bucket& bucket, size_t hash_value) {
+    for (int i = 0; i < kEntriesPerBucket; i++) {
+      if (bucket.hash_values[i] == hash_value) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  // Recursively try making an empty slot in the bucket
+  // Returns a slot index in [0, kEntriesPerBucket) for successful operation,
+  // or -1 if failed.
+  int MakeSpace(size_t index, int depth) {
+    if (depth >= kMaxCuckooPath) {
+      return -1;
+    }
+
+    Bucket& bucket = buckets_[index];
+
+    for (int i = 0; i < kEntriesPerBucket; i++) {
+      const K& key = bucket.key_indices[i];
+      size_t pri = Hash(key);
+      size_t sec = HashSecondary(pri);
+
+      size_t alt_index;
+
+      // this entry is in its primary bucket?
+      if (pri == bucket.hash_values[i]) {
+        alt_index = sec & bucket_mask_;
+      } else if (sec == bucket.hash_values[i]) {
+        alt_index = pri & bucket_mask_;
+      } else {
+        return -1;
+      }
+
+      // Find empty slot
+      int j = FindSlot(buckets_[alt_index], 0);
+      if (j == -1) {
+        j = MakeSpace(alt_index, depth + 1);
+      }
+      if (j >= 0) {
+        Bucket& alt_bucket = buckets_[alt_index];
+        alt_bucket.hash_values[j] = bucket.hash_values[i];
+        alt_bucket.key_indices[j] = bucket.key_indices[i];
+        bucket.hash_values[i] = 0;
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  // Get the entry given the primary hash value of the key.
+  // Returns the pointer to the entry or nullptr if failed.
+  Entry* GetHash(size_t primary, const K& key) {
+    Entry* ret = GetFromBucket(primary, primary & bucket_mask_, key);
+    if (ret) {
+      return ret;
+    }
+    return GetFromBucket(primary, HashSecondary(primary) & bucket_mask_, key);
+  }
+
+  // Secondary hash value
+  static size_t HashSecondary(uint32_t primary) {
+    size_t tag = primary >> 12;
+    return primary ^ ((tag + 1) * 0x5bd1e995);
+  }
+
+  // Primary hash value
+  static size_t Hash(const K& key) { return H(key, kHashInitval); }
+
+  // Resize the space of entries. Grow less aggressively than buckets.
+  void ExpandEntries() {
+    size_t old_size = num_entries_;
+    size_t new_size = old_size + old_size / 2;
+
+    entries_.resize(new_size);
+
+    for (size_t i = new_size - 1; i >= old_size; --i) {
+      free_entry_indices_.push(i);
+    }
+  }
+
+  // Resize the space of buckets.
+  void ExpandBuckets() {
+    size_t new_size = (bucket_mask_ + 1) * 2;
+    buckets_.resize(new_size);
+    bucket_mask_ = new_size - 1;
+  }
+
+  // # of buckets == mask + 1
+  size_t bucket_mask_;
+
+  // # of entries
+  size_t num_entries_;
+
+  // bucket and entry arrays grow independently
+  std::vector<Bucket> buckets_;
+  std::vector<Entry> entries_;
+
+  // Stack of free entries
+  std::stack<size_t> free_entry_indices_;
+};
+
+}  // namespace utils
+}  // namespace bess
+
+#endif  // BESS_UTILS_CUCKOOMAP_H_

--- a/core/utils/cuckoo_map_test.cc
+++ b/core/utils/cuckoo_map_test.cc
@@ -1,0 +1,75 @@
+#include "cuckoo_map.h"
+
+#include <rte_config.h>
+#include <rte_hash.h>
+#include <rte_hash_crc.h>
+
+#include <gtest/gtest.h>
+
+using bess::utils::CuckooMap;
+
+namespace {
+
+typedef uint16_t value_t;
+
+// Test Insert function
+TEST(CuckooMapTest, Insert) {
+  CuckooMap<uint32_t, value_t> cuckoo;
+  EXPECT_EQ(cuckoo.Insert(1, 99)->second, 99);
+  EXPECT_EQ(cuckoo.Insert(2, 98)->second, 98);
+  EXPECT_EQ(cuckoo.Insert(1, 1)->second, 1);
+}
+
+// Test Find function
+TEST(CuckooMapTest, Find) {
+  CuckooMap<uint32_t, value_t> cuckoo;
+
+  cuckoo.Insert(1, 99);
+  cuckoo.Insert(2, 99);
+
+  EXPECT_EQ(cuckoo.Find(1)->second, 99);
+  EXPECT_EQ(cuckoo.Find(2)->second, 99);
+
+  cuckoo.Insert(1, 2);
+  EXPECT_EQ(cuckoo.Find(1)->second, 2);
+
+  EXPECT_EQ(cuckoo.Find(3), nullptr);
+  EXPECT_EQ(cuckoo.Find(4), nullptr);
+}
+
+// Test Remove function
+TEST(CuckooMapTest, Remove) {
+  CuckooMap<uint32_t, value_t> cuckoo;
+
+  cuckoo.Insert(1, 99);
+  cuckoo.Insert(2, 99);
+
+  EXPECT_EQ(cuckoo.Find(1)->second, 99);
+  EXPECT_EQ(cuckoo.Find(2)->second, 99);
+
+  EXPECT_TRUE(cuckoo.Remove(1));
+  EXPECT_TRUE(cuckoo.Remove(2));
+
+  EXPECT_EQ(cuckoo.Find(1), nullptr);
+  EXPECT_EQ(cuckoo.Find(2), nullptr);
+}
+
+// Test Count function
+TEST(CuckooMapTest, Count) {
+  CuckooMap<uint32_t, value_t> cuckoo;
+
+  EXPECT_EQ(cuckoo.Count(), 0);
+
+  cuckoo.Insert(1, 99);
+  cuckoo.Insert(2, 99);
+  EXPECT_EQ(cuckoo.Count(), 2);
+
+  cuckoo.Insert(1, 2);
+  EXPECT_EQ(cuckoo.Count(), 2);
+
+  EXPECT_TRUE(cuckoo.Remove(1));
+  EXPECT_TRUE(cuckoo.Remove(2));
+  EXPECT_EQ(cuckoo.Count(), 0);
+}
+
+}  // namespace (unnamed)


### PR DESCRIPTION
`CuckooMap` is a re-implementation of `HTableBase`/`HTable` in C++, which should be easier to use. We should also make a call about whether to obsolete the old `HTableBase`/`HTable` class, since there are still some performance differences between the two. (@sangjinhan Do you know why?)

Performance test on my laptop:

```
Run on (2 X 3100 MHz CPU s)
2017-02-01 00:41:50
***WARNING*** Library was built as DEBUG. Timings may be affected.
Benchmark                                        Time           CPU Iterations
------------------------------------------------------------------------------
HTableFixture/BessGet/4                         12 ns         12 ns   59760123    81.908M items/s
HTableFixture/BessGet/16                        13 ns         13 ns   51220177   75.7545M items/s
HTableFixture/BessGet/64                        12 ns         12 ns   55772978   77.6166M items/s
HTableFixture/BessGet/256                       19 ns         19 ns   45307156   51.4939M items/s
HTableFixture/BessGet/1024                      19 ns         19 ns   34998986   51.2979M items/s
HTableFixture/BessGet/4k                        24 ns         24 ns   30117613   39.0721M items/s
HTableFixture/BessGet/16k                       31 ns         31 ns   26598897   30.9128M items/s
HTableFixture/BessGet/64k                       35 ns         35 ns   16286704   27.4377M items/s
HTableFixture/BessGet/256k                      67 ns         67 ns   10090639   14.2278M items/s
HTableFixture/BessGet/1024k                     96 ns         95 ns    7213336   9.99544M items/s
HTableFixture/BessInlinedGet/4                   3 ns          3 ns  231264211    304.49M items/s
HTableFixture/BessInlinedGet/16                  4 ns          4 ns  176768681   239.973M items/s
HTableFixture/BessInlinedGet/64                  4 ns          4 ns  196084934   266.154M items/s
HTableFixture/BessInlinedGet/256                 4 ns          4 ns  196217411   270.817M items/s
HTableFixture/BessInlinedGet/1024                4 ns          4 ns  190971570   241.514M items/s
HTableFixture/BessInlinedGet/4k                  9 ns          9 ns   73837645   110.465M items/s
HTableFixture/BessInlinedGet/16k                16 ns         16 ns   48800422   59.3508M items/s
HTableFixture/BessInlinedGet/64k                16 ns         16 ns   43832130   60.5671M items/s
HTableFixture/BessInlinedGet/256k               35 ns         35 ns   18817139   27.1261M items/s
HTableFixture/BessInlinedGet/1024k              50 ns         50 ns   10000000   18.9119M items/s
HTableFixture/CuckooMapInlinedGet/4              3 ns          3 ns  245701128   343.512M items/s
HTableFixture/CuckooMapInlinedGet/16             4 ns          4 ns  184277310   227.769M items/s
HTableFixture/CuckooMapInlinedGet/64             4 ns          4 ns  164592249   229.898M items/s
HTableFixture/CuckooMapInlinedGet/256            4 ns          4 ns  174026201   230.333M items/s
HTableFixture/CuckooMapInlinedGet/1024           5 ns          5 ns  130955084   195.433M items/s
HTableFixture/CuckooMapInlinedGet/4k             5 ns          5 ns  120370723   182.016M items/s
HTableFixture/CuckooMapInlinedGet/16k            8 ns          8 ns   85845310   112.459M items/s
HTableFixture/CuckooMapInlinedGet/64k           41 ns         41 ns   17347395   23.3109M items/s
HTableFixture/CuckooMapInlinedGet/256k          55 ns         55 ns   12863429   17.2977M items/s
HTableFixture/CuckooMapInlinedGet/1024k         54 ns         54 ns   17099507   17.5932M items/s
HTableFixture/STLUnorderedMapGet/4              14 ns         14 ns   50579583   67.4564M items/s
HTableFixture/STLUnorderedMapGet/16             15 ns         15 ns   46794735   64.6603M items/s
HTableFixture/STLUnorderedMapGet/64             15 ns         15 ns   46970834   63.1689M items/s
HTableFixture/STLUnorderedMapGet/256            15 ns         15 ns   46294849   62.9837M items/s
HTableFixture/STLUnorderedMapGet/1024           17 ns         17 ns   42070981   57.5958M items/s
HTableFixture/STLUnorderedMapGet/4k             21 ns         21 ns   34000828   46.3679M items/s
HTableFixture/STLUnorderedMapGet/16k            25 ns         25 ns   27502445   37.7127M items/s
HTableFixture/STLUnorderedMapGet/64k            43 ns         43 ns   12836915   22.0371M items/s
HTableFixture/STLUnorderedMapGet/256k           88 ns         88 ns    7365466   10.7965M items/s
HTableFixture/STLUnorderedMapGet/1024k         173 ns        173 ns    3572826   5.50022M items/s
```
