### PR TITLE
Fix memory hogging bug in flowgen

### DIFF
--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -280,7 +280,7 @@ pb_cmd_response_t FlowGen::CommandUpdate(const bess::pb::FlowGenArg &arg) {
 
   double prev_pps = 0;
   if (!(std::isnan(arg.pps()) || arg.pps() == 0.0)) {
-    if(arg.pps() < 0){
+    if (arg.pps() < 0) {
       set_cmd_response_error(&response,
                              pb_error(EINVAL, "pps cannot be negative"));
       return response;
@@ -293,7 +293,7 @@ pb_cmd_response_t FlowGen::CommandUpdate(const bess::pb::FlowGenArg &arg) {
 
   double prev_flowrate = 0;
   if (!(std::isnan(arg.flow_rate()) || arg.flow_rate() == 0.0)) {
-    if(arg.flow_rate() < 0){
+    if (arg.flow_rate() < 0) {
       set_cmd_response_error(&response,
                              pb_error(EINVAL, "flow rate cannot be negative"));
       return response;
@@ -305,18 +305,18 @@ pb_cmd_response_t FlowGen::CommandUpdate(const bess::pb::FlowGenArg &arg) {
     flow_rate_ = arg.flow_rate();
   }
 
-  if (flow_rate_ > total_pps_){
-      flow_rate_ = prev_flowrate;
-      total_pps_ = prev_pps;
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "flow rate cannot be more than pps"));
-      return response;
+  if (flow_rate_ > total_pps_) {
+    flow_rate_ = prev_flowrate;
+    total_pps_ = prev_pps;
+    set_cmd_response_error(
+        &response, pb_error(EINVAL, "flow rate cannot be more than pps"));
+    return response;
   }
 
   if (!(std::isnan(arg.flow_duration()) || arg.flow_duration() == 0.0)) {
-    if(arg.flow_duration() < 0){
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "flow duration cannot be negative"));
+    if (arg.flow_duration() < 0) {
+      set_cmd_response_error(
+          &response, pb_error(EINVAL, "flow duration cannot be negative"));
       return response;
     }
 
@@ -329,9 +329,10 @@ pb_cmd_response_t FlowGen::CommandUpdate(const bess::pb::FlowGenArg &arg) {
   } else if (arg.arrival() == "exponential") {
     arrival_ = ARRIVAL_EXPONENTIAL;
   } else if (arg.arrival() != "") {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "arrival must be 'uniform' or 'exponential'"));
-      return response;
+    set_cmd_response_error(
+        &response,
+        pb_error(EINVAL, "arrival must be 'uniform' or 'exponential'"));
+    return response;
   }
 
   if (arg.duration() == "uniform") {
@@ -339,9 +340,11 @@ pb_cmd_response_t FlowGen::CommandUpdate(const bess::pb::FlowGenArg &arg) {
   } else if (arg.duration() == "pareto") {
     duration_ = DURATION_PARETO;
   } else if (arg.duration() != "") {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "duration must be 'uniform' or 'pareto' {%s}", arg.duration().c_str()));
-      return response;
+    set_cmd_response_error(
+        &response,
+        pb_error(EINVAL, "duration must be 'uniform' or 'pareto' {%s}",
+                 arg.duration().c_str()));
+    return response;
   }
 
   UpdateDerivedParameters();

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -24,14 +24,14 @@ struct flow {
 
 class FlowGen final : public Module {
  public:
-  enum Arrival {
-    ARRIVAL_UNIFORM = 0,
-    ARRIVAL_EXPONENTIAL,
+  enum class Arrival {
+    kUniform = 0,
+    kExponential,
   };
 
-  enum Duration {
-    DURATION_UNIFORM = 0,
-    DURATION_PARETO,
+  enum class Duration {
+    kUniform = 0,
+    kPareto,
   };
 
   static const gate_idx_t kNumIGates = 0;
@@ -39,9 +39,7 @@ class FlowGen final : public Module {
   FlowGen()
       : Module(),
         active_flows_(),
-        allocated_flows_(),
         generated_flows_(),
-        flows_(),
         flows_free_(),
         events_(),
         templ_(),
@@ -82,15 +80,16 @@ class FlowGen final : public Module {
   bess::Packet *FillPacket(struct flow *f);
   void GeneratePackets(bess::PacketBatch *batch);
 
-  pb_error_t InitFlowPool();
   pb_error_t ProcessArguments(const bess::pb::FlowGenArg &arg);
 
+  // the number of concurrent flows
   int active_flows_;
-  int allocated_flows_;
+  // the total number of flows generated so far (statistics only)
   uint64_t generated_flows_;
-  struct flow *flows_;
+  // pool of free flow structs. LIFO for temporal locality.
   std::stack<struct flow *> flows_free_;
 
+  // Priority queue of future events
   EventQueue events_;
 
   char *templ_;

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -1,8 +1,8 @@
 #ifndef BESS_MODULES_FLOWGEN_H_
 #define BESS_MODULES_FLOWGEN_H_
 
-#include <deque>
 #include <queue>
+#include <stack>
 
 #include "../module.h"
 #include "../module_msg.pb.h"
@@ -89,7 +89,7 @@ class FlowGen final : public Module {
   int allocated_flows_;
   uint64_t generated_flows_;
   struct flow *flows_;
-  std::deque<struct flow *> flows_free_;
+  std::stack<struct flow *> flows_free_;
 
   EventQueue events_;
 


### PR DESCRIPTION
- When the event queue (priority_queue) is empty, top() returns a garbage value. It results in an infinite loop, pushing a (garbage) flow to the pool for each iteration.
- Another issue addressed: the pool of free flow structs is sized 120% of the number of average concurrent connections. Since now Update() command can change the load level at runtime, the pool size should not be hard-limited. Now the pool grows dynamically as needed.