### PR TITLE
32 bit compile issues, Makefile envirnomental control variables

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -43,9 +43,10 @@ else ifeq ($(words $(MAKECMDGOALS)),1)
 	endif
 endif
 
-CXXFLAGS += -std=gnu++11 -g3 -ggdb3 -march=native \
-	    -Werror -isystem $(DPDK_INC_DIR) -isystem . -D_GNU_SOURCE \
-	    -Wall -Wextra -Wcast-align
+CXXARCHFLAGS ?= -march=native
+CXXFLAGS += -std=gnu++11 -g3 -ggdb3 $(CXXARCHFLAGS) \
+            -Werror -isystem $(DPDK_INC_DIR) -isystem . -D_GNU_SOURCE \
+            -Wall -Wextra -Wcast-align
 
 PERMISSIVE := -Wno-unused-parameter -Wno-missing-field-initializers \
 	      -Wno-unused-private-field
@@ -55,14 +56,23 @@ ifeq "$(shell expr $(CXXCOMPILER) = g++ \& $(CXXVERSION) \< 50000)" "0"
 	CXXFLAGS += -Wshadow
 endif
 
-LDFLAGS += -rdynamic -L$(DPDK_LIB_DIR) -Wl,-rpath=$(DPDK_LIB_DIR) -pthread \
-	   -static-libstdc++
+LDFLAGS += -rdynamic -L$(DPDK_LIB_DIR) -Wl,-rpath=$(DPDK_LIB_DIR) -pthread
+ifdef BESS_LINK_DYNAMIC
+    LIBS_ALL_SHARED = -Wl,-call_shared
+    LIBS_DL_SHARED = 
+else # Used static libraries
+    LIBS_ALL_SHARED =
+    LIBS_DL_SHARED = -Wl,-call_shared
+    LIBS_LZMA = -llzma
+    LDFLAGS += -static-libstdc++
+endif
 
 LIBS += -Wl,-non_shared \
 	-Wl,--whole-archive -l$(DPDK_LIB) -Wl,--no-whole-archive \
+	$(LIBS_ALL_SHARED) \
 	-lglog -lgflags -lprotobuf -lgrpc++ -lgrpc \
-	-lssl -lcrypto -lunwind -llzma -lpcap -lz \
-	-Wl,-call_shared \
+	-lssl -lcrypto -lunwind $(LIBS_LZMA) -lpcap -lz \
+	$(LIBS_DL_SHARED) \
 	-ldl
 
 ifdef SANITIZE

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -215,7 +215,8 @@ static std::string PrintCode(std::string symbol, int context) {
   uintptr_t obj_addr = GetRelativeAddress(sym_addr);
 
   std::string cmd = bess::utils::Format(
-      "addr2line -C -i -f -p -e %s 0x%lx 2> /dev/null", objfile, obj_addr);
+      "addr2line -C -i -f -p -e %s 0x%" PRIxPTR " 2> /dev/null", objfile,
+      obj_addr);
 
   std::istringstream result(RunCommand(cmd));
   std::string line;

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -319,8 +319,9 @@ void PMDPort::CollectStats(bool reset) {
   }
 
   VLOG(1) << bess::utils::Format(
-      "PMD port %d: ipackets %lu opackets %lu ibytes %lu obytes %lu "
-      "imissed %lu ierrors %lu oerrors %lu rx_nombuf %lu",
+      "PMD port %d: ipackets %" PRIu64 " opackets %" PRIu64
+      " ibytes %" PRIu64 " obytes %" PRIu64 " imissed %" PRIu64
+      " ierrors %" PRIu64 " oerrors %" PRIu64 " rx_nombuf %" PRIu64,
       dpdk_port_id_, stats.ipackets, stats.opackets, stats.ibytes, stats.obytes,
       stats.imissed, stats.ierrors, stats.oerrors, stats.rx_nombuf);
 

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -140,7 +140,7 @@ void ExactMatch::ProcessBatch(bess::PacketBatch *batch) {
 }
 
 std::string ExactMatch::GetDesc() const {
-  return bess::utils::Format("%d fields, %ld rules", num_fields_, ht_.Count());
+  return bess::utils::Format("%d fields, %zu rules", num_fields_, ht_.Count());
 }
 
 pb_error_t ExactMatch::GatherKey(const RepeatedPtrField<std::string> &fields,

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -64,7 +64,7 @@ class em_hash {
     }
     return init_val;
 #else
-    return rte_hash_crc(&key, key.key_len, init_val);
+    return rte_hash_crc(&key, len_, init_val);
 #endif
   }
 

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -1,3 +1,5 @@
+#include <rte_config.h>
+
 #include "ip_lookup.h"
 
 #include <arpa/inet.h>
