### PR TITLE
Further optimizations to AVX2 checksumming

### DIFF
--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -4,9 +4,9 @@
 #ifndef BESS_UTILS_CHECKSUM_H_
 #define BESS_UTILS_CHECKSUM_H_
 
-#include <cstdint>
-#include <glog/logging.h>
 #include <x86intrin.h>
+
+#include <glog/logging.h>
 
 #include "ip.h"
 #include "tcp.h"
@@ -18,73 +18,78 @@ namespace utils {
 // Todo: strongly-typed endian for input/output paramters
 
 // Return 32-bit one's complement sum of 'len' bytes from 'buf' and 'sum16'.
-static inline uint32_t CalculateSum(const void *buf, size_t len,
-                                    uint16_t sum16 = 0) {
+static inline uint32_t CalculateSum(const void *buf, size_t len) {
   const uint64_t *buf64 = reinterpret_cast<const uint64_t *>(buf);
-  uint64_t sum64 = sum16;
+  uint64_t sum64 = 0;
+  bool odd = len & 1;
 
 #if __AVX2__
-  if (len >= sizeof(uint64_t) * 12) {
-    union {
-      __m256i sum256;      // 256-bit signed integer for simd
-      uint32_t sumb32[8];  // 32-bit access pointers for non-simd
-    };                     // 256-bit one's complement sum
-    sum256 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf64));
-    buf64 += 4;
-    len -= sizeof(uint64_t) * 4;
+  // Faster for >128B data
+  if (len >= sizeof(__m256i) * 4) {
+    const __m256i *buf256 = reinterpret_cast<const __m256i *>(buf64);
+    __m256i zero256 = _mm256_setzero_si256();
 
-    union {
-      __m256i overflow256;  // 256-bit signed integer for simd
-      uint64_t ofb[4];      // 64-bit accesss pointer for non-simd
-    };                      // 256-bit overflow counts
-    overflow256 = _mm256_setzero_si256();
+    // We parallelize two ymm streams to minimize register dependency:
+    //     a: buf256,             buf256 + 2,             ...
+    //     b:         buf256 + 1,             buf256 + 3, ...
+    __m256i a = _mm256_loadu_si256(buf256);
+    __m256i b = _mm256_loadu_si256(buf256 + 1);
 
-    // Repeat 256-bit one's complement sum (at sum256)
-    // Count the overflows (at overflow256)
-    while (len >= sizeof(uint64_t) * 4) {
-      __m256i temp256 =
-          _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf64));
-      sum256 = _mm256_add_epi64(sum256, temp256);
+    // For each stream, accumulate unpackhi and unpacklo in parallel
+    // (as 4x64bit vectors, so that each upper 0000 can hold carries)
+    // -------------------------------------------------------------------
+    // 32B data: aaaaAAAA bbbbBBBB ccccCCCC ddddDDDD  (1 letter = 1 byte)
+    // unpackhi: bbbb0000 BBBB0000 dddd0000 DDDD0000
+    // unpacklo: aaaa0000 AAAA0000 cccc0000 CCCC0000
+    __m256i sum_a_hi = _mm256_unpackhi_epi32(a, zero256);
+    __m256i sum_a_lo = _mm256_unpacklo_epi32(a, zero256);
+    __m256i sum_b_hi = _mm256_unpackhi_epi32(b, zero256);
+    __m256i sum_b_lo = _mm256_unpacklo_epi32(b, zero256);
 
-      // Handling carry flags:
-      // Use 'mask64' for conducting unsigned comparison using sined operations
-      const __m256i mask64 = _mm256_set1_epi64x(0x8000000000000000L);
-      overflow256 = _mm256_sub_epi64(
-          overflow256,
-          // Results of temp256 >= sum256, meaning overflow
-          _mm256_cmpgt_epi64(_mm256_xor_si256(temp256, mask64),
-                             _mm256_xor_si256(sum256, mask64)));
-      len -= sizeof(uint64_t) * 4;
-      buf64 += 4;
+    len -= sizeof(__m256i) * 2;
+    buf256 += 2;
+
+    while (len >= sizeof(__m256i) * 2) {
+      a = _mm256_loadu_si256(buf256);
+      b = _mm256_loadu_si256(buf256 + 1);
+
+      sum_a_hi = _mm256_add_epi64(sum_a_hi, _mm256_unpackhi_epi32(a, zero256));
+      sum_a_lo = _mm256_add_epi64(sum_a_lo, _mm256_unpacklo_epi32(a, zero256));
+      sum_b_hi = _mm256_add_epi64(sum_b_hi, _mm256_unpackhi_epi32(b, zero256));
+      sum_b_lo = _mm256_add_epi64(sum_b_lo, _mm256_unpacklo_epi32(b, zero256));
+
+      len -= sizeof(__m256i) * 2;
+      buf256 += 2;
     }
 
-    // Transfer data from simd register to normal register
-    // C++ compiler does faster than inline asm
-    // The sum of overflow should not raise overflow
-    sum64 += ofb[0] + ofb[1] + ofb[2] + ofb[3];
-    sum64 +=
-        static_cast<uint64_t>(sumb32[0]) + static_cast<uint64_t>(sumb32[1]) +
-        static_cast<uint64_t>(sumb32[2]) + static_cast<uint64_t>(sumb32[3]) +
-        static_cast<uint64_t>(sumb32[4]) + static_cast<uint64_t>(sumb32[5]) +
-        static_cast<uint64_t>(sumb32[6]) + static_cast<uint64_t>(sumb32[7]);
+    // fold four 256bit sums into one 128bit sum
+    __m256i sum256 = _mm256_add_epi64(_mm256_add_epi64(sum_a_hi, sum_a_lo),
+                                      _mm256_add_epi64(sum_b_hi, sum_b_lo));
+    __m128i sum128 = _mm_add_epi64(_mm256_extracti128_si256(sum256, 0),
+                                   _mm256_extracti128_si256(sum256, 1));
+
+    // fold 128bit sum into 64bit
+    sum64 += _mm_extract_epi64(sum128, 0) + _mm_extract_epi64(sum128, 1);
+    buf64 = reinterpret_cast<const uint64_t *>(buf256);
   }
 #endif
 
   // Repeat 64-bit one's complement sum (at sum64) including carrys
   // 8 additions in a loop
   while (len >= sizeof(uint64_t) * 8) {
-    asm(
-        "addq 0*8(%[src]), %[sum] \n\t"
-        "adcq 1*8(%[src]), %[sum] \n\t"
-        "adcq 2*8(%[src]), %[sum] \n\t"
-        "adcq 3*8(%[src]), %[sum] \n\t"
-        "adcq 4*8(%[src]), %[sum] \n\t"
-        "adcq 5*8(%[src]), %[sum] \n\t"
-        "adcq 6*8(%[src]), %[sum] \n\t"
-        "adcq 7*8(%[src]), %[sum] \n\t"
+    asm("addq %[u0], %[sum] \n\t"
+        "adcq %[u1], %[sum] \n\t"
+        "adcq %[u2], %[sum] \n\t"
+        "adcq %[u3], %[sum] \n\t"
+        "adcq %[u4], %[sum] \n\t"
+        "adcq %[u5], %[sum] \n\t"
+        "adcq %[u6], %[sum] \n\t"
+        "adcq %[u7], %[sum] \n\t"
         "adcq $0, %[sum]"
         : [sum] "+r"(sum64)
-        : [src] "r"(buf64));
+        : [u0] "m"(buf64[0]), [u1] "m"(buf64[1]), [u2] "m"(buf64[2]),
+          [u3] "m"(buf64[3]), [u4] "m"(buf64[4]), [u5] "m"(buf64[5]),
+          [u6] "m"(buf64[6]), [u7] "m"(buf64[7]));
     len -= sizeof(uint64_t) * 8;
     buf64 += 8;
   }
@@ -92,12 +97,11 @@ static inline uint32_t CalculateSum(const void *buf, size_t len,
   while (len >= sizeof(uint64_t) * 2) {
     // Repeat 64-bit one's complement sum (at sum64) including carrys
     // 2 additions in a loop
-    asm(
-        "addq %[u0], %[sum] \n\t"
+    asm("addq %[u0], %[sum] \n\t"
         "adcq %[u1], %[sum] \n\t"
         "adcq $0, %[sum]"
-        : [sum] "+rm"(sum64)
-        : "r"(buf64), [u0] "rm"(buf64[0]), [u1] "rm"(buf64[1]));
+        : [sum] "+r"(sum64)
+        : [u0] "m"(buf64[0]), [u1] "m"(buf64[1]));
     len -= sizeof(uint64_t) * 2;
     buf64 += 2;
   }
@@ -114,7 +118,7 @@ static inline uint32_t CalculateSum(const void *buf, size_t len,
   }
 
   // Add remaining 8-bit to the one's complement sum
-  if (len == 1) {
+  if (odd) {
     sum64 += *reinterpret_cast<const uint8_t *>(buf16);
   }
 
@@ -125,29 +129,29 @@ static inline uint32_t CalculateSum(const void *buf, size_t len,
   return static_cast<uint32_t>(sum64);
 }
 
-// Return internet checksum (the negative of 16-bit one's complement sum)
-// of 'len' bytes from 'buf' and 'sum16'
-static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len,
-                                                uint16_t sum16 = 0) {
-  uint32_t sum = CalculateSum(buf, len, sum16);
-
-  // Reduce 32-bit unsigned int to 16-bit unsigned int
-  sum = (sum >> 16) + (sum & 0xFFFF);
-  sum += (sum >> 16);
-  sum = ~sum;
-
-  return static_cast<uint16_t>(sum);
+// Fold a 32-bit non-inverted checksum into a inverted 16-bit one,
+// which can be readily written to L3/L4 checksum field
+static inline uint16_t FoldChecksum(uint32_t cksum) {
+  cksum = (cksum >> 16) + (cksum & 0xFFFF);
+  cksum += (cksum >> 16);
+  return ~cksum;
 }
 
-// Return true if the 'cksum' is correct to the 'len' bytes from 'buf'
+// Return internet checksum (the negative of 16-bit one's complement sum)
+// of 'len' bytes from 'buf'
+static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len) {
+  return FoldChecksum(CalculateSum(buf, len));
+}
+
+// Return true if the 'cksum' is correct for the 'len' bytes from 'buf'
 static inline bool VerifyGenericChecksum(const void *buf, size_t len,
                                          uint16_t cksum) {
-  uint16_t ret = CalculateGenericChecksum(buf, len, cksum);
-  return (ret == 0x0000);
+  uint16_t ret = CalculateGenericChecksum(buf, len);
+  return (ret == cksum);
 }
 
 // Return true if the 'len' bytes from 'buf' is correct
-// Assumption: the 'buf' bytestream includes 16-bit checksum e.g.,IP/TCP header
+// Assumption: 'buf' already includes 16-bit checksum (e.g., IP/TCP header)
 static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
   return VerifyGenericChecksum(buf, len, 0);
 }
@@ -156,28 +160,20 @@ static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
 static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   uint32_t sum = buf32[0];
-  uint32_t temp = 0;
 
   // Calculate internet checksum, the optimized way is
   // 1. get 32-bit one's complement sum including carrys
-  // 2. reduce to 16-bit unsigned integers
-  // 3. negate
-  asm(
-      "addl %[u321], %[sum]   \n\t"
-      "adcl %[u322], %[sum]   \n\t"
-      "adcl %[u323], %[sum]   \n\t"
-      "adcl %[u324], %[sum]   \n\t"
+  // 2. reduce to 16-bit unsigned integer
+  asm("addl %[u1], %[sum]   \n\t"
+      "adcl %[u2], %[sum]   \n\t"
+      "adcl %[u3], %[sum]   \n\t"
+      "adcl %[u4], %[sum]   \n\t"
       "adcl $0, %[sum]        \n\t"
-      "movl %[sum], %[temp]   \n\t"
-      "shrl $16, %[sum]       \n\t"
-      "addw %w[temp], %w[sum] \n\t"
-      "adcl $0, %[sum]        \n\t"
-      "notl %[sum]            \n\t"
-      : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(buf32), [u321] "rm"(buf32[1]), [u322] "rm"(buf32[2]),
-        [u323] "rm"(buf32[3]), [u324] "rm"(buf32[4]));
+      : [sum] "+r"(sum)
+      : [u1] "m"(buf32[1]), [u2] "m"(buf32[2]), [u3] "m"(buf32[3]),
+        [u4] "m"(buf32[4]));
 
-  return (static_cast<uint16_t>(sum) == 0x0000);
+  return FoldChecksum(sum) == 0;
 }
 
 // Return IP checksum of the ip header 'iph' without ip options
