### PR TITLE
Isolate background threads within a core

### DIFF
--- a/core/worker.cc
+++ b/core/worker.cc
@@ -151,19 +151,22 @@ int is_any_worker_running() {
 void Worker::SetNonWorker() {
   int socket;
 
-  /* These TLS variables should not be accessed by the master thread.
-   * Assign INT_MIN to the variables so that the program can crash
-   * when accessed as an index of an array. */
+  // These TLS variables should not be accessed by non-worker threads.
+  // Assign INT_MIN to the variables so that the program can crash
+  // when accessed as an index of an array.
   wid_ = INT_MIN;
   core_ = INT_MIN;
   socket_ = INT_MIN;
   fd_event_ = INT_MIN;
 
-  /* Packet pools should be available to non-worker threads */
+  // Packet pools should be available to non-worker threads.
+  // (doesn't need to be NUMA-aware, so pick any)
   for (socket = 0; socket < RTE_MAX_NUMA_NODES; socket++) {
     struct rte_mempool *pool = bess::get_pframe_pool_socket(socket);
-    if (pool)
+    if (pool) {
       pframe_pool_ = pool;
+      break;
+    }
   }
 }
 

--- a/core/worker.h
+++ b/core/worker.h
@@ -21,17 +21,17 @@
 typedef uint16_t gate_idx_t;
 #define MAX_GATES 8192
 
-/* 	TODO: worker threads doesn't necessarily be pinned to 1 core
+/*  TODO: worker threads doesn't necessarily be pinned to 1 core
  *
- *  	n: MAX_WORKERS
+ *  n: MAX_WORKERS
  *
- *  	Role		DPDK lcore ID		Hardware core(s)
- *  	--------------------------------------------------------
- *  	worker 0	0			1 specified core
- *	worker 1	1			1 specified core
- *	...
- *	worker n-1	n-1			1 specified core
- *	master		RTE_MAX_LCORE-1		all other cores
+ *  Role              DPDK lcore ID      Hardware core(s)
+ *  --------------------------------------------------------
+ *  worker 0                      0      1 specified core
+ *  worker 1                      1      1 specified core
+ *  ...
+ *  worker n-1                  n-1      1 specified core
+ *  master          RTE_MAX_LCORE-1      all other cores that are allowed
  */
 
 typedef enum {


### PR DESCRIPTION
Background threads (spawned by either DPDK or gRPC) may interfere with worker threads, potentially introducing high jitter and transient packet loss. This commit provides a temporary fix to the issue, by isolating all non-worker threads in a separate core, which can be configurable with `taskset`.