### PR TITLE
Checksum

### DIFF
--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -1,3 +1,6 @@
+// Internet checksum calculation/verification implementation
+// for bytestream, IP, TCP, and incremental update of checksum
+
 #ifndef BESS_UTILS_CHECKSUM_H_
 #define BESS_UTILS_CHECKSUM_H_
 
@@ -14,48 +17,50 @@ namespace utils {
 // All input bytestreams for checksum should be network-order
 // Todo: strongly-typed endian for input/output paramters
 
-static inline uint32_t __attribute__((always_inline))
-CalculateSum(const void *buf, size_t len, uint16_t sum16 = 0) {
-  const uint64_t *u64 = reinterpret_cast<const uint64_t *>(buf);
+// Return 32-bit one's complement sum of 'len' bytes from 'buf' and 'sum16'.
+static inline uint32_t CalculateSum(const void *buf, size_t len,
+                                    uint16_t sum16 = 0) {
+  const uint64_t *buf64 = reinterpret_cast<const uint64_t *>(buf);
   uint64_t sum64 = sum16;
 
 #if __AVX2__
   if (len >= sizeof(uint64_t) * 12) {
     union {
-      __m256i sum256;
-      uint64_t sumb64[4];
-      uint32_t sumb32[8];
-    };
-    sum256 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u64));
-    u64 += 4;
+      __m256i sum256;      // 256-bit signed integer for simd
+      uint32_t sumb32[8];  // 32-bit access pointers for non-simd
+    };                     // 256-bit one's complement sum
+    sum256 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf64));
+    buf64 += 4;
     len -= sizeof(uint64_t) * 4;
 
     union {
-      __m256i overflow256;
-      uint64_t ofb[4];
-    };
+      __m256i overflow256;  // 256-bit signed integer for simd
+      uint64_t ofb[4];      // 64-bit accesss pointer for non-simd
+    };                      // 256-bit overflow counts
     overflow256 = _mm256_setzero_si256();
 
+    // Repeat 256-bit one's complement sum (at sum256)
+    // Count the overflows (at overflow256)
     while (len >= sizeof(uint64_t) * 4) {
       __m256i temp256 =
-          _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u64));
+          _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf64));
       sum256 = _mm256_add_epi64(sum256, temp256);
 
-      // handling carry flags:
-      // use 'mask64' for conducting unsigned comparison
+      // Handling carry flags:
+      // Use 'mask64' for conducting unsigned comparison using sined operations
       const __m256i mask64 = _mm256_set1_epi64x(0x8000000000000000L);
       overflow256 = _mm256_sub_epi64(
           overflow256,
-          // results of temp256 >= sum256, meaning overflow
+          // Results of temp256 >= sum256, meaning overflow
           _mm256_cmpgt_epi64(_mm256_xor_si256(temp256, mask64),
                              _mm256_xor_si256(sum256, mask64)));
       len -= sizeof(uint64_t) * 4;
-      u64 += 4;
+      buf64 += 4;
     }
 
-    // transfer data from simd register to normal
-    // c++ compiler does faster than inline asm
-    // the sum of overflow should not raise overflow
+    // Transfer data from simd register to normal register
+    // C++ compiler does faster than inline asm
+    // The sum of overflow should not raise overflow
     sum64 += ofb[0] + ofb[1] + ofb[2] + ofb[3];
     sum64 +=
         static_cast<uint64_t>(sumb32[0]) + static_cast<uint64_t>(sumb32[1]) +
@@ -65,56 +70,72 @@ CalculateSum(const void *buf, size_t len, uint16_t sum16 = 0) {
   }
 #else
   if (len >= sizeof(uint64_t) * 8) {
+    // Repeat 64-bit one's complement sum (at sum64) including carrys
+    // 8 additions in a loop
     while (len >= sizeof(uint64_t) * 8) {
-      asm("addq %[u0], %[sum]	\n\t"
-          "adcq %[u1], %[sum]	\n\t"
-          "adcq %[u2], %[sum]	\n\t"
-          "adcq %[u3], %[sum]	\n\t"
-          "adcq %[u4], %[sum]	\n\t"
-          "adcq %[u5], %[sum]	\n\t"
-          "adcq %[u6], %[sum]	\n\t"
-          "adcq %[u7], %[sum]	\n\t"
+      asm(
+          "addq %[u0], %[sum] \n\t"
+          "adcq %[u1], %[sum] \n\t"
+          "adcq %[u2], %[sum] \n\t"
+          "adcq %[u3], %[sum] \n\t"
+          "adcq %[u4], %[sum] \n\t"
+          "adcq %[u5], %[sum] \n\t"
+          "adcq %[u6], %[sum] \n\t"
+          "adcq %[u7], %[sum] \n\t"
           "adcq $0, %[sum]"
           : [sum] "+rm"(sum64)
-          : "r"(u64), [u0] "rm"(u64[0]), [u1] "rm"(u64[1]), [u2] "rm"(u64[2]),
-            [u3] "rm"(u64[3]), [u4] "rm"(u64[4]), [u5] "rm"(u64[5]),
-            [u6] "rm"(u64[6]), [u7] "rm"(u64[7]));
+          : "r"(buf64), [u0] "rm"(buf64[0]), [u1] "rm"(buf64[1]),
+            [u2] "rm"(buf64[2]), [u3] "rm"(buf64[3]), [u4] "rm"(buf64[4]),
+            [u5] "rm"(buf64[5]), [u6] "rm"(buf64[6]), [u7] "rm"(buf64[7]));
       len -= sizeof(uint64_t) * 8;
-      u64 += 8;
+      buf64 += 8;
     }
   }
 #endif
 
   while (len >= sizeof(uint64_t) * 2) {
-    asm("addq %[u0], %[sum]	\n\t"
-        "adcq %[u1], %[sum]	\n\t"
+    // Repeat 64-bit one's complement sum (at sum64) including carrys
+    // 2 additions in a loop
+    asm(
+        "addq %[u0], %[sum] \n\t"
+        "adcq %[u1], %[sum] \n\t"
         "adcq $0, %[sum]"
         : [sum] "+rm"(sum64)
-        : "r"(u64), [u0] "rm"(u64[0]), [u1] "rm"(u64[1]));
+        : "r"(buf64), [u0] "rm"(buf64[0]), [u1] "rm"(buf64[1]));
     len -= sizeof(uint64_t) * 2;
-    u64 += 2;
+    buf64 += 2;
   }
 
-  const uint16_t *u16 = reinterpret_cast<const uint16_t *>(u64);
+  // Reduce 64-bit unsigned integer to 32-bit unsigned integer
+  // Carry may happens, but no need to complete reduce here
+  sum64 = (sum64 >> 32) + (sum64 & 0xFFFFFFFF);
+
+  // Repeat 16-bit one's complement sum (at sum64)
+  const uint16_t *buf16 = reinterpret_cast<const uint16_t *>(buf64);
   while (len >= sizeof(uint16_t)) {
-    sum64 += *u16++;
+    sum64 += *buf16++;
     len -= sizeof(uint16_t);
   }
 
+  // Add remaining 8-bit to the one's complement sum
   if (len == 1) {
-    sum64 += *reinterpret_cast<const uint8_t *>(u16);
+    sum64 += *reinterpret_cast<const uint8_t *>(buf16);
   }
 
+  // Reduce 64-bit unsigned int to 32-bit unsigned int
   sum64 = (sum64 >> 32) + (sum64 & 0xFFFFFFFF);
   sum64 += (sum64 >> 32);
 
   return static_cast<uint32_t>(sum64);
 }
 
+// Return internet checksum (the negative of 16-bit one's complement sum)
+// of 'len' bytes from 'buf' and 'sum16'
 static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len,
                                                 uint16_t sum16 = 0) {
   uint32_t sum = CalculateSum(buf, len, sum16);
 
+  // Reduce 32-bit unsigned int to 16-bit unsigned int
   sum = (sum >> 16) + (sum & 0xFFFF);
   sum += (sum >> 16);
   sum = ~sum;
@@ -122,142 +143,179 @@ static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len,
   return static_cast<uint16_t>(sum);
 }
 