@@ -140,7 +142,7 @@ pb_cmd_response_t IPLookup::CommandAdd(
 
   if (prefix_len > 32) {
     set_cmd_response_error(
-        &response, pb_error(EINVAL, "Invalid prefix length: %lu", prefix_len));
+        &response, pb_error(EINVAL, "Invalid prefix length: %" PRIu64, prefix_len));
     return response;
   }
 
@@ -149,7 +151,7 @@ pb_cmd_response_t IPLookup::CommandAdd(
 
   if (ip_addr & ~netmask) {
     set_cmd_response_error(
-        &response, pb_error(EINVAL, "Invalid IP prefix %s/%lu %x %x", prefix,
+        &response, pb_error(EINVAL, "Invalid IP prefix %s/%" PRIu64 " %x %x", prefix,
                             prefix_len, ip_addr, netmask));
     return response;
   }

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -24,7 +24,7 @@ using bess::utils::CuckooMap;
 
 const uint16_t MIN_PORT = 1024;
 const uint16_t MAX_PORT = 65535;
-const uint64_t TIME_OUT_NS = 120L * 1000 * 1000 * 1000;
+const uint64_t TIME_OUT_NS = (uint64_t)120 * 1000 * 1000 * 1000;
 
 enum Protocol : uint8_t {
   ICMP = 0x01,
@@ -157,7 +157,8 @@ class FlowHash {
     init_val = crc32c_sse42_u64(key.e1, init_val);
     init_val = crc32c_sse42_u64(key.e2, init_val);
 #else
-    init_val = rte_hash_crc(key, sizeof(Flow), init_val);
+    init_val = rte_hash_crc(&key.e1, sizeof(key.e1), init_val);
+    init_val = rte_hash_crc(&key.e2, sizeof(key.e2), init_val);
 #endif
     return init_val;
   }

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -121,7 +121,7 @@ struct task_result PortInc::RunTask(void *arg) {
 pb_error_t PortInc::SetBurst(int64_t burst) {
   if (burst == 0 ||
       burst > static_cast<int64_t>(bess::PacketBatch::kMaxBurst)) {
-    return pb_error(EINVAL, "burst size must be [1,%lu]",
+    return pb_error(EINVAL, "burst size must be [1,%zu]",
                     bess::PacketBatch::kMaxBurst);
   }
   burst_ = burst;

--- a/core/modules/queue.cc
+++ b/core/modules/queue.cc
@@ -150,7 +150,7 @@ struct task_result Queue::RunTask(void *) {
 pb_error_t Queue::SetBurst(int64_t burst) {
   if (burst == 0 ||
       burst > static_cast<int64_t>(bess::PacketBatch::kMaxBurst)) {
-    return pb_error(EINVAL, "burst size must be [1,%lu]",
+    return pb_error(EINVAL, "burst size must be [1,%zu]",
                     bess::PacketBatch::kMaxBurst);
   }
 

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -112,7 +112,7 @@ struct task_result QueueInc::RunTask(void *arg) {
 pb_error_t QueueInc::SetBurst(int64_t burst) {
   if (burst == 0 ||
       burst > static_cast<int64_t>(bess::PacketBatch::kMaxBurst)) {
-    return pb_error(EINVAL, "burst size must be [1,%lu]",
+    return pb_error(EINVAL, "burst size must be [1,%zu]",
                     bess::PacketBatch::kMaxBurst);
   }
   burst_ = burst;

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -23,8 +23,8 @@ pb_cmd_response_t Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {
 
   if (curr + arg.templates_size() > bess::PacketBatch::kMaxBurst) {
     set_cmd_response_error(&response, pb_error(EINVAL,
-                                               "max %lu packet templates "
-                                               "can be used %lu %d",
+                                               "max %zu packet templates "
+                                               "can be used %zu %d",
                                                bess::PacketBatch::kMaxBurst,
                                                curr, arg.templates_size()));
     return response;

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -65,7 +65,7 @@ pb_error_t SetMetadata::AddAttrOne(
                       bess::utils::is_be_system())) {
       return pb_error(EINVAL,
                       "'value_int' field has not a "
-                      "correct %lu-byte value",
+                      "correct %zu-byte value",
                       size);
     }
   } else if (attr.value_case() ==
@@ -73,7 +73,7 @@ pb_error_t SetMetadata::AddAttrOne(
     if (attr.value_bin().length() != size) {
       return pb_error(EINVAL,
                       "'value_bin' field has not a "
-                      "correct %lu-byte value",
+                      "correct %zu-byte value",
                       size);
     }
     memcpy(&value, attr.value_bin().data(), size);

--- a/core/modules/source.cc
+++ b/core/modules/source.cc
@@ -26,7 +26,7 @@ pb_error_t Source::Init(const bess::pb::SourceArg &arg) {
 
   if (arg.burst() > 0) {
     if (arg.burst() > bess::PacketBatch::kMaxBurst) {
-      return pb_error(EINVAL, "burst size must be [0,%ld]",
+      return pb_error(EINVAL, "burst size must be [0,%zu]",
                       bess::PacketBatch::kMaxBurst);
     }
     burst_ = arg.burst();
@@ -41,7 +41,7 @@ pb_cmd_response_t Source::CommandSetBurst(
 
   if (arg.burst() > bess::PacketBatch::kMaxBurst) {
     set_cmd_response_error(&response,
-                           pb_error(EINVAL, "burst size must be [0,%lu]",
+                           pb_error(EINVAL, "burst size must be [0,%zu]",
                                     bess::PacketBatch::kMaxBurst));
     return response;
   }

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -12,7 +12,7 @@ using bess::utils::EthHeader;
 using bess::utils::Ipv4Header;
 using bess::utils::TcpHeader;
 
-const uint64_t TIME_OUT_NS = 10L * 1000 * 1000 * 1000;  // 10 seconds
+const uint64_t TIME_OUT_NS = (uint64_t)10 * 1000 * 1000 * 1000;  // 10 seconds
 
 const Commands UrlFilter::cmds = {
     {"add", "UrlFilterArg", MODULE_CMD_FUNC(&UrlFilter::CommandAdd), 0},

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -174,16 +174,16 @@ std::string WildcardMatch::GetDesc() const {
     num_rules += tuple.ht.Count();
   }
 
-  return bess::utils::Format("%lu fields, %d rules", fields_.size(), num_rules);
+  return bess::utils::Format("%zu fields, %d rules", fields_.size(), num_rules);
 }
 
 template <typename T>
 pb_error_t WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
                                          wm_hkey_t *mask) {
   if ((size_t)arg.values_size() != fields_.size()) {
-    return pb_error(EINVAL, "must specify %lu values", fields_.size());
+    return pb_error(EINVAL, "must specify %zu values", fields_.size());
   } else if ((size_t)arg.masks_size() != fields_.size()) {
-    return pb_error(EINVAL, "must specify %lu masks", fields_.size());
+    return pb_error(EINVAL, "must specify %zu masks", fields_.size());
   }
 
   memset(key, 0, sizeof(*key));
@@ -200,18 +200,18 @@ pb_error_t WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
 
     if (uint64_to_bin(reinterpret_cast<uint8_t *>(&v), field_size,
                       arg.values(i), force_be || bess::utils::is_be_system())) {
-      return pb_error(EINVAL, "idx %lu: not a correct %d-byte value", i,
+      return pb_error(EINVAL, "idx %zu: not a correct %d-byte value", i,
                       field_size);
     } else if (uint64_to_bin(reinterpret_cast<uint8_t *>(&m), field_size,
                              arg.masks(i),
                              force_be || bess::utils::is_be_system())) {
-      return pb_error(EINVAL, "idx %lu: not a correct %d-byte mask", i,
+      return pb_error(EINVAL, "idx %zu: not a correct %d-byte mask", i,
                       field_size);
     }
 
     if (v & ~m) {
       return pb_error(EINVAL,
-                      "idx %lu: invalid pair of "
+                      "idx %zu: invalid pair of "
                       "value 0x%0*" PRIx64
                       " and "
                       "mask 0x%0*" PRIx64,

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -90,7 +90,7 @@ class wm_hash {
     }
     return init_val;
 #else
-    return rte_hash_crc(&key, key.key_len, init_val);
+    return rte_hash_crc(&key, len_, init_val);
 #endif
   }
 

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -74,6 +74,7 @@ static inline uint32_t CalculateSum(const void *buf, size_t len) {
   }
 #endif
 
+#if __x86_64
   // Repeat 64-bit one's complement sum (at sum64) including carrys
   // 8 additions in a loop
   while (len >= sizeof(uint64_t) * 8) {
@@ -109,9 +110,11 @@ static inline uint32_t CalculateSum(const void *buf, size_t len) {
   // Reduce 64-bit unsigned integer to 32-bit unsigned integer
   // Carry may happens, but no need to complete reduce here
   sum64 = (sum64 >> 32) + (sum64 & 0xFFFFFFFF);
+#endif
 
   // Repeat 16-bit one's complement sum (at sum64)
-  const uint16_t *buf16 = reinterpret_cast<const uint16_t *>(buf64);
+  typedef uint16_t __attribute__((__may_alias__)) u16_p;
+  const u16_p *buf16 = reinterpret_cast<const u16_p *>(buf64);
   while (len >= sizeof(uint16_t)) {
     sum64 += *buf16++;
     len -= sizeof(uint16_t);


### PR DESCRIPTION
- changes are required to get bess to compile with a 32 bit compiler.
- changes to the Makefile to allow compilation for an alternative architecture.
- changes to the Makefile to allow the option to link against shared libraries.