@@ -186,70 +182,52 @@ static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
 static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   uint32_t sum = buf32[0];
-  uint32_t temp;
 
   // Calculate internet checksum, the optimized way is
   // 1. get 32-bit one's complement sum including carrys
   // 2. reduce to 16-bit unsigned integers
   // 3. negate
-  asm(
-      "addl %[u321], %[sum]    \n\t"
-      "adcl %[u322], %[sum]    \n\t"
-      "adcl %[u323], %[sum]    \n\t"
-      "adcl %[u324], %[sum]    \n\t"
-      "adcl $0, %[sum]         \n\t"
-      "movl %[sum], %[temp]    \n\t"
-      "shrl $16, %[sum]        \n\t"
-      "addw %w[temp], %w[sum]  \n\t"
-      "adcl $0, %[sum]         \n\t"
-      "notl %[sum]             \n\t"
-      : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(buf32), [u321] "rm"(buf32[1]),
-        [u322] "rm"(buf32[2] & 0xFFFF),  // skip checksum fields
-        [u323] "rm"(buf32[3]), [u324] "rm"(buf32[4]));
+  asm("addl %[u1], %[sum]    \n\t"
+      "adcl %[u2], %[sum]    \n\t"
+      "adcl %[u3], %[sum]    \n\t"
+      "adcl %[u4], %[sum]    \n\t"
+      "adcl $0, %[sum]       \n\t"
+      : [sum] "+r"(sum)
+      : [u1] "m"(buf32[1]),
+        [u2] "g"(buf32[2] & 0xFFFF),  // skip checksum fields
+        [u3] "m"(buf32[3]), [u4] "m"(buf32[4]));
 
