### PR TITLE
Improve CLI usability, including crashlog support

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -5,6 +5,7 @@ import os.path
 import pprint
 import cStringIO
 import tempfile
+import time
 
 import cli
 import commands
@@ -17,7 +18,9 @@ except ImportError:
     print >> sys.stderr, 'Cannot import the API module (libbess-python)'
     raise
 
+
 class BESSCLI(cli.CLI):
+
     def __init__(self, bess, cmd_db, fin=sys.stdin,
                  fout=sys.stdout, history_file=None):
         self.bess = bess
@@ -51,9 +54,21 @@ class BESSCLI(cli.CLI):
     def call_func(self, func, args):
         try:
             super(BESSCLI, self).call_func(func, args)
+
         except self.bess.APIError as e:
             self.err(e)
             raise self.HandledError()
+
+        except self.bess.RPCError as e:
+            self.err('RPC failed to {}:{} - {}'.format(
+                    self.bess.peer[0], self.bess.peer[1], e.message))
+
+            host = self.bess.peer[0]
+            if host == 'localhost' or self.bess.peer[0].startswith('127.'):
+                self.print_crashlog()
+
+            raise self.HandledError()
+
         except self.bess.Error as e:
             self.err(e.errmsg)
 
@@ -82,15 +97,13 @@ class BESSCLI(cli.CLI):
         try:
             log_path = tempfile.gettempdir() + '/bessd_crash.log'
             log = open(log_path).read()
-            self.fout.write(log)
-        except:
-            pass
+            ctime = time.ctime(os.path.getmtime(log_path))
+            self.ferr.write('From {} ({}):\n{}'.format(log_path, ctime, log))
+        except Exception as e:
+            self.ferr.write('%s is not available: %s' % (log_path, str(e)))
 
     def loop(self):
         super(BESSCLI, self).loop()
-        # TODO: raise an exception when gRPC abnormaly disconnects
-        # Then use self.print_crashlog() to print out the call stack trace
-        # when the bessd daemon process aborts
         self.bess.disconnect()
 
     def get_prompt(self):
@@ -123,7 +136,7 @@ def run_cmds(instream):
     try:
         s = BESS()
         s.connect()
-    except BESS.APIError as e:
+    except BESS.APIError:
         # show no error msg, since user might be about to launch the daemon
         pass
 

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -51,6 +51,12 @@ class BESSCLI(cli.CLI):
     def get_default_args(self):
         return [self]
 
+    def _handle_broken_connection(self):
+        host = self.bess.peer[0]
+        if host == 'localhost' or self.bess.peer[0].startswith('127.'):
+            self._print_crashlog()
+        self.bess.disconnect()
+
     def call_func(self, func, args):
         try:
             super(BESSCLI, self).call_func(func, args)
@@ -63,10 +69,7 @@ class BESSCLI(cli.CLI):
             self.err('RPC failed to {}:{} - {}'.format(
                     self.bess.peer[0], self.bess.peer[1], e.message))
 
-            host = self.bess.peer[0]
-            if host == 'localhost' or self.bess.peer[0].startswith('127.'):
-                self.print_crashlog()
-
+            self._handle_broken_connection()
             raise self.HandledError()
 
         except self.bess.Error as e:
@@ -93,7 +96,7 @@ class BESSCLI(cli.CLI):
 
             raise self.HandledError()
 
-    def print_crashlog(self):
+    def _print_crashlog(self):
         try:
             log_path = tempfile.gettempdir() + '/bessd_crash.log'
             log = open(log_path).read()
@@ -109,8 +112,11 @@ class BESSCLI(cli.CLI):
     def get_prompt(self):
         if self.bess.is_connected():
             return '%s:%d $ ' % self.bess.peer
-        else:
-            return '<disconnected> $ '
+
+        if self.bess.is_connection_broken():
+            self._handle_broken_connection()
+
+        return '<disconnected> $ '
 
 
 def run_cli():

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -21,14 +21,12 @@ except ImportError:
 
 class BESSCLI(cli.CLI):
 
-    def __init__(self, bess, cmd_db, fin=sys.stdin,
-                 fout=sys.stdout, history_file=None):
+    def __init__(self, bess, cmd_db, **kwargs):
         self.bess = bess
         self.cmd_db = cmd_db
         self.this_dir = this_dir
 
