### PR TITLE
add module name to sockname to avoid socket-reuse between tests

### DIFF
--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -100,7 +100,7 @@ for filename in glob.glob(path + "/conf/testing/module_tests/*.py"):
         sockets = []
 
         for port_num in range(max(input_port_cnt, output_port_cnt)):
-            sockname= module.name +"-" + str(output_testid) + "-moduletesting-" + \
+            sockname= module.name +"_" + str(output_testid) + "_moduletesting_" + \
                 SCRIPT_STARTTIME + str(port_num)
             socket_port, mysocket = gen_socket_and_port(sockname)
             input_ports.append(PortInc(port=sockname))

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -100,7 +100,7 @@ for filename in glob.glob(path + "/conf/testing/module_tests/*.py"):
         sockets = []
 
         for port_num in range(max(input_port_cnt, output_port_cnt)):
-            sockname = str(output_testid) + "moduletesting-" + \
+            sockname= module.name +"-" + str(output_testid) + "-moduletesting-" + \
                 SCRIPT_STARTTIME + str(port_num)
             socket_port, mysocket = gen_socket_and_port(sockname)
             input_ports.append(PortInc(port=sockname))


### PR DESCRIPTION
When we create the UnixSockets for testing we need to create a new one for each test. Tony's code revealed a bug where socket names were being reused between tests for different modules, so I added the module name to make sure the socket doesn't get reused. 

Would be great if this got merged quickly before our 1pm meeting with the undergrads.