-  return static_cast<uint16_t>(sum);
+  return FoldChecksum(sum);
 }
 
 // Return true if the TCP checksum is true with the TCP header and
 // pseudo header info - source ip, destiniation ip, and tcp byte stream length
-static inline bool VerifyIpv4TcpChecksum(
-    const TcpHeader &tcph, uint32_t src_ip, uint32_t dst_ip,
-    uint16_t tcp_len /* tcp header + data */) {
-  static const uint32_t TCP = htons(0x06);  // TCP
+// tcp_len: TCP header + payload in bytes
+static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, uint32_t src_ip,
+                                         uint32_t dst_ip, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
-  uint32_t sum = buf32[0];
-  uint32_t temp;
 
   // tcp options and data
-  sum += CalculateSum(buf32 + 5, tcp_len - 20);
+  uint32_t sum = CalculateSum(buf32 + 5, tcp_len - 20);
+  uint32_t len = static_cast<uint32_t>(htons(tcp_len));
 
-  // Calculate internet checksum, the optimized way is
-  // 1. get 32-bit one's complement sum including carrys
-  // 2. reduce to 16-bit unsigned integers
-  // 3. negate
-  asm(
-      "addl %[u1], %[sum]      \n\t"
+  // Calculate the checksum of TCP pseudo header
+  asm("addl %[u0], %[sum]      \n\t"
+      "adcl %[u1], %[sum]      \n\t"
       "adcl %[u2], %[sum]      \n\t"
       "adcl %[u3], %[sum]      \n\t"
       "adcl %[u4], %[sum]      \n\t"
       "adcl %[src], %[sum]     \n\t"
       "adcl %[dst], %[sum]     \n\t"
       "adcl %[len], %[sum]     \n\t"
-      "adcl %[tcp], %[sum]     \n\t"
+      "adcl $0x0600, %[sum]    \n\t"  // 6 == IPPROTO_TCP
       "adcl $0, %[sum]         \n\t"
-      "movl %[sum], %[temp]    \n\t"
-      "shrl $16, %[sum]        \n\t"
-      "addw %w[temp], %w[sum]  \n\t"
-      "adcl $0, %[sum]         \n\t"
-      "notl %[sum]             \n\t"
-      : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(buf32), [u1] "rm"(buf32[1]), [u2] "rm"(buf32[2]),
-        [u3] "rm"(buf32[3]), [u4] "rm"(buf32[4]), [src] "rm"(src_ip),
-        [dst] "rm"(dst_ip), [len] "rm"(static_cast<uint32_t>(htons(tcp_len))),
-        [tcp] "rm"(TCP));
+      : [sum] "+r"(sum)
+      : [u0] "m"(buf32[0]), [u1] "m"(buf32[1]), [u2] "m"(buf32[2]),
+        [u3] "m"(buf32[3]), [u4] "m"(buf32[4]), [src] "r"(src_ip),
+        [dst] "r"(dst_ip), [len] "r"(len));
 
-  return (static_cast<uint16_t>(sum) == 0x0000);
+  return FoldChecksum(sum) == 0;
 }
 
 // Return true if the TCP checksum is true