-        super(BESSCLI, self).__init__(self.cmd_db.cmdlist, fin=fin, fout=fout,
-                                      history_file=history_file)
+        super(BESSCLI, self).__init__(self.cmd_db.cmdlist, **kwargs)
 
     def get_var_attrs(self, var_token, partial_word):
         return self.cmd_db.get_var_attrs(self, var_token, partial_word)
@@ -119,12 +117,34 @@ class BESSCLI(cli.CLI):
         return '<disconnected> $ '
 
 
+class ColorizedOutput(object):
+    def __init__(self, orig_out, color):
+        self.orig_out = orig_out
+        self.color = color
+
+    def __getattr__(self, attr):
+        def_color = '\033[0;0m'  # resets all terminal attributes
+
+        if attr == 'write':
+            return lambda x: self.orig_out.write(self.color + x + def_color)
+        else:
+            return getattr(self.orig_out, attr)
+
+
 def run_cli():
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+
+    # Colorize output to standard error
+    if interactive and sys.stderr.isatty():
+        stderr = ColorizedOutput(sys.stderr, '\033[31m')  # red (not bright)
+    else:
+        stderr = sys.stderr
+
     try:
         hist_file = os.path.expanduser('~/.bess_history')
         open(hist_file, 'a+').close()
     except:
-        print >> sys.stderr, 'Error: Cannot open ~/.bess_history'
+        print >> stderr, 'Error: Cannot open ~/.bess_history'
         hist_file = None
         raise
 
@@ -132,9 +152,10 @@ def run_cli():
         s = BESS()
         s.connect()
     except BESS.APIError as e:
-        print >> sys.stderr, e.message, '(bessd daemon is not running?)'
+        print >> stderr, e.message, '(bessd daemon is not running?)'
 
-    cli = BESSCLI(s, commands, history_file=hist_file)
+    cli = BESSCLI(s, commands, ferr=stderr, interactive=interactive,
+                  history_file=hist_file)
     cli.loop()
 
 
@@ -146,7 +167,7 @@ def run_cmds(instream):
         # show no error msg, since user might be about to launch the daemon
         pass
 
-    cli = BESSCLI(s, commands, fin=instream, history_file=None)
+    cli = BESSCLI(s, commands, fin=instream, interactive=False)
     cli.loop()
 
     # end of loop due to error?

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -541,6 +541,9 @@ def _do_start(cli, opts):
     else:
         cli.bess.connect()
 
+    if cli.interactive:
+        cli.fout.write('Done.\n')
+
 
 @cmd('daemon start [BESSD_OPTS...]', 'Start BESS daemon in the local machine')
 def daemon_start(cli, opts):
@@ -563,9 +566,6 @@ def daemon_start(cli, opts):
         warn(cli, 'Existing BESS daemon will be killed.', _do_start, opts)
     else:
         _do_start(cli, opts)
-
-    if cli.interactive:
-        cli.fout.write('Done.\n')
 
 
 def is_pipeline_empty(cli):

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -892,7 +892,12 @@ def _show_tc_list(cli, tcs):
 
 @cmd('show tc', 'Show the list of traffic classes')
 def show_tc_all(cli):
-    _show_tc_list(cli, cli.bess.list_tcs().classes_status)
+    classes = cli.bess.list_tcs().classes_status
+
+    if len(classes) == 0:
+        raise cli.CommandError('There is no traffic class tho show.')
+    else:
+        _show_tc_list(cli, classes)
 
 
 @cmd('show tc worker WORKER_ID...', 'Show the list of traffic classes')

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -673,13 +673,14 @@ def _do_run_file(cli, conf_file):
         cli.err('%s (most recent call last)' % errmsg)
         cli.ferr.write(''.join(traceback.format_list(stack)))
 
-        if isinstance(v, cli.bess.Error):
+        if isinstance(v, (cli.bess.Error, cli.bess.RPCError)):
             raise
         else:
             cli.ferr.write(''.join(traceback.format_exception_only(t, v)))
             raise cli.HandledError()
     finally:
-        cli.bess.resume_all()
+        if cli.bess.is_connected():
+            cli.bess.resume_all()
 
 
 def _run_file(cli, conf_file, env_map):

--- a/bessctl/module.py
+++ b/bessctl/module.py
@@ -25,7 +25,6 @@ class Module(object):
                                       self.choose_arg(None, kwargs))
 
         self.name = ret.name
-        print 'Module %s created' % self
 
         # add mclass-specific methods
         cls = self.bess.get_mclass_info(self.__class__.__name__)
