### PR TITLE
Stop crash if you free an empty packet batch

### DIFF
--- a/core/packet.h
+++ b/core/packet.h
@@ -385,6 +385,7 @@ int Packet::Alloc(Packet **pkts, size_t cnt, uint16_t len) {
 }
 
 void Packet::Free(Packet **pkts, int cnt) {
+  if(cnt == 0) return;
   struct rte_mempool *pool = pkts[0]->pool_;
 
   int i;


### PR DESCRIPTION
So, there is an argument to be had whether or not we should have this -- I'm adding a check literally every time we free a packetbatch here. One could argue that it's the module's job to check that it's not handing in an empty packet batch -- in which case, I'll replace this pull request with one that just adds a comment saying "DO NOT CALL WITH CNT == 0".

That said, chasing down why things were crashing here was pretty obnoxious and I think it would be good to save future folks from shooting themselves in the foot. So, please discuss and let me know whether we prefer the comment or check route. This PR adds a check.