@@ -268,41 +246,29 @@ static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
 static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
                                                 uint32_t src, uint32_t dst,
                                                 uint16_t tcp_len) {
-  static const uint32_t TCP = htons(0x06);  // TCP
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
-  uint32_t sum = buf32[0];
-  uint32_t temp;
-
   // tcp options and data
-  sum += CalculateSum(buf32 + 5, tcp_len - 20);
+  uint32_t sum = CalculateSum(buf32 + 5, tcp_len - 20);
+  uint32_t len = static_cast<uint32_t>(htons(tcp_len));
 
-  // Calculate internet checksum, the optimized way is
-  // 1. get 32-bit one's complement sum including carrys
-  // 2. reduce to 16-bit unsigned integers
-  // 3. negate
-  asm(
-      "addl %[u1], %[sum]      \n\t"
+  // Calculate the checksum of TCP pseudo header
+  asm("addl %[u0], %[sum]      \n\t"
+      "adcl %[u1], %[sum]      \n\t"
       "adcl %[u2], %[sum]      \n\t"
       "adcl %[u3], %[sum]      \n\t"
       "adcl %[u4], %[sum]      \n\t"
       "adcl %[src], %[sum]     \n\t"
       "adcl %[dst], %[sum]     \n\t"
       "adcl %[len], %[sum]     \n\t"
-      "adcl %[tcp], %[sum]     \n\t"
+      "adcl $0x0600, %[sum]    \n\t"  // 6 == IPPROTO_TCP
       "adcl $0, %[sum]         \n\t"
-      "movl %[sum], %[temp]    \n\t"
-      "shrl $16, %[sum]        \n\t"
-      "addw %w[temp], %w[sum]  \n\t"
-      "adcl $0, %[sum]         \n\t"
-      "notl %[sum]             \n\t"
-      : [sum] "+rm"(sum), [temp] "=&r"(temp)
-      : "r"(buf32), [u1] "rm"(buf32[1]), [u2] "rm"(buf32[2]),
-        [u3] "rm"(buf32[3]),
-        [u4] "rm"(buf32[4] >> 16),  // skip checksum field
-        [src] "rm"(src), [dst] "r"(dst),
-        [len] "rm"(static_cast<uint32_t>(htons(tcp_len))), [tcp] "rm"(TCP));
+      : [sum] "+r"(sum)
+      : [u0] "m"(buf32[0]), [u1] "m"(buf32[1]), [u2] "m"(buf32[2]),
+        [u3] "m"(buf32[3]),
+        [u4] "g"(buf32[4] >> 16),  // skip checksum field
+        [src] "r"(src), [dst] "r"(dst), [len] "r"(len));
 
-  return static_cast<uint16_t>(sum);
+  return FoldChecksum(sum);
 }
 
 // Return true if the TCP (on IPv4) checksum is true