@@ -82,9 +81,6 @@ class Module(object):
     def connect(self, next_mod, ogate=0, igate=0):
         if not isinstance(next_mod, Module):
             assert False, '%s is not a module' % next_mod
-
-        print 'Connecting %s:%d -> %d:%s' % (
-            self.name, ogate, igate, next_mod.name)
 
         self.bess.connect_modules(self.name, next_mod.name, ogate, igate)
 

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -307,7 +307,7 @@ static std::string DumpStack() {
 }
 
 [[noreturn]] static void exit_failure() {
-  exit(EXIT_FAILURE);
+  _exit(EXIT_FAILURE);
 }
 
 [[noreturn]] void GoPanic() {

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -369,6 +369,7 @@ static void TrapHandler(int sig_num, siginfo_t *info, void *ucontext) {
     // Never reaches here. LOG(FATAL) will terminate the process.
   } else {
     LOG(INFO) << oops.str() << DumpStack();
+    trap_ip = nullptr;
   }
 }
 

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -255,53 +255,82 @@ static std::string print_code(char *symbol, int context) {
 static void *trap_ip;
 static std::string oops_msg;
 
-static std::string DumpStack() {
+static bool SkipSymbol(char *symbol) {
+  static const char *blacklist[] = {"(_ZN6google10LogMessage",
+                                    "(_ZN6google15LogMessageFatal"};
+
+  for (auto prefix : blacklist) {
+    if (strstr(symbol, prefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+[[gnu::noinline]] static std::string DumpStack() {
   const size_t max_stack_depth = 64;
-  void *addrs[max_stack_depth];
+  void *addrs[max_stack_depth] = {};
 
   std::ostringstream stack;
 
   char **symbols;
-  int skips;
+  int skips = 0;
 
-  /* the linker requires -rdynamic for non-exported symbols */
+  // the linker requires -rdynamic for non-exported symbols
   int cnt = backtrace(addrs, max_stack_depth);
-  if (cnt < 3) {
-    stack << "ERROR: backtrace() failed" << std::endl;
-    return stack.str();
-  }
 
-  /* addrs[0]: this function
-   * addrs[1]: sigaction in glibc
-   * addrs[2]: the trigerring instruction pointer *or* its caller
-   *           (depending on the kernel behavior?) */
-  if (addrs[2] == trap_ip) {
-    skips = 2;
-  } else {
-    if (trap_ip != nullptr)
-      addrs[1] = trap_ip;
-    skips = 1;
+  // in some cases the bottom of the stack is NULL - not useful at all, remove.
+  while (cnt > 0 && !addrs[cnt - 1]) {
+    cnt--;
   }
 
   // The return addresses point to the next instruction after its call,
   // so adjust them by -1
-  for (int i = skips + 1; i < cnt; i++)
-    addrs[i] = reinterpret_cast<void *>((uintptr_t)addrs[i] - 1);
+  for (int i = 0; i < cnt; i++) {
+    if (addrs[i] != trap_ip) {
+      addrs[i] =
+          reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(addrs[i]) - 1);
+    }
+  }
 
   symbols = backtrace_symbols(addrs, cnt);
-
-  if (symbols) {
-    stack << "Backtrace (recent calls first) ---" << std::endl;
-
-    for (int i = skips; i < cnt; ++i) {
-      stack << "(" << i - skips << "): " << symbols[i] << std::endl;
-      stack << print_code(symbols[i], (i == skips) ? 3 : 0);
-    }
-
-    free(symbols);  // required by backtrace_symbols()
-  } else {
-    stack << "ERROR: backtrace_symbols() failed\n";
+  if (!symbols) {
+    return "ERROR: backtrace_symbols() failed\n";
   }
+
+  // Triggered by a signal? (trap_ip is set)
+  if (trap_ip) {
+    // addrs[0]: DumpStack() <- this function calling backtrace()
+    // addrs[1]: TrapHandler()
+    // addrs[2]: sigaction in glibc, or pthread signal handler
+    // addrs[3]: the trigerring instruction pointer *or* its caller
+    //           (depending on the kernel behavior?)
+    if (addrs[3] == trap_ip) {
+      skips = 3;
+    } else {
+      skips = 2;
+      addrs[2] = trap_ip;
+    }
+  } else {
+    // LOG(FATAL) or CHECK() failed
+    // addrs[0]: DumpStack() <- this function calling backtrace()
+    // addrs[1]: GoPanic()
+    // addrs[2]: caller of GoPanic()
+    skips = 2;
+    while (skips < cnt && SkipSymbol(symbols[skips])) {
+      skips++;
+    }
+  }
+
+  stack << "Backtrace (recent calls first) ---" << std::endl;
+
+  for (int i = skips; i < cnt; i++) {
+    stack << "(" << i - skips << "): " << symbols[i] << std::endl;
+    stack << print_code(symbols[i], (i == skips) ? 3 : 0);
+  }
+
+  free(symbols);  // required by backtrace_symbols()
 
   return stack.str();
 }
@@ -310,7 +339,7 @@ static std::string DumpStack() {
   _exit(EXIT_FAILURE);
 }
 
-[[noreturn]] void GoPanic() {
+[[gnu::noinline, noreturn]] void GoPanic() {
   if (oops_msg == "")
     oops_msg = DumpStack();
 

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -102,6 +102,14 @@ static const char *si_code_to_str(int sig_num, int si_code) {
           return "SEGV_MAPERR: address not mapped to object";
         case SEGV_ACCERR:
           return "SEGV_ACCERR: invalid permissions for mapped object";
+#if defined(SEGV_BNDERR)
+        case SEGV_BNDERR:
+          return "SEGV_BNDERR: failed address bound checks";
+#endif
+#if defined(SEGV_PKUERR)
+        case SEGV_PKUERR:
+          return "SEGV_PKUERR: failed protection key checks";
+#endif
         default:
           return "unknown";
       }
@@ -114,10 +122,12 @@ static const char *si_code_to_str(int sig_num, int si_code) {
           return "BUS_ADRERR: nonexistent physical address";
         case BUS_OBJERR:
           return "BUS_OBJERR: object-specific hardware error";
-#if 0
+#if defined(BUS_MCEERR_AR)
         case BUS_MCEERR_AR:
           return "BUS_MCEERR_AR: Hardware memory error consumed on a machine "
                  "check";
+#endif
+#if defined(BUS_MCEERR_AO)
         case BUS_MCEERR_AO:
           return "BUS_MCEERR_AO: Hardware memory error detected in process but "
                  "not consumed";

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -34,6 +34,10 @@ class BESS(object):
                 self.err, err_code, os.strerror(self.err), self.errmsg,
                 repr(self.details))
 
+    # abnormal RPC failure
+    class RPCError(Exception):
+        pass
+
     # errors from this class itself
     class APIError(Exception):
         pass
@@ -89,7 +93,11 @@ class BESS(object):
         req_fn = getattr(self.stub, name)
         if request is None:
             request = bess_msg.EmptyRequest()
-        response = req_fn(request)
+
+        try:
+            response = req_fn(request)
+        except grpc._channel._Rendezvous as e:
+            raise self.RPCError(str(e))
 
         if response.error.err != 0:
             err = response.error.err

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -117,10 +117,23 @@ class BESS(object):
         if request is None:
             request = bess_msg.EmptyRequest()
 
+        if self.debug:
+            print '====',  req_fn._method
+            req = proto_conv.protobuf_to_dict(request)
+            print '--->', type(request).__name__
+            if req:
+                pprint.pprint(req)
+
         try:
             response = req_fn(request)
         except grpc._channel._Rendezvous as e:
             raise self.RPCError(str(e))
+
+        if self.debug:
+            print '<---', type(response).__name__
+            res = proto_conv.protobuf_to_dict(response)
+            if res:
+                pprint.pprint(res)
 
         if response.error.err != 0:
             err = response.error.err
@@ -131,17 +144,6 @@ class BESS(object):
             if details == '':
                 details = None
             raise self.Error(err, errmsg, details)
-
-        if self.debug:
-            req = proto_conv.protobuf_to_dict(request)
-            res = proto_conv.protobuf_to_dict(response)
-            print '====',  req_fn._method
-            print '--->', type(request).__name__
-            if req:
-                pprint.pprint(req)
-            print '<---', type(response).__name__
-            if res:
-                pprint.pprint(res)
 
         return response
 


### PR DESCRIPTION
This PR has a series of usability patches (mainly for the CLI and crashlog), addressing some issues including the following:

* When bessd process crashes due to a failure from gRPC thread, a deadlock may occur. From user's viewpoint, bessctl gets stuck without knowing what's happening.
* If bessctl commands/scripts trigger a failure of bessd process for whatever reason, it now prints out the crashlog (the stack backtrace of the troubling bessd thread). bessctl can catch synchronous and asynchronous (failures happening in background, mostly due to a worker thread crash)
* Error output is now colored, if the stderr is a termnial.