### PR TITLE
Module UpdateTTL initial commit

### DIFF
--- a/bessctl/conf/samples/update_ttl.bess
+++ b/bessctl/conf/samples/update_ttl.bess
@@ -1,0 +1,24 @@
+import scapy.all as scapy
+
+eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
+ip = scapy.IP(src='192.168.1.1', dst='10.0.0.1', ttl=2)
+udp = scapy.UDP(sport=10001, dport=10002)
+payload = 'helloworld'
+pkt_bytes = str(eth/ip/udp/payload)
+
+Source() -> Rewrite(templates=[pkt_bytes]) -> rr::RoundRobin(gates=[1, 2, 3])
+
+rr:1 \
+    -> UpdateTTL() \
+    -> Sink()
+
+rr:2 \
+    -> UpdateTTL() \
+    -> UpdateTTL() \
+    -> Sink()
+
+rr:3 \
+    -> UpdateTTL() \
+    -> UpdateTTL() \
+    -> UpdateTTL() \
+    -> Sink()

--- a/bessctl/conf/samples/update_ttl.bess
+++ b/bessctl/conf/samples/update_ttl.bess
@@ -8,6 +8,10 @@ pkt_bytes = str(eth/ip/udp/payload)
 
 Source() -> Rewrite(templates=[pkt_bytes]) -> rr::RoundRobin(gates=[1, 2, 3])
 
+# UpdateTTL is a module that takes in no parameters
+# it modifies a batch of packets by decrementing their TTL by 1 or
+# dropping packets if their TTL is <= 1
+
 rr:1 \
     -> UpdateTTL() \
     -> Sink()

--- a/bessctl/conf/testing/module_tests/update_ttl.py
+++ b/bessctl/conf/testing/module_tests/update_ttl.py
@@ -12,7 +12,7 @@ CRASH_TEST_INPUTS.append([m0, 1, 1])
 # Decrement Test
 m1 = UpdateTTL()
 in_packet = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=2)
-out_packet= scapy.Ether(in_packet);
+out_packet = scapy.Ether(in_packet)
 out_packet.ttl -= 1
 out_packet = str(out_packet)
 OUTPUT_TEST_INPUTS.append([m1, 1, 1,

--- a/bessctl/conf/testing/module_tests/update_ttl.py
+++ b/bessctl/conf/testing/module_tests/update_ttl.py
@@ -1,0 +1,44 @@
+import sugar
+import scapy.all as scapy
+from module import *
+from port import *
+
+
+## CRASH TESTS ##
+m0 = UpdateTTL()
+CRASH_TEST_INPUTS.append([m0, 1, 1])
+
+## OUTPUT TESTS ##
+# Decrement Test
+m1 = UpdateTTL()
+in_packet = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=2)
+out_packet= scapy.Ether(in_packet);
+out_packet.ttl -= 1
+out_packet = str(out_packet)
+OUTPUT_TEST_INPUTS.append([m1, 1, 1,
+                           [{'input_port': 0,
+                             'input_packet': in_packet,
+                             'output_port': 0,
+                             'output_packet': out_packet}]])
+
+# Drop test
+m2 = UpdateTTL()
+drop_packet0 = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=0)
+
+drop_packet1 = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=1)
+OUTPUT_TEST_INPUTS.append([m2, 1, 1,
+                           [{'input_port': 0,
+                             'input_packet': drop_packet0,
+                             'output_port': 0,
+                             'output_packet': None},
+                            {'input_port': 0,
+                             'input_packet': in_packet,
+                             'output_port': 0,
+                             'output_packet': out_packet},
+                            {'input_port': 0,
+                             'input_packet': drop_packet1,
+                             'output_port': 0,
+                             'output_packet': None}]])
+
+# TODO: If Checksum code is modified and integrated make sure to write tests for it
+

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -26,9 +26,9 @@ def gen_socket_and_port(sockname):
 
 # Craft a packet with the specified IP addresses
 # All the other fields -- Ether, ports -- are dummy values.
-def gen_packet(proto, src_ip, dst_ip):
+def gen_packet(proto, src_ip, dst_ip, ip_ttl=64):
     eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