@@ -314,36 +280,28 @@ static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4Header &iph,
 
 // Return incrementally updated internet checksum of old_checksum
 // when 'old_value' changes to 'new_value' e.g., changed IP address
-static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
-                                                          uint32_t old_value,
-                                                          uint32_t new_value) {
+static inline uint16_t CalculateChecksumIncremental32(uint16_t old_checksum,
+                                                      uint32_t old_value,
+                                                      uint32_t new_value) {
   // new checksum = ~(~old_checksum + ~old_value + new_value) by RFC 1624
   uint32_t sum = ~old_checksum & 0xFFFF;
   sum += (~old_value >> 16) + (~old_value & 0xFFFF);
   sum += (new_value >> 16) + (new_value & 0xFFFF);
 
-  sum = (sum >> 16) + (sum & 0xFFFF);
-  sum += (sum >> 16);
-  sum = ~sum;
-
-  return static_cast<uint16_t>(sum);
+  return FoldChecksum(sum);
 }
 
 // Return incrementally updated internet checksum of old_checksum
 // when 'old_value' changes to 'new_value' e.g., changed port number
-static inline uint16_t CalculateChecksumIncrementalUpdate(uint16_t old_checksum,
-                                                          uint16_t old_value,
-                                                          uint16_t new_value) {
+static inline uint16_t CalculateChecksumIncremental16(uint16_t old_checksum,
+                                                      uint16_t old_value,
+                                                      uint16_t new_value) {
   // new checksum = ~(~old_checksum + ~old_value + new_value) by RFC 1624
   uint32_t sum = ~old_checksum & 0xFFFF;
   sum += ~old_value & 0xFFFF;
   sum += new_value;
 
-  sum = (sum >> 16) + (sum & 0xFFFF);
-  sum += (sum >> 16);
-  sum = ~sum;
-
-  return static_cast<uint16_t>(sum);
+  return FoldChecksum(sum);
 }
 
 }  // namespace utils

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -68,30 +68,26 @@ static inline uint32_t CalculateSum(const void *buf, size_t len,
         static_cast<uint64_t>(sumb32[4]) + static_cast<uint64_t>(sumb32[5]) +
         static_cast<uint64_t>(sumb32[6]) + static_cast<uint64_t>(sumb32[7]);
   }
-#else
-  if (len >= sizeof(uint64_t) * 8) {
-    // Repeat 64-bit one's complement sum (at sum64) including carrys
-    // 8 additions in a loop
-    while (len >= sizeof(uint64_t) * 8) {
-      asm(
-          "addq %[u0], %[sum] \n\t"
-          "adcq %[u1], %[sum] \n\t"
-          "adcq %[u2], %[sum] \n\t"
-          "adcq %[u3], %[sum] \n\t"
-          "adcq %[u4], %[sum] \n\t"
-          "adcq %[u5], %[sum] \n\t"
-          "adcq %[u6], %[sum] \n\t"
-          "adcq %[u7], %[sum] \n\t"
-          "adcq $0, %[sum]"
-          : [sum] "+rm"(sum64)
-          : "r"(buf64), [u0] "rm"(buf64[0]), [u1] "rm"(buf64[1]),
-            [u2] "rm"(buf64[2]), [u3] "rm"(buf64[3]), [u4] "rm"(buf64[4]),
-            [u5] "rm"(buf64[5]), [u6] "rm"(buf64[6]), [u7] "rm"(buf64[7]));
-      len -= sizeof(uint64_t) * 8;
-      buf64 += 8;
-    }
-  }
 #endif
+
+  // Repeat 64-bit one's complement sum (at sum64) including carrys
+  // 8 additions in a loop
+  while (len >= sizeof(uint64_t) * 8) {
+    asm(
+        "addq 0*8(%[src]), %[sum] \n\t"
+        "adcq 1*8(%[src]), %[sum] \n\t"
+        "adcq 2*8(%[src]), %[sum] \n\t"
+        "adcq 3*8(%[src]), %[sum] \n\t"
+        "adcq 4*8(%[src]), %[sum] \n\t"
+        "adcq 5*8(%[src]), %[sum] \n\t"
+        "adcq 6*8(%[src]), %[sum] \n\t"
+        "adcq 7*8(%[src]), %[sum] \n\t"
+        "adcq $0, %[sum]"
+        : [sum] "+r"(sum64)
+        : [src] "r"(buf64));
+    len -= sizeof(uint64_t) * 8;
+    buf64 += 8;
+  }
 
   while (len >= sizeof(uint64_t) * 2) {
     // Repeat 64-bit one's complement sum (at sum64) including carrys

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -147,7 +147,7 @@ static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len) {
 static inline bool VerifyGenericChecksum(const void *buf, size_t len,
                                          uint16_t cksum) {
   uint16_t ret = CalculateGenericChecksum(buf, len);
-  return (ret == cksum);
+  return ret == cksum;
 }
 
 // Return true if the 'len' bytes from 'buf' is correct
@@ -278,8 +278,8 @@ static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4Header &iph,
                                   ntohs(iph.length) - (iph.header_length << 2));
 }
 