-static inline bool VerifyGenericChecksum(const void *ptr, size_t len,
+// Return true if the 'cksum' is correct to the 'len' bytes from 'buf'
+static inline bool VerifyGenericChecksum(const void *buf, size_t len,
                                          uint16_t cksum) {
-  uint16_t ret = CalculateGenericChecksum(ptr, len, cksum);
+  uint16_t ret = CalculateGenericChecksum(buf, len, cksum);
   return (ret == 0x0000);
 }
 
+// Return true if the 'len' bytes from 'buf' is correct
+// Assumption: the 'buf' bytestream includes 16-bit checksum e.g.,IP/TCP header
 static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
   return VerifyGenericChecksum(buf, len, 0);
 }
 
+// Return true if the IP checksum is true
 static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
-  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&iph);
-  uint32_t sum = u32[0];
+  const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
+  uint32_t sum = buf32[0];
   uint32_t temp = 0;
 
-  asm("addl %[u321], %[sum]	\n\t"
-      "adcl %[u322], %[sum]	\n\t"
-      "adcl %[u323], %[sum]	\n\t"
-      "adcl %[u324], %[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "movl	%[sum], %[temp]	\n\t"
-      "shrl $16, %[sum]			\n\t"
-      "addw %w[temp], %w[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "notl %[sum]					\n\t"
+  // Calculate internet checksum, the optimized way is
+  // 1. get 32-bit one's complement sum including carrys
+  // 2. reduce to 16-bit unsigned integers
+  // 3. negate
+  asm(
+      "addl %[u321], %[sum]   \n\t"
+      "adcl %[u322], %[sum]   \n\t"
+      "adcl %[u323], %[sum]   \n\t"
+      "adcl %[u324], %[sum]   \n\t"
+      "adcl $0, %[sum]        \n\t"
+      "movl %[sum], %[temp]   \n\t"
+      "shrl $16, %[sum]       \n\t"
+      "addw %w[temp], %w[sum] \n\t"
+      "adcl $0, %[sum]        \n\t"
+      "notl %[sum]            \n\t"
       : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(u32), [u321] "rm"(u32[1]), [u322] "rm"(u32[2]), [u323] "rm"(u32[3]),
-        [u324] "rm"(u32[4]));
+      : "r"(buf32), [u321] "rm"(buf32[1]), [u322] "rm"(buf32[2]),
+        [u323] "rm"(buf32[3]), [u324] "rm"(buf32[4]));
 
   return (static_cast<uint16_t>(sum) == 0x0000);
 }
 
+// Return IP checksum of the ip header 'iph' without ip options
+// The checksum field does not include to calculation 
+// It does not set the checksum field in ip header
 static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
-  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&iph);
-  uint32_t sum = u32[0];
+  const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
+  uint32_t sum = buf32[0];
   uint32_t temp;
 
-  asm("addl %[u321], %[sum]	\n\t"
-      "adcl %[u322], %[sum]	\n\t"
-      "adcl %[u323], %[sum]	\n\t"
-      "adcl %[u324], %[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "movl	%[sum], %[temp]	\n\t"
-      "shrl $16, %[sum]			\n\t"
-      "addw %w[temp], %w[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "notl %[sum]					\n\t"
+  // Calculate internet checksum, the optimized way is
+  // 1. get 32-bit one's complement sum including carrys
+  // 2. reduce to 16-bit unsigned integers
+  // 3. negate
+  asm(
+      "addl %[u321], %[sum]    \n\t"
+      "adcl %[u322], %[sum]    \n\t"
+      "adcl %[u323], %[sum]    \n\t"
+      "adcl %[u324], %[sum]    \n\t"
+      "adcl $0, %[sum]         \n\t"
+      "movl %[sum], %[temp]    \n\t"
+      "shrl $16, %[sum]        \n\t"
+      "addw %w[temp], %w[sum]  \n\t"
+      "adcl $0, %[sum]         \n\t"
+      "notl %[sum]             \n\t"
       : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(u32), [u321] "rm"(u32[1]),
-        [u322] "rm"(u32[2] & 0xFFFF),  // skip checksum fields
-        [u323] "rm"(u32[3]), [u324] "rm"(u32[4]));
+      : "r"(buf32), [u321] "rm"(buf32[1]),
+        [u322] "rm"(buf32[2] & 0xFFFF),  // skip checksum fields
+        [u323] "rm"(buf32[3]), [u324] "rm"(buf32[4]));
 
   return static_cast<uint16_t>(sum);
 }
 
+// Return true if the TCP checksum is true with the TCP header and
+// pseudo header info - source ip, destiniation ip, and tcp byte stream length
 static inline bool VerifyIpv4TcpChecksum(
-    const TcpHeader &tcph, uint32_t src, uint32_t dst,
+    const TcpHeader &tcph, uint32_t src_ip, uint32_t dst_ip,
     uint16_t tcp_len /* tcp header + data */) {
-  static const uint32_t protocol = htons(0x06);  // TCP
-  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&tcph);
-  uint32_t sum = u32[0];
+  static const uint32_t TCP = htons(0x06);  // TCP
+  const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
+  uint32_t sum = buf32[0];
   uint32_t temp;
 
   // tcp options and data
-  sum += CalculateSum(u32 + 5, tcp_len - 20);
+  sum += CalculateSum(buf32 + 5, tcp_len - 20);
 
-  asm("addl %[u1], %[sum]	\n\t"
-      "adcl %[u2], %[sum]	\n\t"
-      "adcl %[u3], %[sum]	\n\t"
-      "adcl %[u4], %[sum]	\n\t"
-      "adcl %[src], %[sum]	\n\t"
-      "adcl %[dst], %[sum]	\n\t"
-      "adcl %[len], %[sum]	\n\t"
-      "adcl %[protocol], %[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "movl	%[sum], %[temp]	\n\t"
-      "shrl $16, %[sum]			\n\t"
-      "addw %w[temp], %w[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "notl %[sum]					\n\t"
+  // Calculate internet checksum, the optimized way is
+  // 1. get 32-bit one's complement sum including carrys
+  // 2. reduce to 16-bit unsigned integers
+  // 3. negate
+  asm(
+      "addl %[u1], %[sum]      \n\t"
+      "adcl %[u2], %[sum]      \n\t"
+      "adcl %[u3], %[sum]      \n\t"
+      "adcl %[u4], %[sum]      \n\t"
+      "adcl %[src], %[sum]     \n\t"
+      "adcl %[dst], %[sum]     \n\t"
+      "adcl %[len], %[sum]     \n\t"
+      "adcl %[tcp], %[sum]     \n\t"
+      "adcl $0, %[sum]         \n\t"
+      "movl %[sum], %[temp]    \n\t"
+      "shrl $16, %[sum]        \n\t"
+      "addw %w[temp], %w[sum]  \n\t"
+      "adcl $0, %[sum]         \n\t"
+      "notl %[sum]             \n\t"
       : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(u32), [u1] "rm"(u32[1]), [u2] "rm"(u32[2]), [u3] "rm"(u32[3]),
-        [u4] "rm"(u32[4]), [src] "rm"(src), [dst] "rm"(dst),
-        [len] "rm"(static_cast<uint32_t>(htons(tcp_len))),
-        [protocol] "rm"(protocol));
+      : "r"(buf32), [u1] "rm"(buf32[1]), [u2] "rm"(buf32[2]),
+        [u3] "rm"(buf32[3]), [u4] "rm"(buf32[4]), [src] "rm"(src_ip),
+        [dst] "rm"(dst_ip), [len] "rm"(static_cast<uint32_t>(htons(tcp_len))),
+        [tcp] "rm"(TCP));
 
   return (static_cast<uint16_t>(sum) == 0x0000);
 }
 
