### PR TITLE
Do not run google benchmarks on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ script:
 
 after_success:
   - "[[ ${DEBUG:-0} != 0 ]] && bash <(curl -s https://codecov.io/bash)"
-  - for bench in core/*_bench; do ./$bench; done
 
 notifications:
   slack: nefeli:x5udJ7nDIKjCaCrRYprGc4mw


### PR DESCRIPTION
... in order to reduce the feedback time. Running benchmarks on CI is not useful as the performance numbers are not very precise.