### PR TITLE
traffic_class: fix out-of-bounds access in RunTaks

### DIFF
--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -344,6 +344,8 @@ bool LeafTrafficClass::RemoveTask(Task *t) {
   auto it = std::find(tasks_.begin(), tasks_.end(), t);
   if (it != tasks_.end()) {
     tasks_.erase(it);
+    // Avoid out-of-bounds access in RunTasks()
+    task_index_ = 0;
     return true;
   }
   return false;


### PR DESCRIPTION
Successive calls to RemoveTask() on a leaf traffic class with more than
one task attached to it may cause RunTasks() to reach beyond the limits
of its vector of tasks. This patch changes RemoveTask() to reset the
leaf's pointer into its task list to avoid overrunning it.

To recreate the buggy behavior, create any two modules that register tasks, then delete them one at a time.
```
$ ~/bess/bin/bessctl
Type "help" for more information.
<disconnected> $ daemon start
Done.
localhost:10514 $ add module Source
  The new module "source0" has been created
localhost:10514 $ add module Queue
  The new module "queue0" has been created
localhost:10514 $ delete module source0
localhost:10514 $ delete module queue0
localhost:10514 $ show module
<disconnected> $
```

Produces the following stack trace (ymmv, since it's reaching into garbage):
```
F0208 23:24:00.666764  3783 debug.cc:367] Backtrace (recent calls first) ---
(0): /home/melvin/bess/core/bessd(_ZN6Module7RunTaskEPv+0x47) [0x617927]
    Module::RunTask(void*) at /home/melvin/bess/core/module.cc:191
         188: void Module::DeInit() {}
         189:
         190: struct task_result Module::RunTask(void *) {
      -> 191:   CHECK(0);  // You must override this function
         192:   return task_result();
         193: }
         194:
(1): /home/melvin/bess/core/bessd(_ZN4Task9ScheduledEv+0x14) [0x640664]
    Task::Scheduled() at /home/melvin/bess/core/task.cc:36
      -> 36:
(2): /home/melvin/bess/core/bessd(_ZN4bess9Scheduler12ScheduleLoopEv+0x3dd) [0x61747d]
    bess::LeafTrafficClass::RunTasks() at /home/melvin/bess/core/traffic_class.h:473
      -> 473:       struct task_result ret = tasks_[task_index_++]->Scheduled();
     (inlined by) bess::Scheduler::ScheduleOnce() at /home/melvin/bess/core/scheduler.h:69
      -> 69:       struct task_result ret = leaf->RunTasks();
     (inlined by) bess::Scheduler::ScheduleLoop() at /home/melvin/bess/core/scheduler.cc:30
      -> 30:     ScheduleOnce();
(3): /home/melvin/bess/core/bessd(_ZN6Worker3RunEPv+0x640) [0x615f70]
    Worker::Run(void*) at /home/melvin/bess/core/worker.cc:241
      -> 241:   scheduler_->ScheduleLoop();
(4): /home/melvin/bess/core/bessd(_Z10run_workerPv+0x72) [0x6165c2]
    run_worker(void*) at /home/melvin/bess/core/worker.cc:254
      -> 254:   return ctx.Run(_arg);
(5): /home/melvin/bess/core/bessd() [0xbeba4f]
    execute_native_thread_routine at thread.o:?
        (file/line not available)
(6): /lib/x86_64-linux-gnu/libpthread.so.0(+0x76b9) [0x7f277e3576b9]
    ?? ??:0
(7): /lib/x86_64-linux-gnu/libc.so.6(clone+0x6c) [0x7f277e08d82c]
    ?? ??:0
```