### PR TITLE
Added -y flag to prevent playbook execution from hanging on confirmation

### DIFF
--- a/ansible-playbook.yml
+++ b/ansible-playbook.yml
@@ -98,7 +98,7 @@
       become: true
 
     - name: Install linux-headers
-      shell: apt-get install linux-headers-`uname -r`
+      shell: apt-get -y install linux-headers-`uname -r`
       become: true
 
     - name: Update submodules


### PR DESCRIPTION
Fixed the minor error in the ansible playbook hanging on confirmation for the installation of linux headers
