### PR TITLE
Fix typo in IPLookup::DeInit()

### DIFF
--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -36,7 +36,7 @@ pb_error_t IPLookup::Init(const bess::pb::EmptyArg &) {
 }
 
 void IPLookup::DeInit() {
-  if (!lpm_) {
+  if (lpm_) {
     rte_lpm_free(lpm_);
   }
 }


### PR DESCRIPTION
This PR addresses #349.