+// Return true if the TCP checksum is true
 static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
                                          const TcpHeader &tcph) {
   return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
                                ntohs(iph.length) - (iph.header_length << 2));
 }
 
+// Return TCP (on IPv4) checksum of the tcp header 'tcph' with pseudo header
+// informations - source ip, destiniation ip, and tcp byte stream length
+// The checksum field does not include to calculation 
+// It does not set the checksum field in TCP header
 static inline uint16_t CalculateIpv4TcpChecksum(
     const TcpHeader &tcph, uint32_t src, uint32_t dst,
     uint16_t tcp_len /* host-order: tcp header + data */) {
-  static const uint32_t protocol = htons(0x06);  // TCP
-  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&tcph);
-  uint32_t sum = u32[0];
+  static const uint32_t TCP = htons(0x06);  // TCP
+  const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
+  uint32_t sum = buf32[0];
   uint32_t temp;
 
   // tcp options and data
-  sum += CalculateSum(u32 + 5, tcp_len - 20);
+  sum += CalculateSum(buf32 + 5, tcp_len - 20);
 
-  asm("addl %[u1], %[sum]	\n\t"
-      "adcl %[u2], %[sum]	\n\t"
-      "adcl %[u3], %[sum]	\n\t"
-      "adcl %[u4], %[sum]	\n\t"
-      "adcl %[src], %[sum]	\n\t"
-      "adcl %[dst], %[sum]	\n\t"
-      "adcl %[len], %[sum]	\n\t"
-      "adcl %[protocol], %[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "movl	%[sum], %[temp]	\n\t"
-      "shrl $16, %[sum]			\n\t"
-      "addw %w[temp], %w[sum]	\n\t"
-      "adcl $0, %[sum]			\n\t"
-      "notl %[sum]					\n\t"
+  // Calculate internet checksum, the optimized way is
+  // 1. get 32-bit one's complement sum including carrys
+  // 2. reduce to 16-bit unsigned integers
+  // 3. negate
+  asm(
+      "addl %[u1], %[sum]      \n\t"
+      "adcl %[u2], %[sum]      \n\t"
+      "adcl %[u3], %[sum]      \n\t"
+      "adcl %[u4], %[sum]      \n\t"
+      "adcl %[src], %[sum]     \n\t"
+      "adcl %[dst], %[sum]     \n\t"
+      "adcl %[len], %[sum]     \n\t"
+      "adcl %[tcp], %[sum]     \n\t"
+      "adcl $0, %[sum]         \n\t"
+      "movl %[sum], %[temp]    \n\t"
+      "shrl $16, %[sum]        \n\t"
+      "addw %w[temp], %w[sum]  \n\t"
+      "adcl $0, %[sum]         \n\t"
+      "notl %[sum]             \n\t"
       : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(u32), [u1] "rm"(u32[1]), [u2] "rm"(u32[2]), [u3] "rm"(u32[3]),
-        [u4] "rm"(u32[4] >> 16),  // skip checksum field
+      : "r"(buf32), [u1] "rm"(buf32[1]), [u2] "rm"(buf32[2]),
+        [u3] "rm"(buf32[3]),
+        [u4] "rm"(buf32[4] >> 16),  // skip checksum field
         [src] "rm"(src), [dst] "r"(dst),
-        [len] "rm"(static_cast<uint32_t>(htons(tcp_len))),
-        [protocol] "rm"(protocol));
+        [len] "rm"(static_cast<uint32_t>(htons(tcp_len))), [tcp] "rm"(TCP));
 
   return static_cast<uint16_t>(sum);
 }
 
+// Return true if the TCP (on IPv4) checksum is true
 static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4Header &iph,
                                                 const TcpHeader &tcph) {
   return CalculateIpv4TcpChecksum(tcph, iph.src, iph.dst,
                                   ntohs(iph.length) - (iph.header_length << 2));
 }
 
+// Return incrementally updated internet checksum of old_checksum
+// when 'old_value' changes to 'new_value' e.g., changed IP address
 static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
                                                           uint32_t old_value,
                                                           uint32_t new_value) {
@@ -273,6 +331,8 @@ static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
   return static_cast<uint16_t>(sum);
 }
 
