### PR TITLE
Do not swap endianness for value_bin

### DIFF
--- a/bessctl/conf/samples/vxlan.bess
+++ b/bessctl/conf/samples/vxlan.bess
@@ -3,8 +3,9 @@ Simple VXLAN example. The tunnel is established between eth_alice and BESS,
 and Bob is a tenant on the overlay network.
 
                +-------------------------------+
-               |                               |
-               |                               |
+               |             ping              |
+               |              |                |
+               |              V                |
                |            vxlan0             |   IP: 172.16.100.34/28
                |              +                |
                |              |                |
@@ -13,7 +14,7 @@ root container |          eth_alice            |   IP: 10.0.10.2/24
                +--------------+----------------+      (02:0a:0b:0c:0d:0e)
                               |
                               |
-			      | (tunneled traffic w/ VNI 999)
+                              | (tunneled traffic w/ VNI 999)
                               |
                               | vport_alice
                   +------+----+----+------+           (02:01:02:03:04:05)
@@ -27,7 +28,7 @@ BESS              |           |           |
                               |
                               | (non-tunneled traffic)
                               |
-			      |
+                              |
                +--------------+----------------+   IP: 172.16.100.33/28
                |           eth_bob             |
 Container Bob  |    (regular Ethernet port)    |

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -54,6 +54,12 @@ pb_error_t SetMetadata::AddAttrOne(
                     bess::metadata::kMetadataAttrMaxSize);
   }
 
+  // All metadata values are stored in a reserved area of packet data.
+  // Note they are stored in network order. This does not mean that you need
+  // to pass endian-swapped values in value_int to the module. Value is just
+  // value, and it has nothing to do with endianness (how an integer value is
+  // stored in memory). value_bin is a short stream of bytes, which means that
+  // its data will never be reordered.
   if (attr.value_case() == bess::pb::SetMetadataArg_Attribute::kValueInt) {
     if (uint64_to_bin((uint8_t *)&value, size, attr.value_int(),
                       bess::utils::is_be_system())) {
@@ -70,11 +76,7 @@ pb_error_t SetMetadata::AddAttrOne(
                       "correct %lu-byte value",
                       size);
     }
-    std::string value_bin(attr.value_bin());
-    if (!bess::utils::is_be_system()) {
-      std::reverse(value_bin.begin(), value_bin.end());
-    }
-    memcpy(&value, value_bin.data(), size);
+    memcpy(&value, attr.value_bin().data(), size);
   } else {
     offset = attr.offset();
     if (offset < 0 || offset + size >= SNBUF_DATA) {

--- a/core/utils/ether.h
+++ b/core/utils/ether.h
@@ -48,6 +48,14 @@ struct[[gnu::packed]] EthHeader {
     char bytes[kSize];
   };
 
+  enum Type : uint16_t {
+    kIpv4 = 0x0800,
+    kArp = 0x0806,
+    kVlan = 0x8100,
+    kQinQ = 0x88a8,  // 802.1ad double-tagged VLAN packets
+    kIpv6 = 0x86DD,
+  };
+
   Address dst_addr;
   Address src_addr;
   be16_t ether_type;

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -25,6 +25,11 @@ struct CIDRNetwork {
 
 // An IPv4 header definition loosely based on the BSD version.
 struct[[gnu::packed]] Ipv4Header {
+  enum Flag : uint16_t {
+    kMF = 1 << 13,  // More fragments
+    kDF = 1 << 14,  // Do not fragment
+  };
+
 #if __BYTE_ORDER == __LITTLE_ENDIAN
   unsigned int header_length : 4;  // Header length.
   unsigned int version : 4;        // Version.


### PR DESCRIPTION
SetMetadata takes two different types of values: `value_int` and `value_bin`. When value_bin is given to the module, the data should be used verbatim. At the moment, `value_bin` is only used by the `samples/vxlan` example, which does not work correctly due to incorrect metadata values. This PR fixes this issue by not converting endianness for `value_bin` data.

This PR also fixes an IPEncap bug found during the process. The module occasionally generates incorrect IP checksum values, depending on the garbage values in the IP checksum field. DPDK checksum routines require the field to be set to zero before calculating checksum. Switched to utils/checksum.h which does not impose this limitation.