-// Return incrementally updated internet checksum of old_checksum
-// when 'old_value' changes to 'new_value' e.g., changed IP address
+// Return incrementally updated checksum from old_checksum
+// when 32-bit 'old_value' changes to 'new_value' e.g., changed IPv4 address
 static inline uint16_t CalculateChecksumIncremental32(uint16_t old_checksum,
                                                       uint32_t old_value,
                                                       uint32_t new_value) {
@@ -291,8 +291,8 @@ static inline uint16_t CalculateChecksumIncremental32(uint16_t old_checksum,
   return FoldChecksum(sum);
 }
 
-// Return incrementally updated internet checksum of old_checksum
-// when 'old_value' changes to 'new_value' e.g., changed port number
+// Return incrementally updated checksum from old_checksum
+// when 16-bit 'old_value' changes to 'new_value' e.g., changed port number
 static inline uint16_t CalculateChecksumIncremental16(uint16_t old_checksum,
                                                       uint16_t old_value,
                                                       uint16_t new_value) {

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -34,10 +34,9 @@ class ChecksumFixture : public benchmark::Fixture {
 BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumDpdk)
 (benchmark::State &state) {
   size_t buf_len = state.range(0);
-  void *buf;
 
   while (state.KeepRunning()) {
-    buf = get_buffer(buf_len);
+    const void *buf = get_buffer(buf_len);
 
     // DPDK raw cksum does not return the negative of the sum
     // so we take the negative here
@@ -52,13 +51,11 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumDpdk)
 BENCHMARK_DEFINE_F(ChecksumFixture, BmGenericChecksumBess)
 (benchmark::State &state) {
   size_t buf_len = state.range(0);
-  void *buf;
 
   while (state.KeepRunning()) {
-    buf = get_buffer(buf_len);
+    const void *buf = get_buffer(buf_len);
 
-    benchmark::DoNotOptimize(
-        CalculateGenericChecksum(reinterpret_cast<const void *>(buf), buf_len));
+    benchmark::DoNotOptimize(CalculateGenericChecksum(buf, buf_len));
   }
 
   state.SetItemsProcessed(state.iterations());
@@ -222,7 +219,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
 
     tcp->src_port = GetRandom();
 
-    benchmark::DoNotOptimize(cksum_update = CalculateChecksumIncrementalUpdate(
+    benchmark::DoNotOptimize(cksum_update = CalculateChecksumIncremental32(
                                  cksum, src_port_old, tcp->src_port));
     cksum = cksum_update;
   }
@@ -252,7 +249,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
 
     ip->src = GetRandom();
 
-    benchmark::DoNotOptimize(cksum_update = CalculateChecksumIncrementalUpdate(
+    benchmark::DoNotOptimize(cksum_update = CalculateChecksumIncremental32(
                                  cksum, src_ip_old, ip->src));
     cksum = cksum_update;
   }
@@ -320,11 +317,11 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
     // NAT simulation
     // - one update for ip checksum recalcuation
     // - two for tcp checksum
-    benchmark::DoNotOptimize(ip->checksum = CalculateChecksumIncrementalUpdate(
+    benchmark::DoNotOptimize(ip->checksum = CalculateChecksumIncremental32(
                                  ip->checksum, src_ip_old, ip->src));
-    benchmark::DoNotOptimize(tcp->checksum = CalculateChecksumIncrementalUpdate(
+    benchmark::DoNotOptimize(tcp->checksum = CalculateChecksumIncremental32(
                                  tcp->checksum, src_ip_old, ip->src));
-    benchmark::DoNotOptimize(tcp->checksum = CalculateChecksumIncrementalUpdate(
+    benchmark::DoNotOptimize(tcp->checksum = CalculateChecksumIncremental16(
                                  tcp->checksum, src_port_old, tcp->src_port));
   }
 


### PR DESCRIPTION
Recent Intel processors have two vector load units that can be simultaneously utilized for every cycle. This patch parallelizes checksum accumulation with two input streams. 30-40% improvement is observed with 500B or larger packets.

It also includes some style fixups.