+// Return incrementally updated internet checksum of old_checksum
+// when 'old_value' changes to 'new_value' e.g., changed port number
 static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
                                                           uint16_t old_value,
                                                           uint16_t new_value) {

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -1,0 +1,295 @@
+#ifndef BESS_UTILS_CHECKSUM_H_
+#define BESS_UTILS_CHECKSUM_H_
+
+#include <cstdint>
+#include <glog/logging.h>
+#include <x86intrin.h>
+
+#include "ip.h"
+#include "tcp.h"
+
+namespace bess {
+namespace utils {
+
+// All input bytestreams for checksum should be network-order
+// Todo: strongly-typed endian for input/output paramters
+
+static inline uint32_t __attribute__((always_inline))
+CalculateSum(const void *buf, size_t len, uint16_t sum16 = 0) {
+  const uint64_t *u64 = reinterpret_cast<const uint64_t *>(buf);
+  uint64_t sum64 = sum16;
+
+#if __AVX2__
+  if (len >= sizeof(uint64_t) * 12) {
+    union {
+      __m256i sum256;
+      uint64_t sumb64[4];
+      uint32_t sumb32[8];
+    };
+    sum256 = _mm256_loadu_si256((const __m256i *)u64);
+    u64 += 4;
+    len -= sizeof(uint64_t) * 4;
+
+    union {
+      __m256i overflow256 = _mm256_setzero_si256();
+      uint64_t ofb[4];
+    };
+
+    while (len >= sizeof(uint64_t) * 4) {
+      __m256i temp256 = _mm256_loadu_si256((const __m256i *)u64);
+      sum256 = _mm256_add_epi64(sum256, temp256);
+
+      // handling carry flags:
+      // use 'mask64' for conducting unsigned comparison
+      const __m256i mask64 = _mm256_set1_epi64x(0x8000000000000000L);
+      overflow256 = _mm256_sub_epi64(
+          overflow256,
+          // results of temp256 >= sum256, meaning overflow
+          _mm256_cmpgt_epi64(_mm256_xor_si256(temp256, mask64),
+                             _mm256_xor_si256(sum256, mask64)));
+
+      len -= sizeof(uint64_t) * 4;
+      u64 += 4;
+    }
+
+    // transfer data from simd register to normal
+    // c++ compiler does faster than inline asm
+    // the sum of overflow should not raise overflow
+    sum64 += ofb[0] + ofb[1] + ofb[2] + ofb[3];
+    sum64 +=
+        static_cast<uint64_t>(sumb32[0]) + static_cast<uint64_t>(sumb32[1]) +
+        static_cast<uint64_t>(sumb32[2]) + static_cast<uint64_t>(sumb32[3]) +
+        static_cast<uint64_t>(sumb32[4]) + static_cast<uint64_t>(sumb32[5]) +
+        static_cast<uint64_t>(sumb32[6]) + static_cast<uint64_t>(sumb32[7]);
+  }
+#else
+  if (len >= sizeof(uint64_t) * 8) {
+    while (len >= sizeof(uint64_t) * 8) {
+      asm("addq %[u0], %[sum]	\n\t"
+          "adcq %[u1], %[sum]	\n\t"
+          "adcq %[u2], %[sum]	\n\t"
+          "adcq %[u3], %[sum]	\n\t"
+          "adcq %[u4], %[sum]	\n\t"
+          "adcq %[u5], %[sum]	\n\t"
+          "adcq %[u6], %[sum]	\n\t"
+          "adcq %[u7], %[sum]	\n\t"
+          "adcq $0, %[sum]"
+          : [sum] "+r"(sum64)
+          : [u0] "r"(u64[0]), [u1] "r"(u64[1]), [u2] "r"(u64[2]),
+            [u3] "r"(u64[3]), [u4] "r"(u64[4]), [u5] "r"(u64[5]),
+            [u6] "r"(u64[6]), [u7] "r"(u64[7])
+          : "memory");
+      len -= sizeof(uint64_t) * 8;
+      u64 += 8;
+    }
+  }
+#endif
+
+  while (len >= sizeof(uint64_t) * 2) {
+    asm("addq %[u0], %[sum]	\n\t"
+        "adcq %[u1], %[sum]	\n\t"
+        "adcq $0, %[sum]"
+        : [sum] "+r"(sum64)
+        : [u0] "r"(u64[0]), [u1] "r"(u64[1])
+        : "memory");
+    len -= sizeof(uint64_t) * 2;
+    u64 += 2;
+  }
+
+  const uint16_t *u16 = reinterpret_cast<const uint16_t *>(u64);
+  while (len >= sizeof(uint16_t)) {
+    sum64 += *u16++;
+    len -= sizeof(uint16_t);
+  }
+
+  if (len == 1) {
+    sum64 += *reinterpret_cast<const uint8_t *>(u16);
+  }
+
+  sum64 = (sum64 >> 32) + (sum64 & 0xFFFFFFFF);
+  sum64 += (sum64 >> 32);
+
+  return static_cast<uint32_t>(sum64);
+}
+
+static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len,
+                                                uint16_t sum16 = 0) {
+  uint32_t sum = CalculateSum(buf, len, sum16);
+
+  sum = (sum >> 16) + (sum & 0xFFFF);
+  sum += (sum >> 16);
+  sum = ~sum;
+
+  return static_cast<uint16_t>(sum);
+}
+
+static inline bool VerifyGenericChecksum(const void *ptr, size_t len,
+                                         uint16_t cksum) {
+  uint16_t ret = CalculateGenericChecksum(ptr, len, cksum);
+  return (ret == 0x0000);
+}
+
+static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
+  return VerifyGenericChecksum(buf, len, 0);
+}
+
+static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
+  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&iph);
+  uint32_t sum = u32[0];
+  uint32_t temp = 0;
+
+  asm("addl %[u321], %[sum]	\n\t"
+      "adcl %[u322], %[sum]	\n\t"
+      "adcl %[u323], %[sum]	\n\t"
+      "adcl %[u324], %[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "movl	%[sum], %[temp]	\n\t"
+      "shrl $16, %[sum]			\n\t"
+      "addw %w[temp], %w[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "notl %[sum]					\n\t"
+      : [sum] "+r"(sum), [temp] "=&r"(temp)
+      : [u321] "r"(u32[1]), [u322] "r"(u32[2]), [u323] "r"(u32[3]),
+        [u324] "r"(u32[4]));
+
+  return (static_cast<uint16_t>(sum) == 0x0000);
+}
+
+static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
+  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&iph);
+  uint32_t sum = u32[0];
+  uint32_t temp;
+
+  asm("addl %[u321], %[sum]	\n\t"
+      "adcl %[u322], %[sum]	\n\t"
+      "adcl %[u323], %[sum]	\n\t"
+      "adcl %[u324], %[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "movl	%[sum], %[temp]	\n\t"
+      "shrl $16, %[sum]			\n\t"
+      "addw %w[temp], %w[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "notl %[sum]					\n\t"
+      : [sum] "+r"(sum), [temp] "=&r"(temp)
+      : [u321] "r"(u32[1]),
+        [u322] "r"(u32[2] & 0xFFFF),  // skip checksum fields
+        [u323] "r"(u32[3]), [u324] "r"(u32[4]));
+
+  return static_cast<uint16_t>(sum);
+}
+
+static inline bool VerifyIpv4TcpChecksum(
+    const TcpHeader &tcph, uint32_t src, uint32_t dst,
+    uint16_t tcp_len /* tcp header + data */) {
+  static const uint32_t protocol = htons(0x06);  // TCP
+  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&tcph);
+  uint32_t sum = u32[0];
+  uint32_t temp;
+
+  // tcp options and data
+  sum += CalculateSum(u32 + 5, tcp_len - 20);
+
+  asm("addl %[u1], %[sum]	\n\t"
+      "adcl %[u2], %[sum]	\n\t"
+      "adcl %[u3], %[sum]	\n\t"
+      "adcl %[u4], %[sum]	\n\t"
+      "adcl %[src], %[sum]	\n\t"
+      "adcl %[dst], %[sum]	\n\t"
+      "adcl %[len], %[sum]	\n\t"
+      "adcl %[protocol], %[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "movl	%[sum], %[temp]	\n\t"
+      "shrl $16, %[sum]			\n\t"
+      "addw %w[temp], %w[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "notl %[sum]					\n\t"
+      : [sum] "+r"(sum), [temp] "=&r"(temp)
+      : [u1] "r"(u32[1]), [u2] "r"(u32[2]), [u3] "r"(u32[3]), [u4] "r"(u32[4]),
+        [src] "r"(src), [dst] "r"(dst),
+        [len] "r"(static_cast<uint32_t>(htons(tcp_len))),
+        [protocol] "r"(protocol));
+
+  return (static_cast<uint16_t>(sum) == 0x0000);
+}
+
+static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
+                                         const TcpHeader &tcph) {
+  return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
+                               ntohs(iph.length) - (iph.header_length << 2));
+}
+
+static inline uint16_t CalculateIpv4TcpChecksum(
+    const TcpHeader &tcph, uint32_t src, uint32_t dst,
+    uint16_t tcp_len /* host-order: tcp header + data */) {
+  static const uint32_t protocol = htons(0x06);  // TCP
+  const uint32_t *u32 = reinterpret_cast<const uint32_t *>(&tcph);
+  uint32_t sum = u32[0];
+  uint32_t temp;
+
+  // tcp options and data
+  sum += CalculateSum(u32 + 5, tcp_len - 20);
+
+  asm("addl %[u1], %[sum]	\n\t"
+      "adcl %[u2], %[sum]	\n\t"
+      "adcl %[u3], %[sum]	\n\t"
+      "adcl %[u4], %[sum]	\n\t"
+      "adcl %[src], %[sum]	\n\t"
+      "adcl %[dst], %[sum]	\n\t"
+      "adcl %[len], %[sum]	\n\t"
+      "adcl %[protocol], %[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "movl	%[sum], %[temp]	\n\t"
+      "shrl $16, %[sum]			\n\t"
+      "addw %w[temp], %w[sum]	\n\t"
+      "adcl $0, %[sum]			\n\t"
+      "notl %[sum]					\n\t"
+      : [sum] "+r"(sum), [temp] "=&r"(temp)
+      : [u1] "r"(u32[1]), [u2] "r"(u32[2]), [u3] "r"(u32[3]),
+        [u4] "r"(u32[4] >> 16),  // skip checksum field
+        [src] "r"(src), [dst] "r"(dst),
+        [len] "r"(static_cast<uint32_t>(htons(tcp_len))),
+        [protocol] "r"(protocol));
+
+  return static_cast<uint16_t>(sum);
+}
+
+static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4Header &iph,
+                                                const TcpHeader &tcph) {
+  return CalculateIpv4TcpChecksum(tcph, iph.src, iph.dst,
+                                  ntohs(iph.length) - (iph.header_length << 2));
+}
+
+static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
+                                                          uint32_t old_value,
+                                                          uint32_t new_value) {
+  // new checksum = ~(~old_checksum + ~old_value + new_value) by RFC 1624
+  uint32_t sum = ~old_checksum & 0xFFFF;
+  sum += (~old_value >> 16) + (~old_value & 0xFFFF);
+  sum += (new_value >> 16) + (new_value & 0xFFFF);
+
+  sum = (sum >> 16) + (sum & 0xFFFF);
+  sum += (sum >> 16);
+  sum = ~sum;
+
+  return static_cast<uint16_t>(sum);
+}
+
+static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
+                                                          uint16_t old_value,
+                                                          uint16_t new_value) {
+  // new checksum = ~(~old_checksum + ~old_value + new_value) by RFC 1624
+  uint32_t sum = ~old_checksum & 0xFFFF;
+  sum += ~old_value & 0xFFFF;
+  sum += new_value;
+
+  sum = (sum >> 16) + (sum & 0xFFFF);
+  sum += (sum >> 16);
+  sum = ~sum;
+
+  return static_cast<uint16_t>(sum);
+}
+
+}  // namespace utils
+}  // namespace bess
+
+#endif

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -185,7 +185,7 @@ static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
 }
 
 // Return IP checksum of the ip header 'iph' without ip options
