### PR TITLE
Suppress scapy IPv6 warning

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -7,6 +7,10 @@ import cStringIO
 import tempfile
 import time
 
+# Suppress scapy IPv6 warning (must be done before importing scapy module)
+import logging
+logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
+
 import cli
 import commands
 
@@ -153,7 +157,9 @@ def run_cli():
         s = BESS()
         s.connect()
     except BESS.APIError as e:
-        print >> stderr, e.message, '(bessd daemon is not running?)'
+        print >> stderr, e.message
+        print >> stderr, 'Perhaps bessd daemon is not running locally? ' \
+                         'Try "daemon start".'
 
     cli = BESSCLI(s, commands, ferr=stderr, interactive=interactive,
                   history_file=hist_file)


### PR DESCRIPTION
Scapy can generate this warning when it is imported:

```
WARNING: No route found for IPv6 destination :: (no default route?)
```

This warning message is suprious in that it only matters using Scapy send() function for IPv6 packets, whereas bessctl sample scripts use Scapy for packet crafting, not packet injection.