### PR TITLE
Fix errors with module command arguments in sample scripts

### DIFF
--- a/bessctl/conf/perftest/bpf.bess
+++ b/bessctl/conf/perftest/bpf.bess
@@ -10,12 +10,12 @@ bpf:2 -> Sink()      # for matched packets (by the second filter)
 
 def run_testcase(exps, test_pkts):
     rewrite.clear()
-    rewrite.add({'templates': map(lambda x: str(x), test_pkts)})
+    rewrite.add(templates=map(lambda x: str(x), test_pkts))
 
     # the higher number, the higher priority.
     bpf.clear()
-    bpf.add({'filters': [{'priority': -i, 'filter': exp, 'gate': i + 1} \
-            for i, exp in enumerate(exps)]})
+    bpf.add(filters=[{'priority': -i, 'filter': exp, 'gate': i + 1} \
+            for i, exp in enumerate(exps)])
 
     bess.resume_all()
 

--- a/bessctl/conf/samples/vxlan.bess
+++ b/bessctl/conf/samples/vxlan.bess
@@ -64,7 +64,7 @@ PortInc(port=v_bob) \
     -> EtherEncap() \
     -> PortOut(port=v_alice)
 
-bpf.add([{'filter':'ip and udp dst port 4789', 'gate':1}])
+bpf.add(filters=[{'filter':'ip and udp dst port 4789', 'gate':1}])
 
 os.system('sudo ip neigh replace 10.0.10.1 lladdr 02:01:02:03:04:05 dev eth_alice')
 os.system('sudo ip link add vxlan0 type vxlan id 999 group 239.1.1.1 dev eth_alice dstport 4789')

--- a/bessctl/module.py
+++ b/bessctl/module.py
@@ -3,7 +3,7 @@ import types
 
 
 def _callback_factory(self, cmd, arg_type):
-    return lambda mod, arg=None, **kwargs: \
+    return lambda mod, **kwargs: \
         self.bess.run_module_command(self.name, cmd, arg_type, kwargs)
 
 


### PR DESCRIPTION
We do not support `module_foo.command_bar(xxx, yyy)` syntax any longer since we switched to protobuf. Only keyword arguments are supported, as in `module_foo.command_bar(a=xxx, b=yyy)`. This PR updates outdated sample scripts in that regard.