### PR TITLE
Remove unused C-style error handling code

### DIFF
--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -66,24 +66,6 @@ static inline uint64_t align_ceil_pow2(uint64_t v) {
   return v + 1;
 }
 
-/* err is defined as -errno,  */
-static inline intptr_t ptr_to_err(const void *ptr) {
-  return (intptr_t)ptr;
-}
-
-static inline void *err_to_ptr(intptr_t err) {
-  return (void *)err;
-}
-
-static inline int is_err(const void *ptr) {
-  const int max_errno = 4095;
-  return (uintptr_t)ptr >= (uintptr_t)-max_errno;
-}
-
-static inline int is_err_or_null(const void *ptr) {
-  return !ptr || is_err(ptr);
-}
-
 #define __cacheline_aligned __attribute__((aligned(64)))
 
 /* For x86_64. DMA operations are not safe with these macros */


### PR DESCRIPTION
They used to be used to support Linux kernel style error handling, but not used any longer.