### PR TITLE
Fix deinit crash

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -318,7 +318,7 @@ static Module* create_module(const std::string& name,
   *perr = m->InitWithGenericArg(arg);
   if (perr->err() != 0) {
     VLOG(1) << perr->DebugString();
-    ModuleBuilder::DestroyModule(m);  // XXX: fix me
+    ModuleBuilder::DestroyModule(m);
     return nullptr;
   }
 

--- a/core/module.cc
+++ b/core/module.cc
@@ -60,8 +60,6 @@ int ModuleBuilder::DestroyModule(Module *m, bool erase) {
     all_modules_.erase(m->name());
   }
 
-  m->ogates_.clear();
-  m->igates_.clear();
   delete m;
   return 0;
 }

--- a/core/module.h
+++ b/core/module.h
@@ -161,6 +161,8 @@ class Module {
   virtual ~Module() {}
 
   pb_error_t Init(const bess::pb::EmptyArg &arg);
+
+  // NOTE: this function will be called even if Init() has failed.
   virtual void DeInit();
 
   virtual struct task_result RunTask(void *arg);

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -36,7 +36,9 @@ pb_error_t IPLookup::Init(const bess::pb::EmptyArg &) {
 }
 
 void IPLookup::DeInit() {
-  rte_lpm_free(lpm_);
+  if (!lpm_) {
+    rte_lpm_free(lpm_);
+  }
 }
 
 void IPLookup::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -59,8 +59,10 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
 }
 
 void PortInc::DeInit() {
-  port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_INC,
-                       nullptr, 0);
+  if (port_) {
+    port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_INC,
+                         nullptr, 0);
+  }
 }
 
 std::string PortInc::GetDesc() const {

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -31,8 +31,10 @@ pb_error_t PortOut::Init(const bess::pb::PortOutArg &arg) {
 }
 
 void PortOut::DeInit() {
-  port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_OUT,
-                       nullptr, 0);
+  if (port_) {
+    port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_OUT,
+                         nullptr, 0);
+  }
 }
 
 std::string PortOut::GetDesc() const {

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -49,8 +49,10 @@ pb_error_t QueueInc::Init(const bess::pb::QueueIncArg &arg) {
 }
 
 void QueueInc::DeInit() {
-  port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_INC,
-                       &qid_, 1);
+  if (port_) {
+    port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_INC,
+                         &qid_, 1);
+  }
 }
 
 std::string QueueInc::GetDesc() const {

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -30,8 +30,10 @@ pb_error_t QueueOut::Init(const bess::pb::QueueOutArg &arg) {
 }
 
 void QueueOut::DeInit() {
-  port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_OUT,
-                       &qid_, 1);
+  if (port_) {
+    port_->ReleaseQueues(reinterpret_cast<const module *>(this), PACKET_DIR_OUT,
+                         &qid_, 1);
+  }
 }
 
 std::string QueueOut::GetDesc() const {


### PR DESCRIPTION
When module Init() fails, the module's DeInit() function will be called immediately. This behavior is different from the legacy C version, where DeInit() was skipped for half-initialized modules. Some modules' DeInit() functions crash in this case.

How to reproduce:
```bessctl add module PortInc```
(module `Init()` fails since `port` is not specified, then `DeIniit()` crashes with a null pointer access)