### PR TITLE
Add ability to change MAC for vport

### DIFF
--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -689,6 +689,8 @@ static const struct net_device_ops sn_netdev_ops = {
 	.ndo_select_queue	= sn_select_queue,
 	.ndo_get_stats64 	= sn_get_stats64,
 	.ndo_fix_features	= sn_fix_features,
+	.ndo_set_mac_address    = eth_mac_addr,
+	.ndo_validate_addr      = eth_validate_addr,
 };
 
 extern const struct ethtool_ops sn_ethtool_ops;


### PR DESCRIPTION
VPort driver now allows changing MAC address via SIOC* ioctls.
(e.g., `ip link set <ifname> address xx:xx:xx:xx:xx:xx`, once the port is down state)