### PR TITLE
Add comments to BESS APIs and message types

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -823,7 +823,7 @@ class BESSControlImpl final : public BESSControl::Service {
                    ListPortsResponse* response) override {
     for (const auto& pair : PortBuilder::all_ports()) {
       const ::Port* p = pair.second;
-      bess::pb::Port* port = response->add_ports();
+      bess::pb::ListPortsResponse::Port* port = response->add_ports();
 
       port->set_name(p->name());
       port->set_driver(p->port_builder()->class_name());

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -40,6 +40,8 @@ bool PriorityTrafficClass::AddChild(TrafficClass *child, priority_t priority) {
   }
 
   // Ensure that no child already has the given priority.
+  // FIXME: Allow having multiple TCs with the same priority.
+  //        (However, who gets scheduled first among them is not guaranteed)
   for (const auto &c : children_) {
     if (c.priority_ == priority) {
       return false;

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -3,214 +3,108 @@ syntax = "proto3";
 import "google/protobuf/any.proto";
 import "error.proto";
 
-package bess.pb;
+/// - "timestamp" represents the current time in seconds since the Epoch.
+/// (in the same manner as gettimeofday() in C and time.time() in Python)
+///
+/// - All Responses (including EmptyResponse) messages have an "Error"-type
+///   field. Upon a successful RPC the message has the default value
+///   (with error code 0). Otherwise the error code has a non-zero value.
 
-message EmptyRequest {
-}
+package bess.pb;
 
 message EmptyArg {
 }
 
+message EmptyRequest {
+}
+
 message EmptyResponse {
+  /// Contains a non-zero error code and a non-empty message if and only if
+  /// there has been an error
   Error error = 1;
 }
 
-message DisableTcpdumpRequest {
-  string name = 1;
-  uint64 gate = 2;
-  bool is_igate = 3;
-}
-
-message EnableTcpdumpRequest {
-  string name = 1;
-  uint64 gate = 2;
-  string fifo = 3;
-  bool is_igate = 4;
-}
-
-message AttachTaskRequest {
-  string name = 1;
-  uint64 taskid = 2;
-  oneof identifier {
-    string tc = 3;
-    uint64 wid = 4;
-  }
-}
-
-message DisconnectModulesRequest {
-  string name = 1;
-  uint64 ogate = 2;
-}
-
-message ConnectModulesRequest {
-  string m1 = 1;
-  string m2 = 2;
-  uint64 ogate = 3;
-  uint64 igate = 4;
-}
-
-message GetModuleInfoResponse {
-  message IGate {
-    message OGate {
-      uint64 ogate = 1;
-      string name = 2;
-    }
-    uint64 igate = 1;
-    repeated OGate ogates = 2;
-    uint64 cnt = 3;
-    uint64 pkts = 4;
-    double timestamp = 5;
-  }
-  message OGate {
-    uint64 ogate = 1;
-    uint64 cnt = 2;
-    uint64 pkts = 3;
-    double timestamp = 4;
-    string name = 5;
-    uint64 igate = 6;
-  }
-  message Attribute {
-    string name = 1;
-    uint64 size = 2;
-    string mode = 3;
-    int64 offset = 4;
-  }
-  Error error = 1;
-  string name = 2;
-  string mclass = 3;
-  string desc = 4;
-  // TODO: string dump = 4;
-  repeated IGate igates = 6;
-  repeated OGate ogates = 7;
-  repeated Attribute metadata = 8;
-}
-
-message GetModuleInfoRequest {
-  string name = 1;
-}
-
-message DestroyModuleRequest {
-  string name = 1;
-}
-
-message CreateModuleResponse {
-  Error error = 1;
-  string name = 2;
-}
-
-message ListModulesResponse {
-  message Module {
-    string name = 1;
-    string mclass = 2;
-    string desc = 3;
-  }
-  Error error = 1;
-  repeated Module modules = 2;
-}
-
-message GetPortStatsResponse {
-  message Stat {
-    uint64 packets = 1;
-    uint64 dropped = 2;
-    uint64 bytes = 3;
-  }
-  Error error = 1;
-  Stat inc = 2;
-  Stat out = 3;
-  double timestamp = 4;
-}
-
-message GetPortStatsRequest {
-  string name = 1;
-}
-
-message DestroyPortRequest {
-  string name = 1;
-}
-
-message Port {
-  string name = 1;
-  string driver = 2;
-  string mac_addr = 3;
-}
-
-message ListPortsResponse {
-  Error error = 1;
-  repeated Port ports = 2;
+message ImportMclassRequest {
+  string path = 1;  /// Path to the module library (*.so file)
 }
 
 message ListWorkersResponse {
   message WorkerStatus {
-    int64 wid = 1;
-    int64 core = 2;
-    int64 running = 3;
+    int64 wid = 1;      /// Worker ID, starting from 0
+    int64 core = 2;     /// CPU core ID on which the worker is pinned
+    int64 running = 3;  /// 1 if running, or 0. TODO: bool
+
+    /// Number of traffic classes running on the worker
     int64 num_tcs = 4;
+
+    /// Total number of packets that have been silently dropped on the worker.
+    /// Silent drops happen when a module transmit packets via disconnected
+    /// output gates.
     int64 silent_drops = 5;
   }
-  Error error = 1;
-  repeated WorkerStatus workers_status = 2;
-}
 
-message GetLinkStatusRequest {
-  string name = 1;       /// name of the port to query
-}
-
-message GetLinkStatusResponse {
   Error error = 1;
-  uint32 speed = 2;      /// speed in mbps: 1000, 40000, etc. 0 for vports
-  bool full_duplex = 3;  /// full-duplex enabled?
-  bool autoneg = 4;      /// auto-negotiated speed and duplex?
-  bool link_up = 5;      /// link up?
+  repeated WorkerStatus workers_status = 2;  /// List of all existing workers
 }
 
 message AddWorkerRequest {
-  int64 wid = 1;
-  int64 core = 2;
+  int64 wid = 1;   /// Worker ID to be added
+  int64 core = 2;  /// CPU core ID on which the worker would run
 }
 
 message DestroyWorkerRequest {
-  int64 wid = 1;
-}
-
-message ListTcsRequest {
-  int64 wid = 1;
+  int64 wid = 1;  /// Worker ID
 }
 
 message TrafficClass {
-  message Resource {
-    int64 schedules = 1;
-    int64 cycles = 2;
-    int64 packets = 3;
-    int64 bits = 4;
-  }
-  string parent = 1;
-  string name = 2;
-  bool blocked = 3;
+  string parent = 1;    /// Name of paraent TC
+  string name = 2;      /// Name of TC
+  bool blocked = 3;     /// Is it running or ready to run at the moment?
+
+  /// One of "priority", "weighted_fair", "round_robin", "rate_limit", "leaf"
   string policy = 4;
+
+  /// Type of resource to regulate. Only used for traffic classes of
+  /// weighted_fair and rate_limit types.
+  /// Should be one of resource types: "count", "cycle", "packet", "bit"
   string resource = 5;
+
   oneof arg {
+    /// Used by "priority". Lower number == high priority.
+    //  FIXME: should be higher number == higher priority, to be consistent
+    //         other uses of "priority" in BESS
     int64 priority = 6;
+
+    /// Relative weight (share), used by "weighted_fair".
+    /// 1 <= share <= 1024 is recommended. Higher number will result in
+    /// lower scheduling accuracy.
     int64 share = 7;
   }
-  int64 wid = 8;
+
+  int64 wid = 8;  /// Worker ID that this TC belongs to
+
+  //  FIXME: If one can specify limit for only one resource type per TC,
+  //         these two fields shouldn't be a map.
+
+  /// Long-term average of resource limit, in cycles/s, packets/s, ...
   map<string, int64> limit = 9;
+
+  /// Burst allowance of resource limit, in cycles, packets, bits, ...
+  /// If set to 0, no extra tokens will be saved.
   map<string, int64> max_burst = 10;
 }
 
-message GetTcStatsResponse {
-  Error error = 1;
-  double timestamp = 2;
-  uint64 count = 3;
-  uint64 cycles = 4;
-  uint64 packets = 5;
-  uint64 bits = 6;
+message ListTcsRequest {
+  /// Specify a worker thrread to fetch traffic claees.
+  /// To include all traffic classes on every worker, specify -1.
+  int64 wid = 1;
 }
 
 message ListTcsResponse {
   message TrafficClassStatus {
     TrafficClass class = 1;
-    string parent = 2;
-    int64 tasks = 3;
+    string parent = 2;  /// Name of its parent TC
+    int64 tasks = 3;    /// How many tasks belong to this TC?
   }
   Error error = 1;
   repeated TrafficClassStatus classes_status = 2;
@@ -225,92 +119,291 @@ message UpdateTcRequest {
 }
 
 message GetTcStatsRequest {
-  string name = 1;
+  string name = 1;  /// Name of TC
+}
+
+message GetTcStatsResponse {
+  Error error = 1;
+  double timestamp = 2;  /// The time that stat counters were read
+
+  /// THe following counters represent the total amount of accumulated resource
+  /// usage of a module since its creation.
+  uint64 count = 3;    /// # of scheduled times
+  uint64 cycles = 4;   /// CPU cycles
+  uint64 packets = 5;  /// # of packets
+  uint64 bits = 6;     /// # of bits
+}
+
+message AttachTaskRequest {
+  string name = 1;    /// Name of module
+  uint64 taskid = 2;  /// Task ID, starting from 0
+  oneof identifier {
+    string tc = 3;    /// Name of TC to bind
+    uint64 wid = 4;   /// Worker ID, starting from 0
+  }
 }
 
 message ListDriversResponse {
   Error error = 1;
-  repeated string driver_names = 2;
+  repeated string driver_names = 2;  /// List of availabe port drivers
 }
 
 message GetDriverInfoRequest {
-  string driver_name = 1;
+  string driver_name = 1;  /// Name of port driver
 }
 
 message GetDriverInfoResponse {
   Error error = 1;
-  string name = 2;
-  string help = 3;
-  repeated string commands = 4;
+  string name = 2;  /// Name of port driver
+  string help = 3;  /// 1-line description of the driver
+  repeated string commands = 4;  /// List of supported commands (TODO)
 }
 
-message ListMclassResponse {
+message ListPortsResponse {
+  message Port {
+    string name = 1;      /// Name of port
+    string driver = 2;    /// Name of port driver.
+    string mac_addr = 3;  /// MAC address of the port
+  }
+
   Error error = 1;
-  repeated string names = 2;
-}
-
-message GetMclassInfoRequest {
-  string name = 1;
-}
-
-message GetMclassInfoResponse {
-  Error error = 1;
-  string name = 2;
-  string help = 3;
-  repeated string cmds = 4;
-  repeated string cmd_args = 5;
-}
-
-message CreateModuleRequest {
-  string name = 1;
-  string mclass = 2;
-  google.protobuf.Any arg = 3;
-}
-
-message ModuleCommandRequest {
-  string name = 1;
-  string cmd = 2;
-  google.protobuf.Any arg = 3;
-}
-
-message ModuleCommandResponse {
-  Error error = 1;
-  google.protobuf.Any other = 2;
+  repeated Port ports = 2;  /// List of all existing ports
 }
 
 message CreatePortRequest {
+  /// Name of the port to create. Every port must have a unique name.
+  /// If not specified, a default name will be assigned
+  /// (returned via CreatePortResponse for future reference).
   string name = 1;
+
+  /// Name of port driver. Must be specified.
   string driver = 2;
+
+  /// Number of incoming/RX queues (Ext -> BESS). Default is 1
   uint64 num_inc_q = 3;
+  /// Number of outgoind/TX queues (BESS -> Ext). Default is 1
   uint64 num_out_q = 4;
+
+  /// Size of each incoming queue (# of packets).
+  /// If not set (0), a driver-specific default value will be used.
   uint64 size_inc_q = 5;
+  /// Size of each incoming queue (# of packets).
+  /// If not set (0), a driver-specific default value will be used.
   uint64 size_out_q = 6;
+
+  /// MAC address for the new port. Should be "xx:xx:xx:xx:xx:xx" format.
   string mac_addr = 7;
+
+  /// Driver specific argument for port initialization. See port_msg.proto
   google.protobuf.Any arg = 8;
 }
 
 message CreatePortResponse {
   Error error = 1;
-  string name = 2;
-  string mac_addr = 3;
+  string name = 2;      /// Name of the created port (specified or default one)
+  string mac_addr = 3;  /// Port MAC address (specified or default one)
 }
 
-message EnableTrackRequest {
+message DestroyPortRequest {
+  string name = 1;  /// Name of port
+}
+
+message GetPortStatsRequest {
+  string name = 1;  /// Name of port
+}
+
+message GetPortStatsResponse {
+  message Stat {
+    /// Number of objects that have been successfully sent/received.
+    /// All counters shows the accumulated value since port initialization.
+    uint64 packets = 1;
+
+    /// Number of dropped packets.
+    /// For incoming direction, it implies BESS is not picking up fast enough.
+    /// For outgoing direction, non-zero drop counter indicates that the "peer"
+    /// of this port is the performance bottleneck: namely, VMs/containers/apps
+    /// for virtual ports, or PCIe/NIC/link for physical port.
+    uint64 dropped = 2;
+
+    /// Total number of bytes, not including Frame CRC or Ethernet overheads
+    uint64 bytes = 3;
+  }
+  Error error = 1;
+  Stat inc = 2;          /// Port stats for incoming (Ext -> BESS) direction.
+  Stat out = 3;          /// Port stats for outgoing (BESS -> Ext) direction.
+  double timestamp = 4;  /// Time that stat counters were read.
+}
+
+message GetLinkStatusRequest {
+  string name = 1;       /// name of the port to query
+}
+
+message GetLinkStatusResponse {
+  Error error = 1;
+  uint32 speed = 2;      /// speed in mbps: 1000, 40000, etc. 0 for vports
+  bool full_duplex = 3;  /// full-duplex enabled?
+  bool autoneg = 4;      /// auto-negotiated speed and duplex?
+  bool link_up = 5;      /// link up?
+}
+
+
+
+
+
+message ListMclassResponse {
+  Error error = 1;
+  repeated string names = 2;  /// List of module types
+}
+
+message GetMclassInfoRequest {
+  string name = 1;  /// Name of module type
+}
+
+message GetMclassInfoResponse {
+  Error error = 1;
+  string name = 2;               /// Name of module type
+  string help = 3;               /// 1=line description of the module type
+  repeated string cmds = 4;      /// List of commands supported by the module
+  repeated string cmd_args = 5;  /// Corresponding Protobuf message types
+
+  /// FIXME; Should be "repeated ModuleCommand cmds", with the above two grouped
+}
+
+message ListModulesResponse {
+  message Module {
+    string name = 1;    /// Name of module
+    string mclass = 2;  /// Module type
+    string desc = 3;    /// Current status of module as a short, 1-line string
+  }
+  Error error = 1;
+  repeated Module modules = 2;  /// List of all existing modules
+}
+
+message CreateModuleRequest {
+  /// Name of the module to create. Every module must have a unique name.
+  /// If not specified, a default name will be assigned
+  /// (returned via CreateModuleResponse for future reference).
   string name = 1;
-  int64 gate = 2;
-  bool is_igate = 3;
-  bool use_gate = 4;
+
+  /// Name of module type. Must be specified.
+  string mclass = 2;
+
+  /// Protobuf message to be used for module initialization.
+  /// See module_msg.proto for the argument message types.
+  google.protobuf.Any arg = 3;
+}
+
+message CreateModuleResponse {
+  Error error = 1;
+  string name = 2;  /// Name of the created module (specified or default one)
+}
+
+message DestroyModuleRequest {
+  string name = 1;  /// Name of module to remove
+}
+
+message GetModuleInfoRequest {
+  string name = 1;  /// Name of module to query
+}
+
+message GetModuleInfoResponse {
+  message IGate {
+    message OGate {
+      uint64 ogate = 1;  /// Output gate of "previous" module
+      string name = 2;   /// Name of "previous" module
+    }
+    uint64 igate = 1;           /// Input gate ID
+    repeated OGate ogates = 2;  /// The list of upstream output gates
+    uint64 cnt = 3;             /// # of packet batches seen
+    uint64 pkts = 4;            /// # of packets seen
+    double timestamp = 5;       /// The time that cnt/pkts counters were read
+  }
+  message OGate {
+    uint64 ogate = 1;      /// Output gate ID
+    uint64 cnt = 2;        /// # of packet batches seen
+    uint64 pkts = 3;       /// # of packets seen
+    double timestamp = 4;  /// The time thatcnt/pkts counters were read
+    string name = 5;       /// Name of the "next" module it connects to
+    uint64 igate = 6;      /// Input gate ID of the "next" module
+  }
+  message Attribute {
+    string name = 1;   /// Name of per-packet metadata attribute
+    uint64 size = 2;   /// Size of attribute (in bytes)
+    string mode = 3;   /// "read", "write", or "update"
+    int64 offset = 4;  /// (internal debugging purpose only)
+  }
+  Error error = 1;
+  string name = 2;    /// Name of module
+  string mclass = 3;  /// Module type
+  string desc = 4;    /// Current status of module as a short, 1-line string
+
+  // TODO: string dump = 4;
+  repeated IGate igates = 6;        /// List of connected input gates
+  repeated OGate ogates = 7;        /// List of connected output gates
+  repeated Attribute metadata = 8;  /// List of metadata used by the module
+}
+
+message ConnectModulesRequest {
+  string m1 = 1;      /// Name of "previous" module name
+  string m2 = 2;      /// name of "next" module name
+  uint64 ogate = 3;   /// m1's output gate ID
+  uint64 igate = 4;   /// m2's input gate ID
+}
+
+message DisconnectModulesRequest {
+  string name = 1;   /// Name of previous module
+  uint64 ogate = 2;  /// Output gate ID of previous module
+}
+
+message ModuleCommandRequest {
+  string name = 1;              /// Name of module to handle this command
+  string cmd = 2;               /// Name of command
+  google.protobuf.Any arg = 3;  /// Command argument (see module_msg.proto)
+}
+
+message ModuleCommandResponse {
+  Error error = 1;
+  google.protobuf.Any other = 2;  /// Command response (see module_msg.proto)
+}
+
+
+//  -------------------------------------------------------------------------
+//  Module hook
+//  -------------------------------------------------------------------------
+
+message EnableTrackRequest {
+  string name = 1;    /// Name of module
+  int64 gate = 2;     /// Gate ID, starting from 0
+  bool is_igate = 3;  /// Either input gate (True) or output gate (False)
+  bool use_gate = 4;  /// If False, the hook is installed on all igates & ogates
+
+  // FIXME: use oneof {igate, ogate)
+  // FIXME: get rid of use_gate (e.g., gate == -1)
 }
 
 message DisableTrackRequest {
-  string name = 1;
-  int64 gate = 2;
-  bool is_igate = 3;
-  bool use_gate = 4;
+  string name = 1;    /// Name of module
+  int64 gate = 2;     /// Gate ID, starting from 0
+  bool is_igate = 3;  /// Either input gate (True) or output gate (False)
+  bool use_gate = 4;  /// If False, the hook is installed on all igates & ogates
+
+  // FIXME: use oneof {igate, ogate)
+  // FIXME: get rid of use_gate (e.g., gate == -1)
 }
 
-message ImportMclassRequest {
-  string path = 1;    /// Path to the module library
+message EnableTcpdumpRequest {
+  string name = 1;    /// Name of module
+  uint64 gate = 2;    /// Gate ID, starting from 0
+  string fifo = 3;    /// Path to the FIFO file.
+  bool is_igate = 4;  /// Either input gate (True) or output gate (False)
+
+  // FIXME: use oneof {igate, ogate)
 }
 
-// TODO: add something like PortCommandRequest
+message DisableTcpdumpRequest {
+  string name = 1;    /// Name of module
+  uint64 gate = 2;    /// Gate ID, starting from 0
+  bool is_igate = 3;  /// Either input gate (True) or output gate (False)
+
+  // FIXME: use oneof {igate, ogate)
+}

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -5,54 +5,265 @@ import "bess_msg.proto";
 package bess.pb;
 
 service BESSControl {
+
+  //  -------------------------------------------------------------------------
+  //  System
+  //  -------------------------------------------------------------------------
+
+  /// Reset the current packet processing datapath to the initial state.
+  ///
+  /// This command is identical to the following sequence:
+  ///   ResetModules()
+  ///   ResetPorts()
+  ///   ResetTcs()
+  ///   ResetWorkers()
+  /// As it clears everything, BESS should appear as if the daemon has freshly
+  /// started (if not, it is a bug; please report).
+  ///
+  /// NOTE: There should be no running worker to run this command.
   rpc ResetAll (EmptyRequest) returns (EmptyResponse) {}
 
-  rpc PauseAll (EmptyRequest) returns (EmptyResponse) {}
-  rpc ResumeAll (EmptyRequest) returns (EmptyResponse) {}
-
-  rpc ResetWorkers (EmptyRequest) returns (EmptyResponse) {}
-  rpc ListWorkers (EmptyRequest) returns (ListWorkersResponse) {}
-  rpc AddWorker (AddWorkerRequest) returns (EmptyResponse) {}
-  rpc DestroyWorker (DestroyWorkerRequest) returns (EmptyResponse) {}
-
-  rpc ResetTcs (EmptyRequest) returns (EmptyResponse) {}
-  rpc ListTcs (ListTcsRequest) returns (ListTcsResponse) {}
-  rpc AddTc (AddTcRequest) returns (EmptyResponse) {}
-  rpc UpdateTc (UpdateTcRequest) returns (EmptyResponse) {}
-  rpc GetTcStats (GetTcStatsRequest) returns (GetTcStatsResponse) {}
-
-  rpc ListDrivers (EmptyRequest) returns (ListDriversResponse) {}
-  rpc GetDriverInfo(GetDriverInfoRequest) returns (GetDriverInfoResponse) {}
-  // TODO: import_driver()
-
-  rpc ResetPorts (EmptyRequest) returns (EmptyResponse) {}
-  rpc ListPorts (EmptyRequest) returns (ListPortsResponse) {}
-  rpc CreatePort (CreatePortRequest) returns (CreatePortResponse) {}
-  rpc DestroyPort (DestroyPortRequest) returns (EmptyResponse) {}
-  rpc GetPortStats (GetPortStatsRequest) returns (GetPortStatsResponse) {}
-  rpc GetLinkStatus (GetLinkStatusRequest) returns (GetLinkStatusResponse) {}
-
-  rpc ListMclass (EmptyRequest) returns (ListMclassResponse) {}
-  rpc GetMclassInfo (GetMclassInfoRequest) returns (GetMclassInfoResponse) {}
-  rpc ImportMclass (ImportMclassRequest) returns (EmptyResponse) {}
-
-  rpc ResetModules (EmptyRequest) returns (EmptyResponse) {}
-  rpc ListModules (EmptyRequest) returns (ListModulesResponse) {}
-  rpc CreateModule (CreateModuleRequest) returns (CreateModuleResponse) {}
-  rpc DestroyModule (DestroyModuleRequest) returns (EmptyResponse) {}
-  rpc GetModuleInfo (GetModuleInfoRequest) returns (GetModuleInfoResponse) {}
-  rpc ConnectModules (ConnectModulesRequest) returns (EmptyResponse) {}
-  rpc DisconnectModules (DisconnectModulesRequest) returns (EmptyResponse) {}
-
-  rpc AttachTask (AttachTaskRequest) returns (EmptyResponse) {}
-
-  rpc EnableTcpdump (EnableTcpdumpRequest) returns (EmptyResponse) {}
-  rpc DisableTcpdump (DisableTcpdumpRequest) returns (EmptyResponse) {}
-
-  rpc EnableTrack (EnableTrackRequest) returns (EmptyResponse) {}
-  rpc DisableTrack (DisableTrackRequest) returns (EmptyResponse) {}
-
+  /// Terminate the BESS daemon.
+  ///
+  /// BESS daemon shuts off in a graceful manner. Note that this command is
+  /// "asynchronous": this command doesn't block until the BESS daemon has
+  /// shut off.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  /// FIXME: rename (e.g., Terminate)
   rpc KillBess (EmptyRequest) returns (EmptyResponse) {}
 
+  /// Import a plugin
+  ///
+  /// At the moment plugins can only contain module types,
+  /// but might also support drivers/hooks/schedulers in the future.
+  /// FIXME: rename (e.g., ImportPlugin)
+  rpc ImportMclass (ImportMclassRequest) returns (EmptyResponse) {}
+
+
+  //  -------------------------------------------------------------------------
+  //  Worker
+  //  -------------------------------------------------------------------------
+
+  /// Pause all running workers temporarily
+  ///
+  /// Some RPC commands to BESS or individual modules/ports require that
+  /// threads must be inactive, to avoid race conditions.
+  /// For such commands, use PauseALl at the beginning and ResumeAll at the end.
+  ///  PauseAll()
+  ///   SomeCommand1()
+  ///   SomeCommand2()
+  ///   ...
+  ///  ResumeAll()
+  /// Keep the duration as short as possible, to avoid packet drops.
+  rpc PauseAll (EmptyRequest) returns (EmptyResponse) {}
+
+  /// Resume all paused workers
+  rpc ResumeAll (EmptyRequest) returns (EmptyResponse) {}
+
+  /// Remove all existing workers
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc ResetWorkers (EmptyRequest) returns (EmptyResponse) {}
+
+  /// Enumerate all existing workers
+  rpc ListWorkers (EmptyRequest) returns (ListWorkersResponse) {}
+
+  /// Create a new worker
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc AddWorker (AddWorkerRequest) returns (EmptyResponse) {}
+
+  /// Remove a single worker
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc DestroyWorker (DestroyWorkerRequest) returns (EmptyResponse) {}
+
+
+  //  -------------------------------------------------------------------------
+  //  Traffic classe & task
+  //  -------------------------------------------------------------------------
+
+  /// Remove all existing traffic classes
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc ResetTcs (EmptyRequest) returns (EmptyResponse) {}
+
+  /// Enumerate all existing workers
+  rpc ListTcs (ListTcsRequest) returns (ListTcsResponse) {}
+
+  /// Create a new traffic class
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc AddTc (AddTcRequest) returns (EmptyResponse) {}
+
+  /// Update parameters of an existing traffic class
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc UpdateTc (UpdateTcRequest) returns (EmptyResponse) {}
+
+  /// Collect statistics of a traffic class
+  rpc GetTcStats (GetTcStatsRequest) returns (GetTcStatsResponse) {}
+
+  /// Attach a task to the specified traffic class (TC)
+  ///
+  /// Some modules (PortInc/QueueInc/Source/Queue/etc) create schedulable tasks.
+  /// By attaching tasks to a traffic class, their resource usage (e.g., link
+  /// bandwidth or CPU cycles) can be measured and policed.
+  /// If wid is given instead of tc, the task will be attached to a default TC
+  /// running on the specified worker
+  /// If there are tasks that are not attached to any TC when BESS resumes,
+  /// BESS will assign tasks across TCs on all existing workers in an
+  /// arbitrary manner.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc AttachTask (AttachTaskRequest) returns (EmptyResponse) {}
+
+
+  //  -------------------------------------------------------------------------
+  //  Port
+  //  -------------------------------------------------------------------------
+
+  /// Enumerate all port drivers available
+  rpc ListDrivers (EmptyRequest) returns (ListDriversResponse) {}
+
+  /// Query detailed information of a port driver
+  rpc GetDriverInfo(GetDriverInfoRequest) returns (GetDriverInfoResponse) {}
+
+  /// Remove all initialized ports
+  ///
+  /// Will fail if there are modules that are still using ports.
+  /// (e.g., PortInc, PortOut, QueueInc, QueueOut)
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc ResetPorts (EmptyRequest) returns (EmptyResponse) {}
+
+  /// Enumerate all initialized ports
+  rpc ListPorts (EmptyRequest) returns (ListPortsResponse) {}
+
+  /// Create a new port from the specified driver
+  rpc CreatePort (CreatePortRequest) returns (CreatePortResponse) {}
+
+  /// Remove a port
+  ///
+  /// The port should not be being used by a port-related module.
+  /// (e.g., PortInc, PortOut, QueueInc, QueueOut)
+  rpc DestroyPort (DestroyPortRequest) returns (EmptyResponse) {}
+
+  /// Collect port statistics
+  ///
+  /// At the moment, per-queue stats are not supported.
+  rpc GetPortStats (GetPortStatsRequest) returns (GetPortStatsResponse) {}
+
+  /// Query link status
+  rpc GetLinkStatus (GetLinkStatusRequest) returns (GetLinkStatusResponse) {}
+
+  // TODO: Add PortCommand, like ModuleCommand, which performs driver-specific
+  //       actions on a port.
+
+
+  //  -------------------------------------------------------------------------
+  //  Module
+  //  -------------------------------------------------------------------------
+
+  /// Enumerate all module types available
+  rpc ListMclass (EmptyRequest) returns (ListMclassResponse) {}
+
+  /// Query detailed information of a module type
+  rpc GetMclassInfo (GetMclassInfoRequest) returns (GetMclassInfoResponse) {}
+
+  /// Remove all modules.
+  ///
+  /// This RPC will always succeed (unless there is a running worker)
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc ResetModules (EmptyRequest) returns (EmptyResponse) {}
+
+  /// Enumerate all initialized modules
+  rpc ListModules (EmptyRequest) returns (ListModulesResponse) {}
+
+  /// Create a new module instance from the given module type
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc CreateModule (CreateModuleRequest) returns (CreateModuleResponse) {}
+
+  /// Destroy an exsting module
+  ///
+  /// If the module is connected to other modules' input/output gate, they are
+  /// disconnected first. All tasks created by the module will also be destoyed.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc DestroyModule (DestroyModuleRequest) returns (EmptyResponse) {}
+
+  /// Fetch detailed information of an module instance
+  rpc GetModuleInfo (GetModuleInfoRequest) returns (GetModuleInfoResponse) {}
+
+  /// Connect two modules.
+  ///
+  /// Connect between m1's ogate and n2's igate (i.e., ackets sent to m1's ogate
+  /// will be fed to m2's igate). The oate can be connected to only one igate,
+  /// while the igate can be connected to multiple output gates.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc ConnectModules (ConnectModulesRequest) returns (EmptyResponse) {}
+
+  /// Disconnect two modules.
+  ///
+  /// It removes a connection between two modules (you specify the previous one
+  /// and its output gate). All packets coming out from the ogate will be
+  /// dropped. Once disconnected, the ogate can be connected
+  /// to any input gate.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc DisconnectModules (DisconnectModulesRequest) returns (EmptyResponse) {}
+
+  /// Send a command to the specified module instance.
+  ///
+  /// Each module type defines a list of modyle-specific commands, which
+  /// allow external programs to communicate with the module at runtime.
+  /// See module_msg.proto for details.
+  ///
+  /// NOTE: Some commands cannot be used if there are running workers.
+  ///       For those commands you must pause all workers first.
   rpc ModuleCommand (ModuleCommandRequest) returns (ModuleCommandResponse) {}
+
+
+  //  -------------------------------------------------------------------------
+  //  Module hook
+  //  -------------------------------------------------------------------------
+
+  /// Enable "track" hook on a gate (or all gates)
+  ///
+  /// "track" hook accumulates the number of total packets & batches passing
+  /// through a gate. This incurs some amount of CPU overheads. While the cost
+  /// is very small, remember that the delay adds up at every gate.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc EnableTrack (EnableTrackRequest) returns (EmptyResponse) {}
+
+  /// Disable "track" hook on a gate (or all gates)
+  ///
+  /// You may want to disable the hook to squeeze out CPU cycles
+  /// as much as you can.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc DisableTrack (DisableTrackRequest) returns (EmptyResponse) {}
+
+  /// Enable tcpdump tapping at an input/output gate.
+  ///
+  /// Once the tap is installed, all packets going through the gate will be
+  /// captured and sent in PCAP format to the specified named pipe (FIFO).
+  /// Thus you can run `tcpdump -r <path to FIFO>` or save the stream in a file.
+  /// This feature may afffect performance.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc EnableTcpdump (EnableTcpdumpRequest) returns (EmptyResponse) {}
+
+  /// Disable tcpdump tapping at an input/output gate.
+  ///
+  /// Stop mirroring packets and Close the FIFO. Also see EnableTcpdumpRequest.
+  /// Once disabled the performance overhead will be gone.
+  ///
+  /// NOTE: There should be no running worker to run this command.
+  rpc DisableTcpdump (DisableTcpdumpRequest) returns (EmptyResponse) {}
 }


### PR DESCRIPTION
This PR adds comments to protobuf&grpc for BESS system-wide RPCs (comments for module-specific commands is addressed in #304).

Declaration of messages and RPCs was reordered to group them by functionality.