### PR TITLE
Do not use exit() in a child process

### DIFF
--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -357,7 +357,7 @@ pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
         fd = open(buf, O_RDONLY);
         if (fd < 0) {
           PLOG(ERROR) << "open(/proc/pid/ns/net)";
-          exit(errno <= 255 ? errno : ENOMSG);
+          _exit(errno <= 255 ? errno : ENOMSG);
         }
       } else
         fd = netns_fd_;
@@ -365,7 +365,7 @@ pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
       ret = setns(fd, 0);
       if (ret < 0) {
         PLOG(ERROR) << "setns()";
-        exit(errno <= 255 ? errno : ENOMSG);
+        _exit(errno <= 255 ? errno : ENOMSG);
       }
     } else {
       goto wait_child;
@@ -380,7 +380,7 @@ pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
         if (nspace) {
           /* it must be the child */
           DCHECK_EQ(child_pid, 0);
-          exit(errno <= 255 ? errno : ENOMSG);
+          _exit(errno <= 255 ? errno : ENOMSG);
         } else
           break;
       }
@@ -393,9 +393,9 @@ pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
     if (child_pid == 0) {
       if (ret < 0) {
         ret = -ret;
-        exit(ret <= 255 ? ret : ENOMSG);
+        _exit(ret <= 255 ? ret : ENOMSG);
       } else
-        exit(0);
+        _exit(0);
     } else {
       int exit_status;
 


### PR DESCRIPTION
gRPC crashes when a child process from frok() terminates with exit(). Some of its global (static) objects incorrectly free up resources (more specifically, threads) that are still being used by the parent process.

When VPort is created for a network namespace, the driver internally uses fork() so that its child process can attach to the namespace and set up IP addresses as specified. This patch replace exit() done in the child process with _exit(), so that the offending object destructors can be skipped.