-    ip = scapy.IP(src=src_ip, dst=dst_ip)
+    ip = scapy.IP(src=src_ip, dst=dst_ip, ttl=ip_ttl)
     udp = proto(sport=10001, dport=10002)
     payload = 'helloworld'
     pkt = eth / ip / udp / payload

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -1,0 +1,53 @@
+#include "update_ttl.h"
+#include "../utils/ether.h"
+#include "../utils/ip.h"
+//#include <netinet/in.h> // This import is needed for the checksum code
+
+using bess::utils::EthHeader;
+using bess::utils::Ipv4Header;
+
+void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
+  bess::PacketBatch out_batch;
+  bess::PacketBatch free_batch;
+  out_batch.clear();
+  free_batch.clear();
+
+  int cnt = batch->cnt();
+
+  for (int i = 0; i < cnt; i++) {
+    bess::Packet *pkt = batch->pkts()[i];
+
+    struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
+    struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
+
+    if (ip->ttl > 1) {
+      /* Additional code for efficient checksum update for  changing TTL by an
+       * amount n
+       * TODO: Integration - add a check to identify an existing checksum?
+       * WARNING: though this code is efficient it can only update an already
+       * calculated checksum
+       * this code cannot calculate a checksum from scratch like in
+       * ip_checksum.cc
+       */
+
+      //            unsigned long sum;
+      //            unsigned short old;
+
+      //            old = ~ntohs(*(unsigned short *)&ip->ttl);
+      ip->ttl -= 1;  // TODO: make this a customizable parameter
+      //            sum = ntohs(ip->checksum) - old - (ntohs(*(unsigned short
+      //            *)&ip->ttl) & 0xffff);
+      //            sum = (sum & 0xffff) + (sum>>16);
+      //            ip->checksum = htons(sum + (sum>>16));
+      out_batch.add(pkt);
+    } else {
+      free_batch.add(pkt);  // drop the packet since it's TTL is 1 or 0
+    }
+  }
+  if (!free_batch.empty()) {
+    bess::Packet::Free(&free_batch);
+  }
+  RunNextModule(&out_batch);
+}
+
+ADD_MODULE(UpdateTTL, "update_ttl", "updates ttl")

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -20,12 +20,9 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
     struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
 
     if (ip->ttl > 1) {
-      // Additional code for efficient checksum update for  changing TTL by an
-      // amount n
-      // TODO: Integration - add a check to identify an existing checksum?
-      // WARNING: though this code is efficient it can only update an already
-      // calculated checksum
-      // this code cannot calculate a checksum from scratch like ip_checksum.cc
+      // Current design choice: implement a checksum at a downstream module 
+      // instead of updating here. If efficent code for checksumming at each module
+      // is a future change, RFC 1624 will be helpful for implementation in this module.
 
       ip->ttl -= 1;  // TODO: make this a customizable parameter
       out_batch.add(pkt);

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -1,7 +1,6 @@
 #include "update_ttl.h"
 #include "../utils/ether.h"
 #include "../utils/ip.h"
-//#include <netinet/in.h> // This import is needed for the checksum code
 
 using bess::utils::EthHeader;
 using bess::utils::Ipv4Header;
@@ -21,24 +20,14 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
     struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
 
     if (ip->ttl > 1) {
-      /* Additional code for efficient checksum update for  changing TTL by an
-       * amount n
-       * TODO: Integration - add a check to identify an existing checksum?
-       * WARNING: though this code is efficient it can only update an already
-       * calculated checksum
-       * this code cannot calculate a checksum from scratch like in
-       * ip_checksum.cc
-       */
+      // Additional code for efficient checksum update for  changing TTL by an
+      // amount n
+      // TODO: Integration - add a check to identify an existing checksum?
+      // WARNING: though this code is efficient it can only update an already
+      // calculated checksum
+      // this code cannot calculate a checksum from scratch like ip_checksum.cc
 
-      //            unsigned long sum;
-      //            unsigned short old;
-
-      //            old = ~ntohs(*(unsigned short *)&ip->ttl);
       ip->ttl -= 1;  // TODO: make this a customizable parameter
-      //            sum = ntohs(ip->checksum) - old - (ntohs(*(unsigned short
-      //            *)&ip->ttl) & 0xffff);
-      //            sum = (sum & 0xffff) + (sum>>16);
-      //            ip->checksum = htons(sum + (sum>>16));
       out_batch.add(pkt);
     } else {
       free_batch.add(pkt);  // drop the packet since it's TTL is 1 or 0

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -36,7 +36,9 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
   if (!free_batch.empty()) {
     bess::Packet::Free(&free_batch);
   }
-  RunNextModule(&out_batch);
+  if (!out_batch.empty()) {
+    RunNextModule(&out_batch);
+  }
 }
 
 ADD_MODULE(UpdateTTL, "update_ttl", "updates ttl")

--- a/core/modules/update_ttl.h
+++ b/core/modules/update_ttl.h
@@ -3,7 +3,7 @@
 
 #include "../module.h"
 
-// Swap source and destination IP addresses and UDP/TCP ports
+// Updates TTl of packets by decrementing by 1 and dropping packets if their TTl <= 1
 class UpdateTTL final : public Module {
  public:
   void ProcessBatch(bess::PacketBatch *batch) override;

--- a/core/modules/update_ttl.h
+++ b/core/modules/update_ttl.h
@@ -1,0 +1,12 @@
+#ifndef BESS_MODULES_UPDATE_TTL_H_
+#define BESS_MODULES_UPDATE_TTL_H_
+
+#include "../module.h"
+
+// Swap source and destination IP addresses and UDP/TCP ports
+class UpdateTTL final : public Module {
+ public:
+  void ProcessBatch(bess::PacketBatch *batch) override;
+};
+
+#endif  // BESS_MODULES_UPDATE_TTL_H_

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -278,6 +278,7 @@ class BESS(object):
             'Split': module_msg.SplitArg,
             'Timestamp': bess_msg.EmptyArg,
             'Update': module_msg.UpdateArg,
+            'UpdateTTL': bess_msg.EmptyArg,
             'UrlFilter': module_msg.UrlFilterArg,
             'VLANPop': bess_msg.EmptyArg,
             'VLANPush': module_msg.VLANPushArg,


### PR DESCRIPTION
1. Quick checksum modification code is commented out and marked as TODO.
*NOTE* as a result of no checksum updating done by the module, my test has been written to reflect this by manually creating a packet with modified TTL but unmodified checksum (lines 15 -17 in update_ttl.py)

2. Proposed a slight modification to testing framework to allow more flexibility in packet creation, made the additional parameter (ip_ttl) default to 64 which is the scapy default ttl value to not interrupt past tests.

3. Formatted the .cpp and .h with clang-format -style=Google


