### PR TITLE
Do not install linux-virtual via apt-get

### DIFF
--- a/vagrant/bess.yml
+++ b/vagrant/bess.yml
@@ -38,8 +38,6 @@
         - libgoogle-glog-dev
         - libgraph-easy-perl
         - libgtest-dev
-        - google-mock
-        - linux-virtual
         - linux-headers-generic
         - lcov
 


### PR DESCRIPTION
The Ansible script `vagrant/bess.yml` installs `linux-virtual`, which is a stripped down version of Linux image (typically for VMs in cloud). This package should not be installed because:

* The script might be used on non-VM systems, where `linux-virtual` is not intended to be used for.
* Even for VMs, the package lacks useful modules for DPDK, such as `uio_pci_generic` and `vfio-pci`.

--

Also removed `google-mock`, which is never used for building BESS.