### PR TITLE
Show MAC address of PMD device at startup

### DIFF
--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -1,5 +1,6 @@
 #include "pmd.h"
 
+#include "../utils/ether.h"
 #include "../utils/format.h"
 
 /*!
@@ -59,9 +60,13 @@ void PMDPort::InitDriver() {
           dev_info.pci_dev->id.vendor_id, dev_info.pci_dev->id.device_id);
     }
 
+    bess::utils::EthHeader::Address lladdr;
+    rte_eth_macaddr_get(i, reinterpret_cast<ether_addr *>(lladdr.bytes));
+
     LOG(INFO) << "DPDK port_id " << static_cast<int>(i) << " ("
               << dev_info.driver_name << ")   RXQ " << dev_info.max_rx_queues
-              << " TXQ " << dev_info.max_tx_queues << "  " << pci_info;
+              << " TXQ " << dev_info.max_tx_queues << "  " << lladdr.ToString()
+              << "  " << pci_info;
   }
 }
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -327,8 +327,10 @@ void PMDPort::CollectStats(bool reset) {
   port_stats_.inc.dropped = stats.imissed;
 
   // i40e PMD driver doesn't support per-queue stats
-  if (driver_ == "net_i40e") {
-    // NOTE: if link is down, tx bytes won't increase
+  if (driver_ == "net_i40e" || driver_ == "net_i40e_vf") {
+    // NOTE:
+    // - if link is down, tx bytes won't increase
+    // - if destination MAC address is incorrect, rx pkts won't increase
     port_stats_.inc.packets = stats.ipackets;
     port_stats_.inc.bytes = stats.ibytes;
     port_stats_.out.packets = stats.opackets;

--- a/core/utils/ether.h
+++ b/core/utils/ether.h
@@ -22,7 +22,7 @@ struct[[gnu::packed]] EthHeader {
     //   (in that case, the content of parsed is undefined.)
     bool FromString(const std::string &str);
 
-    // Returns "aA:Bb:00:11:22:33"
+    // Returns "aa:bb:00:11:22:33" (all in lower case)
     std::string ToString() const;
 
     void Randomize();


### PR DESCRIPTION
This PR logs the MAC addresses of DPDK PMD devices during the driver initialization phase. This is useful especially because SR-IOV VFs are assigned with a random MAC address when created.

```
I0329 11:31:05.575981 10807 pmd.cc:46] 1 DPDK PMD ports have been recognized:
I0329 11:31:05.575997 10807 pmd.cc:66] DPDK port_id 0 (net_i40e)   RXQ 320 TXQ 320  3c:fd:fe:a2:ac:09  0000:02:00.01 8086:1583
```

While not directly related, this PR also fixes the incorrect port statistics for i40e VFs.