### PR TITLE
Fix sigsegv in cuckoo_map.h

### DIFF
--- a/core/utils/cuckoo_map.h
+++ b/core/utils/cuckoo_map.h
@@ -479,7 +479,11 @@ class CuckooMap {
       }
     }
 
-    *this = std::move(bigger);
+    bucket_mask_ = std::move(bigger.bucket_mask_);
+    num_entries_ = bigger.num_entries_;
+    buckets_ = std::move(bigger.buckets_);
+    entries_ = std::move(bigger.entries_);
+    free_entry_indices_ = std::move(bigger.free_entry_indices_);
   }
 
   // # of buckets == mask + 1


### PR DESCRIPTION
Calling `*this = std::move(<something else>)` is unsafe outside of
the move constructor in C++11 (in particular *this is const). In this
case this resulted in a segfault. I changed this to a series of moves
of the inner elements. Interestingly in searching through [github](https://github.com/search?q="*this+%3D+std%3A%3Amove"+extension%3Acpp+extension%3Acxx&type=Code)
I have not found anyone use this outside of a move constructor, so I
wonder why we chose this construct.