### PR TITLE
bessctl: Fix 'command module'.

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -238,6 +238,10 @@ def get_var_attrs(cli, var_token, partial_word):
             var_type = 'name'
             var_desc = 'module command to run (see "show mclass")'
 
+        elif var_token == 'ARG_TYPE':
+            var_type = 'name'
+            var_desc = 'type of argument (see "show mclass")'
+
         elif var_token == '[NEW_PORT]':
             var_type = 'name'
             var_desc = 'specify a name of the new port'
@@ -789,6 +793,9 @@ def add_connection(cli, m1, m2, ogate, igate):
 @cmd('command module MODULE MODULE_CMD ARG_TYPE [CMD_ARGS...]',
      'Send a command to a module')
 def command_module(cli, module, cmd, arg_type, args):
+    if args is None:
+        args = {}
+
     cli.bess.pause_all()
     try:
         ret = cli.bess.run_module_command(module, cmd, arg_type, args)
@@ -1276,7 +1283,9 @@ def _show_mclass(cli, cls_name, detail):
 
     if detail:
         if len(info.cmds) > 0:
-            cli.fout.write('\t\t commands: %s\n' % (', '.join(info.cmds)))
+            cli.fout.write('\t\t commands: %s\n' %
+                (', '.join(map(lambda cmd, msg: "%s(%s)"
+                    % (cmd,msg), info.cmds, info.cmd_args))))
         else:
             cli.fout.write('\t\t (no commands)\n')
 

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -278,8 +278,15 @@ class BESS(object):
         request.name = name
         request.cmd = cmd
 
-        message_type = getattr(module_msg, arg_type, bess_msg.EmptyArg)
-        arg_msg = pb_conv.dict_to_protobuf(message_type, arg)
+        try:
+            message_type = getattr(module_msg, arg_type)
+        except AttributeError as e:
+            raise self.APIError('Unknown arg "%s"' % arg_type)
+
+        try:
+            arg_msg = pb_conv.dict_to_protobuf(message_type, arg)
+        except (KeyError, ValueError) as e:
+            raise self.APIError(e)
 
         request.arg.Pack(arg_msg)
 

--- a/libbess-python/module_msg.py
+++ b/libbess-python/module_msg.py
@@ -5,11 +5,20 @@ import os
 exclude_list = ['bess_msg_pb2', 'port_msg_pb2']
 
 
+def _load_symbols(mod, *symbols):
+    globals().update({name: mod.__dict__[name] for name in symbols})
+
+
+def load_symbol(mod_name, symbol):
+    mod = importlib.import_module(mod_name)
+    _load_symbols(mod, symbol)
+
+
 def load_symbols(mod_name):
     mod = importlib.import_module(mod_name)
     symbols = [n for n in mod.__dict__ if
                n.endswith('Arg') or n.endswith('Response')]
-    globals().update({name: mod.__dict__[name] for name in symbols})
+    _load_symbols(mod, *symbols)
 
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
@@ -19,3 +28,5 @@ mods = filter(lambda m: m not in exclude_list,
 
 for mod_name in mods:
     load_symbols(mod_name)
+
+load_symbol('bess_msg_pb2', 'EmptyArg')

--- a/libbess-python/protobuf_to_dict.py
+++ b/libbess-python/protobuf_to_dict.py
@@ -105,7 +105,8 @@ def _get_field_mapping(pb, dict_value, strict):
             continue
         if key not in pb.DESCRIPTOR.fields_by_name:
             if strict:
-                raise KeyError("%s does not have a field called %s" % (pb, key))
+                raise KeyError("%s does not have a field called %s" %
+                               (pb.__class__.__name__, key))
             continue
         field_mapping.append((pb.DESCRIPTOR.fields_by_name[key], value, getattr(pb, key, None)))
 
@@ -116,7 +117,9 @@ def _get_field_mapping(pb, dict_value, strict):
             raise ValueError("Extension keys must be integers.")
         if ext_num not in pb._extensions_by_number:
             if strict:
-                raise KeyError("%s does not have a extension with number %s. Perhaps you forgot to import it?" % (pb, key))
+                raise KeyError("%s does not have a extension with number %s. " \
+                               "Perhaps you forgot to import it?" %
+                               (pb.__class__.__name__, key))
             continue
         ext_field = pb._extensions_by_number[ext_num]
         pb_val = pb.Extensions[ext_field]


### PR DESCRIPTION
'ARG_TYPE' should be handled by get_var_attrs(), otherwise the cli will
expect a literal 'ARG_TYPE'.

Error conditions are handled without killing bessctl.

If run_module_command() is passed a wrong message name it fails instead
of defaulting to EmptyArg (to support EmptyArg we now include it in
module_msg).

'show mclass' now also shows the type of protobuf message required for
each command.

Finally, [CMD_ARGS...] is optional, so we shouldn't fail if it's not
provided.