-// The checksum field does not include to calculation 
+// It skips the checksum field into the calculation
 // It does not set the checksum field in ip header
 static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
@@ -264,12 +264,14 @@ static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
 }
 
 // Return TCP (on IPv4) checksum of the tcp header 'tcph' with pseudo header
-// informations - source ip, destiniation ip, and tcp byte stream length
-// The checksum field does not include to calculation 
+// informations - source ip ('src'), destiniation ip ('dst'),
+// and tcp byte stream length ('tcp_len', tcp_header + data len)
+// 'tcp_len' is in host-order, and the others are in network-order
+// It skips the checksum field into the calculation
 // It does not set the checksum field in TCP header
-static inline uint16_t CalculateIpv4TcpChecksum(
-    const TcpHeader &tcph, uint32_t src, uint32_t dst,
-    uint16_t tcp_len /* host-order: tcp header + data */) {
+static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
+                                                uint32_t src, uint32_t dst,
+                                                uint16_t tcp_len) {
   static const uint32_t TCP = htons(0x06);  // TCP
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
   uint32_t sum = buf32[0];

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -1,0 +1,326 @@
+#include "checksum.h"
+
+#include <rte_config.h>
+#include <rte_ip.h>
+
+#include <benchmark/benchmark.h>
+
+#include "ether.h"
+#include "random.h"
+
+using namespace bess::utils;
+
+class ChecksumFixture : public benchmark::Fixture {
+ public:
+  virtual void SetUp(benchmark::State &) {
+    for (size_t i = 0; i < sizeof(buf_); i += sizeof(uint32_t)) {
+      *reinterpret_cast<uint32_t *>(buf_ + i) = rd_.Get();
+    }
+  }
+
+  void *get_buffer(uint16_t size) {
+    CHECK(size <= sizeof(buf_));
+    return buf_;
+  }
+
+  uint32_t GetRandom() { return rd_.Get(); }
+
+ private:
+  char buf_[2048];
+  Random rd_;
+};
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumDpdk)
+(benchmark::State &state) {
+  size_t buf_len = state.range(0);
+  void *buf;
+
+  while (state.KeepRunning()) {
+    buf = get_buffer(buf_len);
+
+    // take the complement for dpdk raw sum
+    benchmark::DoNotOptimize(~rte_raw_cksum(buf, buf_len));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(buf_len * state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumBess)
+(benchmark::State &state) {
+  size_t buf_len = state.range(0);
+  void *buf;
+
+  while (state.KeepRunning()) {
+    buf = get_buffer(buf_len);
+
+    benchmark::DoNotOptimize(
+        CalculateGenericChecksum(reinterpret_cast<const void *>(buf), buf_len));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(buf_len * state.iterations());
+}
+
+BENCHMARK_REGISTER_F(ChecksumFixture, BmGenericChecksumDpdk)
+    ->Arg(16)
+    ->Arg(64)
+    ->Arg(256)
+    ->Arg(1024)
+    ->Arg(2048);
+BENCHMARK_REGISTER_F(ChecksumFixture, BmGenericChecksumBess)
+    ->Arg(16)
+    ->Arg(64)
+    ->Arg(256)
+    ->Arg(1024)
+    ->Arg(2048);
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
+(benchmark::State &state) {
+  char pkt[20] = {0};  // ipv4 header w/o options
+
+  bess::utils::Ipv4Header *ip =
+      reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+
+  ip->version = 4;
+  ip->header_length = 5;
+  ip->type_of_service = 0;
+  ip->length = htons(40);
+  ip->fragment_offset = 0;
+  ip->ttl = 10;
+  ip->protocol = 0x06;    // tcp
+  ip->checksum = 0x0000;  // for dpdk
+
+  while (state.KeepRunning()) {
+    ip->src = GetRandom();
+    ip->dst = GetRandom();
+
+    benchmark::DoNotOptimize(
+        rte_ipv4_cksum(reinterpret_cast<const ipv4_hdr *>(ip)));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
+(benchmark::State &state) {
+  char pkt[20] = {0};  // ipv4 header w/o options
+
+  bess::utils::Ipv4Header *ip =
+      reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+
+  ip->version = 4;
+  ip->header_length = 5;
+  ip->type_of_service = 0;
+  ip->length = htons(40);
+  ip->fragment_offset = 0;
+  ip->ttl = 10;
+  ip->protocol = 0x06;    // tcp
+  ip->checksum = 0x0000;  // for dpdk
+
+  while (state.KeepRunning()) {
+    ip->src = GetRandom();
+    ip->dst = GetRandom();
+
+    benchmark::DoNotOptimize(CalculateIpv4NoOptChecksum(*ip));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_REGISTER_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk);
+BENCHMARK_REGISTER_F(ChecksumFixture, BmIpv4NoOptChecksumBess);
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumDpdk)
+(benchmark::State &state) {
+  void *pkt;
+  size_t buf_len = state.range(0);
+  buf_len = (buf_len < 40) ? 40 : buf_len;
+
+  while (state.KeepRunning()) {
+    pkt = get_buffer(buf_len);
+
+    bess::utils::Ipv4Header *ip =
+        reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+    bess::utils::TcpHeader *tcp =
+        reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+    ip->header_length = 5;
+    ip->length = htons(buf_len);
+    ip->protocol = 0x06;     // tcp
+    tcp->checksum = 0x0000;  // for dpdk
+
+    benchmark::DoNotOptimize(
+        rte_ipv4_udptcp_cksum(reinterpret_cast<const ipv4_hdr *>(ip), tcp));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(buf_len * state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumBess)
+(benchmark::State &state) {
+  void *pkt;
+  size_t buf_len = state.range(0);
+  buf_len = (buf_len < 40) ? 40 : buf_len;
+
+  while (state.KeepRunning()) {
+    pkt = get_buffer(buf_len);
+
+    bess::utils::Ipv4Header *ip =
+        reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+    bess::utils::TcpHeader *tcp =
+        reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+    ip->header_length = 5;
+    ip->length = htons(buf_len);
+    ip->protocol = 0x06;     // tcp
+    tcp->checksum = 0x0000;  // for dpdk
+
+    benchmark::DoNotOptimize(CalculateIpv4TcpChecksum(*ip, *tcp));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(buf_len * state.iterations());
+}
+
+BENCHMARK_REGISTER_F(ChecksumFixture, BmTcpChecksumDpdk)
+    ->Arg(60)
+    ->Arg(787)
+    ->Arg(1514);
+BENCHMARK_REGISTER_F(ChecksumFixture, BmTcpChecksumBess)
+    ->Arg(60)
+    ->Arg(787)
+    ->Arg(1514);
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
+(benchmark::State &state) {
+  void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
+
+  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+  bess::utils::TcpHeader *tcp =
+      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+  ip->header_length = 5;
+  ip->length = htons(60);
+  ip->protocol = 0x06;  // tcp
+
+  uint16_t cksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+
+  while (state.KeepRunning()) {
+    uint16_t src_port_old = tcp->src_port;
+    uint16_t cksum_update;
+
+    tcp->src_port = GetRandom();
+
+    benchmark::DoNotOptimize(cksum_update = CalculateChecksumIncrementalUpdate(
+                                 cksum, src_port_old, tcp->src_port));
+    cksum = cksum_update;
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
+(benchmark::State &state) {
+  void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
+
+  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+  bess::utils::TcpHeader *tcp =
+      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+  ip->header_length = 5;
+  ip->length = htons(60);
+  ip->protocol = 0x06;  // tcp
+
+  uint16_t cksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+
+  while (state.KeepRunning()) {
+    uint32_t src_ip_old = ip->src;
+    uint16_t cksum_update;
+
+    ip->src = GetRandom();
+
+    benchmark::DoNotOptimize(cksum_update = CalculateChecksumIncrementalUpdate(
+                                 cksum, src_ip_old, ip->src));
+    cksum = cksum_update;
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_REGISTER_F(ChecksumFixture, BmIncrementalUpdate16);
+BENCHMARK_REGISTER_F(ChecksumFixture, BmIncrementalUpdate32);
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
+(benchmark::State &state) {
+  void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
+
+  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+  bess::utils::TcpHeader *tcp =
+      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+  ip->header_length = 5;
+  ip->length = htons(60);
+  ip->protocol = 0x06;  // tcp
+
+  while (state.KeepRunning()) {
+    ip->src = GetRandom();
+    tcp->src_port = GetRandom();
+
+    // NAT simulation
+    // - one update for ip checksum recalcuation
+    // - two for tcp checksum
+    benchmark::DoNotOptimize(
+        ip->checksum = rte_ipv4_cksum(reinterpret_cast<const ipv4_hdr *>(ip)));
+    benchmark::DoNotOptimize(tcp->checksum = rte_ipv4_udptcp_cksum(
+                                 reinterpret_cast<const ipv4_hdr *>(ip), tcp));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
+(benchmark::State &state) {
+  void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
+
+  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+  bess::utils::TcpHeader *tcp =
+      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+  ip->header_length = 5;
+  ip->length = htons(60);
+  ip->protocol = 0x06;  // tcp
+
+  ip->checksum = CalculateIpv4NoOptChecksum(*ip);
+  tcp->checksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+
+  while (state.KeepRunning()) {
+    uint32_t src_ip_old = ip->src;
+    uint16_t src_port_old = tcp->src_port;
+
+    ip->src = GetRandom();
+    tcp->src_port = GetRandom();
+
+    // NAT simulation
+    // - one update for ip checksum recalcuation
+    // - two for tcp checksum
+    benchmark::DoNotOptimize(ip->checksum = CalculateChecksumIncrementalUpdate(
+                                 ip->checksum, src_ip_old, ip->src));
+    benchmark::DoNotOptimize(tcp->checksum = CalculateChecksumIncrementalUpdate(
+                                 tcp->checksum, src_ip_old, ip->src));
+    benchmark::DoNotOptimize(tcp->checksum = CalculateChecksumIncrementalUpdate(
+                                 tcp->checksum, src_port_old, tcp->src_port));
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_REGISTER_F(ChecksumFixture, BmSrcIpPortUpdateDpdk);
+BENCHMARK_REGISTER_F(ChecksumFixture, BmSrcIpPortUpdateBess);
+
+BENCHMARK_MAIN();

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -19,7 +19,7 @@ class ChecksumFixture : public benchmark::Fixture {
   }
 
   void *get_buffer(uint16_t size) {
-    CHECK(size <= sizeof(buf_));
+    CHECK_LE(size, sizeof(buf_));
     return buf_;
   }
 
@@ -30,6 +30,7 @@ class ChecksumFixture : public benchmark::Fixture {
   Random rd_;
 };
 
+// Benchmarks DPDK generic checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumDpdk)
 (benchmark::State &state) {
   size_t buf_len = state.range(0);
@@ -38,7 +39,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumDpdk)
   while (state.KeepRunning()) {
     buf = get_buffer(buf_len);
 
-    // take the complement for dpdk raw sum
+    // DPDK raw cksum does not return the negative of the sum
+    // so we take the negative here
     benchmark::DoNotOptimize(~rte_raw_cksum(buf, buf_len));
   }
 
@@ -46,6 +48,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumDpdk)
   state.SetBytesProcessed(buf_len * state.iterations());
 }
 
+// Benchmarks BESS generic checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumBess)
 (benchmark::State &state) {
   size_t buf_len = state.range(0);
@@ -75,6 +78,7 @@ BENCHMARK_REGISTER_F(ChecksumFixture, BmGenericChecksumBess)
     ->Arg(1024)
     ->Arg(2048);
 
+// Benchmarks DPDK IP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
 (benchmark::State &state) {
   char pkt[20] = {0};  // ipv4 header w/o options
@@ -102,6 +106,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
   state.SetItemsProcessed(state.iterations());
 }
 
+// Benchmarks BESS IP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
 (benchmark::State &state) {
   char pkt[20] = {0};  // ipv4 header w/o options
@@ -131,6 +136,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
 BENCHMARK_REGISTER_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk);
 BENCHMARK_REGISTER_F(ChecksumFixture, BmIpv4NoOptChecksumBess);
 
+// Benchmarks DPDK TCP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumDpdk)
 (benchmark::State &state) {
   void *pkt;
@@ -158,6 +164,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumDpdk)
   state.SetBytesProcessed(buf_len * state.iterations());
 }
 
+// Benchmarks BESS TCP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumBess)
 (benchmark::State &state) {
   void *pkt;
@@ -193,6 +200,7 @@ BENCHMARK_REGISTER_F(ChecksumFixture, BmTcpChecksumBess)
     ->Arg(787)
     ->Arg(1514);
 
+// Benchmarks BESS incremental checksum update for 16-bit data update
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
@@ -222,6 +230,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
   state.SetItemsProcessed(state.iterations());
 }
 
+// Benchmarks BESS incremental checksum update for 32-bit data update
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
@@ -254,6 +263,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
 BENCHMARK_REGISTER_F(ChecksumFixture, BmIncrementalUpdate16);
 BENCHMARK_REGISTER_F(ChecksumFixture, BmIncrementalUpdate32);
 
+// Benchmarks DPDK Source IP/port update (Simulating NAT)
 BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
@@ -283,6 +293,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
   state.SetItemsProcessed(state.iterations());
 }
 
+// Benchmarks BESS Source IP/port update (Simulating NAT)
 BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -13,8 +13,8 @@ using namespace bess::utils;
 class ChecksumFixture : public benchmark::Fixture {
  public:
   virtual void SetUp(benchmark::State &) {
-    for (size_t i = 0; i < sizeof(buf_); i += sizeof(uint32_t)) {
-      *reinterpret_cast<uint32_t *>(buf_ + i) = rd_.Get();
+    for (auto &t : buf_) {
+      t = rd_.Get();
     }
   }
 
@@ -26,7 +26,7 @@ class ChecksumFixture : public benchmark::Fixture {
   uint32_t GetRandom() { return rd_.Get(); }
 
  private:
-  char buf_[2048];
+  uint32_t buf_[2048];
   Random rd_;
 };
 

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -15,6 +15,7 @@ namespace {
 Random rd;
 static int TestLoopCount = 100000;
 
+// Tests generic checksum
 TEST(ChecksumTest, GenericChecksum) {
   uint32_t buf[40] = {
       0x45000032, 0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763, 0x45000032,
@@ -25,6 +26,7 @@ TEST(ChecksumTest, GenericChecksum) {
       0x45000032, 0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763, 0x45000032,
       0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763};
 
+  // choose byte size 159, 160 to enter the all loops in the test functions
   uint16_t cksum_bess = CalculateGenericChecksum(buf, 160);
   uint16_t cksum_dpdk = ~rte_raw_cksum(buf, 160);  // take the complement
   EXPECT_EQ(cksum_dpdk, cksum_bess);
@@ -49,6 +51,7 @@ TEST(ChecksumTest, GenericChecksum) {
   }
 }
 
+// Tests IP checksum
 TEST(ChecksumTest, Ipv4NoOptChecksum) {
   char buf[20] = {0};  // ipv4 header w/o options
 
@@ -96,6 +99,7 @@ TEST(ChecksumTest, Ipv4NoOptChecksum) {
   }
 }
 
+// Tests TCP checksum
 TEST(ChecksumTest, TcpChecksum) {
   char buf[40] = {0};  // ipv4 header + tcp header
 
@@ -160,6 +164,7 @@ TEST(ChecksumTest, TcpChecksum) {
   }
 }
 
+// Tests incremental checksum update for unsigned 16-bit integer
 TEST(ChecksumTest, IncrementalUpdateChecksum16) {
   uint16_t old16 = 0x4500;
   uint16_t new16 = 0x1234;
@@ -187,6 +192,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum16) {
   }
 }
 
+// Tests incremental checksum update for unsigned 32-bit integer
 TEST(ChecksumTest, IncrementalUpdateChecksum32) {
   uint32_t old32 = 0x45000032;
   uint32_t new32 = 0x12341234;
@@ -216,7 +222,8 @@ TEST(ChecksumTest, IncrementalUpdateChecksum32) {
   }
 }
 
-TEST(ChecksumTest, IncrementalUpdateIpSrcPort) {
+// Tests incremental checksum update with source IP/port update
+TEST(ChecksumTest, IncrementalUpdateSrcIpPort) {
   char buf[40] = {0};  // ipv4 header + tcp header
 
   bess::utils::Ipv4Header *ip =

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -1,0 +1,271 @@
+#include "checksum.h"
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+#include <rte_config.h>
+#include <rte_ip.h>
+
+#include "random.h"
+
+using namespace bess::utils;
+
+namespace {
+
+Random rd;
+static int TestLoopCount = 100000;
+
+TEST(ChecksumTest, GenericChecksum) {
+  uint32_t buf[40] = {
+      0x45000032, 0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763, 0x45000032,
+      0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763, 0x45000032, 0x00010000,
+      0x40060000, 0x0c22384e, 0xac0c3763, 0x45000032, 0x00010000, 0x40060000,
+      0x0c22384e, 0xac0c3763, 0x45000032, 0x00010000, 0x40060000, 0x0c22384e,
+      0xac0c3763, 0x45000032, 0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763,
+      0x45000032, 0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763, 0x45000032,
+      0x00010000, 0x40060000, 0x0c22384e, 0xac0c3763};
+
+  uint16_t cksum_bess = CalculateGenericChecksum(buf, 160);
+  uint16_t cksum_dpdk = ~rte_raw_cksum(buf, 160);  // take the complement
+  EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+  EXPECT_TRUE(VerifyGenericChecksum(buf, 160, cksum_bess));
+  EXPECT_TRUE(VerifyGenericChecksum(buf, 160, cksum_dpdk));
+
+  cksum_bess = CalculateGenericChecksum(buf, 159);
+  cksum_dpdk = ~rte_raw_cksum(buf, 159);  // take the complement
+  EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+  EXPECT_TRUE(VerifyGenericChecksum(buf, 159, cksum_bess));
+  EXPECT_TRUE(VerifyGenericChecksum(buf, 159, cksum_dpdk));
+
+  for (int i = 0; i < TestLoopCount; i++) {
+    for (int j = 0; j < 40; j++)
+      buf[j] = rd.Get();
+
+    cksum_bess = CalculateGenericChecksum(buf, 160);
+    cksum_dpdk = ~rte_raw_cksum(buf, 160);  // take the complement
+    EXPECT_EQ(cksum_dpdk, cksum_bess);
+  }
+}
+
+TEST(ChecksumTest, Ipv4NoOptChecksum) {
+  char buf[20] = {0};  // ipv4 header w/o options
+
+  bess::utils::Ipv4Header *ip =
+      reinterpret_cast<bess::utils::Ipv4Header *>(buf);
+
+  ip->version = 4;
+  ip->header_length = 5;
+  ip->type_of_service = 0;
+  ip->length = htons(20);
+  ip->fragment_offset = 0;
+  ip->ttl = 10;
+  ip->protocol = 0x06;  // tcp
+  ip->src = 0x12345678;
+  ip->dst = 0x12347890;
+
+  uint16_t cksum_dpdk = rte_ipv4_cksum(reinterpret_cast<const ipv4_hdr *>(ip));
+  uint16_t cksum_bess = CalculateIpv4NoOptChecksum(*ip);
+  EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+  // bess excludes to checksum fields to calculate ip checksum
+  ip->checksum = 0x7823;
+  cksum_bess = CalculateIpv4NoOptChecksum(*ip);
+  EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+  ip->checksum = cksum_bess;
+  EXPECT_TRUE(VerifyIpv4NoOptChecksum(*ip));
+
+  ip->checksum = 0x0000;  // for dpdk
+
+  for (int i = 0; i < TestLoopCount; i++) {
+    ip->src = rd.Get();
+    ip->dst = rd.Get();
+
+    cksum_dpdk = rte_ipv4_cksum(reinterpret_cast<const ipv4_hdr *>(ip));
+    cksum_bess = CalculateIpv4NoOptChecksum(*ip);
+
+    if (cksum_dpdk == 0xffff) {
+      // While the value of IP/TCP checksum field must not be -0 (0xffff),
+      // but DPDK often (incorrectly) gives that value. (RFC 768, 1071, 1624)
+      EXPECT_EQ(0, cksum_bess);
+    } else {
+      EXPECT_EQ(cksum_dpdk, cksum_bess);
+    }
+  }
+}
+
+TEST(ChecksumTest, TcpChecksum) {
+  char buf[40] = {0};  // ipv4 header + tcp header
+
+  bess::utils::Ipv4Header *ip =
+      reinterpret_cast<bess::utils::Ipv4Header *>(buf);
+
+  bess::utils::TcpHeader *tcp =
+      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+  ip->version = 4;
+  ip->header_length = 5;
+  ip->type_of_service = 0;
+  ip->length = htons(40);
+  ip->fragment_offset = 0;
+  ip->ttl = 10;
+  ip->protocol = 0x06;  // tcp
+  ip->src = 0x12345678;
+  ip->dst = 0x12347890;
+
+  tcp->src_port = 0x0024;
+  tcp->dst_port = 0x2097;
+  tcp->seq_num = 0x67546354;
+  tcp->ack_num = 0x98461732;
+
+  uint16_t cksum_dpdk =
+      rte_ipv4_udptcp_cksum(reinterpret_cast<const ipv4_hdr *>(ip), tcp);
+  uint16_t cksum_bess = CalculateIpv4TcpChecksum(*ip, *tcp);
+  EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+  // bess excludes the checksum field to calculate tcp checksum
+  tcp->checksum = 0x0987;
+  cksum_bess = CalculateIpv4TcpChecksum(*ip, *tcp);
+  EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+  tcp->checksum = cksum_bess;
+  EXPECT_TRUE(VerifyIpv4TcpChecksum(*ip, *tcp));
+
+  for (int i = 0; i < TestLoopCount; i++) {
+    uint16_t *p = reinterpret_cast<uint16_t *>(buf);
+
+    for (int j = 0; j < 5; j++) {
+      p[j] = rd.Get();
+
+      ip->version = 4;
+      ip->header_length = 5;
+      ip->length = htons(40);
+      ip->protocol = 0x06;     // tcp
+      ip->checksum = 0x0000;   // for dpdk
+      tcp->checksum = 0x0000;  // for dpdk
+    }
+
+    cksum_dpdk = rte_ipv4_cksum(reinterpret_cast<const ipv4_hdr *>(ip));
+    cksum_bess = CalculateIpv4NoOptChecksum(*ip);
+
+    if (cksum_dpdk == 0xffff) {
+      // While the value of IP/TCP checksum field must not be -0 (0xffff),
+      // but DPDK often (incorrectly) gives that value. (RFC 768, 1071, 1624)
+      EXPECT_EQ(0, cksum_bess);
+    } else {
+      EXPECT_EQ(cksum_dpdk, cksum_bess);
+    }
+  }
+}
+
+TEST(ChecksumTest, IncrementalUpdateChecksum16) {
+  uint16_t old16 = 0x4500;
+  uint16_t new16 = 0x1234;
+  uint16_t buf[5] = {old16, 0x0001, 0x4006, 0x0c22, 0xac0c};
+  uint16_t cksum_old = CalculateGenericChecksum(buf, 10);
+
+  buf[0] = new16;
+  uint16_t cksum_new = CalculateGenericChecksum(buf, 10);
+  uint16_t cksum_update =
+      CalculateChecksumIncrementalUpdate(cksum_old, old16, new16);
+
+  EXPECT_EQ(cksum_new, cksum_update);
+
+  for (int i = 0; i < TestLoopCount; i++) {
+    for (int j = 0; j < 5; j++)
+      buf[j] = rd.Get() >> 16;
+
+    cksum_old = CalculateGenericChecksum(buf, 10);
+
+    old16 = buf[0];
+    new16 = buf[0] = rd.Get() >> 16;
+    cksum_new = CalculateGenericChecksum(buf, 10);
+    cksum_update = CalculateChecksumIncrementalUpdate(cksum_old, old16, new16);
+    EXPECT_EQ(cksum_new, cksum_update);
+  }
+}
+
+TEST(ChecksumTest, IncrementalUpdateChecksum32) {
+  uint32_t old32 = 0x45000032;
+  uint32_t new32 = 0x12341234;
+  uint32_t buf[5] = {0x45000032, 0x00010000, 0x40060000, 0x0c22384e,
+                     0xac0c3763};
+
+  uint16_t cksum_old = CalculateGenericChecksum(buf, 20);
+
+  buf[0] = new32;
+  uint16_t cksum_new = CalculateGenericChecksum(buf, 20);
+  uint16_t cksum_update =
+      CalculateChecksumIncrementalUpdate(cksum_old, old32, new32);
+
+  EXPECT_EQ(cksum_new, cksum_update);
+
+  for (int i = 0; i < TestLoopCount; i++) {
+    for (int j = 0; j < 5; j++)
+      buf[j] = rd.Get();
+
+    cksum_old = CalculateGenericChecksum(buf, 20);
+
+    old32 = buf[0];
+    new32 = buf[0] = rd.Get();
+    cksum_new = CalculateGenericChecksum(buf, 20);
+    cksum_update = CalculateChecksumIncrementalUpdate(cksum_old, old32, new32);
+    EXPECT_EQ(cksum_new, cksum_update);
+  }
+}
+
+TEST(ChecksumTest, IncrementalUpdateIpSrcPort) {
+  char buf[40] = {0};  // ipv4 header + tcp header
+
+  bess::utils::Ipv4Header *ip =
+      reinterpret_cast<bess::utils::Ipv4Header *>(buf);
+
+  bess::utils::TcpHeader *tcp =
+      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+
+  ip->version = 4;
+  ip->header_length = 5;
+  ip->type_of_service = 0;
+  ip->length = htons(40);
+  ip->fragment_offset = 0;
+  ip->ttl = 10;
+  ip->protocol = 0x06;  // tcp
+  ip->src = 0x12345678;
+  ip->dst = 0x12347890;
+
+  tcp->src_port = 0x0024;
+  tcp->dst_port = 0x2097;
+  tcp->seq_num = 0x67546354;
+  tcp->ack_num = 0x98461732;
+
+  ip->checksum = CalculateIpv4NoOptChecksum(*ip);
+  tcp->checksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+  EXPECT_TRUE(VerifyIpv4NoOptChecksum(*ip));
+  EXPECT_TRUE(VerifyIpv4TcpChecksum(*ip, *tcp));
+
+  for (int i = 0; i < TestLoopCount; i++) {
+    uint32_t src_ip_old = ip->src;
+    uint16_t src_port_old = tcp->src_port;
+    uint16_t ip_cksum_old = ip->checksum;
+    uint16_t tcp_cksum_old = tcp->checksum;
+
+    for (int j = 0; j < 5; j++) {
+      ip->src = rd.Get();
+      tcp->src_port = rd.Get() >> 16;
+    }
+
+    ip->checksum =
+        CalculateChecksumIncrementalUpdate(ip_cksum_old, src_ip_old, ip->src);
+    EXPECT_TRUE(VerifyIpv4NoOptChecksum(*ip));
+
+    tcp->checksum =
+        CalculateChecksumIncrementalUpdate(tcp_cksum_old, src_ip_old, ip->src);
+    tcp->checksum = CalculateChecksumIncrementalUpdate(
+        tcp->checksum, src_port_old, tcp->src_port);
+    EXPECT_TRUE(VerifyIpv4TcpChecksum(*ip, *tcp));
+  }
+}
+
+}  // namespace (unnamed)


### PR DESCRIPTION
Efficient IP/TCP checksum calculation code.

```
Benchmark                                           Time           CPU Iterations
---------------------------------------------------------------------------------
ChecksumFixture/BmGenericChecksumDpdk/16            6 ns          6 ns  123607000   2.63547GB/s    168.67M items/s
ChecksumFixture/BmGenericChecksumDpdk/64           13 ns         13 ns   55511677   4.72666GB/s   75.6265M items/s
ChecksumFixture/BmGenericChecksumDpdk/256          33 ns         33 ns   20931654   7.12895GB/s   28.5158M items/s
ChecksumFixture/BmGenericChecksumDpdk/1024        121 ns        121 ns    5769022   7.85933GB/s   7.85933M items/s
ChecksumFixture/BmGenericChecksumDpdk/2048        239 ns        239 ns    2934598   7.99537GB/s   3.99769M items/s
ChecksumFixture/BmGenericChecksumBess/16            5 ns          5 ns  146359258   3.11553GB/s   199.394M items/s
ChecksumFixture/BmGenericChecksumBess/64            8 ns          8 ns   84727279   7.21482GB/s   115.437M items/s
ChecksumFixture/BmGenericChecksumBess/256          20 ns         20 ns   35775345   12.1846GB/s   48.7382M items/s
ChecksumFixture/BmGenericChecksumBess/1024         61 ns         61 ns   11415385   15.5537GB/s   15.5537M items/s
ChecksumFixture/BmGenericChecksumBess/2048        126 ns        126 ns    5547654   15.1316GB/s   7.56579M items/s
ChecksumFixture/BmIpv4NoOptChecksumDpdk             6 ns          6 ns  107919345   147.039M items/s
ChecksumFixture/BmIpv4NoOptChecksumBess             6 ns          6 ns  116843143   159.188M items/s
ChecksumFixture/BmTcpChecksumDpdk/60               23 ns         23 ns   29983989   2.39298GB/s   40.8401M items/s
ChecksumFixture/BmTcpChecksumDpdk/787             123 ns        123 ns    5711600   5.98097GB/s    7.7821M items/s
ChecksumFixture/BmTcpChecksumDpdk/1514            205 ns        205 ns    3415286   6.87973GB/s   4.65313M items/s
ChecksumFixture/BmTcpChecksumBess/60               11 ns         11 ns   61157105   4.87974GB/s   83.2809M items/s
ChecksumFixture/BmTcpChecksumBess/787              49 ns         49 ns   14266095   14.9293GB/s   19.4251M items/s
ChecksumFixture/BmTcpChecksumBess/1514             82 ns         82 ns    8532697   17.1579GB/s   11.6048M items/s
ChecksumFixture/BmIncrementalUpdate16               4 ns          4 ns  163157716   222.276M items/s
ChecksumFixture/BmIncrementalUpdate32               5 ns          5 ns  148103659   201.789M items/s
ChecksumFixture/BmSrcIpPortUpdateDpdk              30 ns         30 ns   23692101   32.2776M items/s
ChecksumFixture/BmSrcIpPortUpdateBess              12 ns         12 ns   57865651   78.8351M items/s
```