### PR TITLE
Do not access over 6-byte boundary

### DIFF
--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -324,9 +324,10 @@ static int l2_flush(struct l2_table *l2tbl) {
 }
 
 static uint64_t l2_addr_to_u64(char *addr) {
-  uint64_t *addrp = reinterpret_cast<uint64_t *>(addr);
+  uint64_t a = *(reinterpret_cast<uint32_t *>(addr));
+  uint64_t b = *(reinterpret_cast<uint16_t *>(addr + 4));
 
-  return (*addrp & 0x0000FFffFFffFFfflu);
+  return a | (b << 32);
 }
 
 /******************************************************************************/
@@ -562,7 +563,9 @@ void L2Forward::ProcessBatch(bess::PacketBatch *batch) {
 
     out_gates[i] = default_gate;
 
-    l2_find(&l2_table_, l2_addr_to_u64(snb->head_data<char *>()),
+    // read destination MAC address (first 6 bytes)
+    // NOTE: assumes little endian
+    l2_find(&l2_table_, *(snb->head_data<uint64_t *>()) & 0x0000ffffffffffff,
             &out_gates[i]);
   }
 

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -4,6 +4,10 @@
 #include "../module.h"
 #include "../module_msg.pb.h"
 
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error this code assumes little endian architecture (x86)
+#endif
+
 struct l2_entry {
   union {
     struct {


### PR DESCRIPTION
This function violates access boundary for mac addresses in `char addr[6]`, setting alarms in ASAN.
```
static uint64_t l2_addr_to_u64(char *addr) {
  uint64_t *addrp = reinterpret_cast<uint64_t *>(addr);
```