### PR TITLE
Unload plugins

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1296,7 +1296,11 @@ def show_mclass_list(cli, cls_names):
 
 @cmd('import plugin PLUGIN_FILE', 'Import the specified plugin (*.so)')
 def import_plugin(cli, plugin):
-    cli.bess.import_mclass(plugin)
+    cli.bess.import_plugin(plugin)
+
+@cmd('unload plugin PLUGIN_FILE', 'Unload the specified plugin (*.so)')
+def unload_plugin(cli, plugin):
+    cli.bess.unload_plugin(plugin)
 
 def _show_driver(cli, drv_name, detail):
     info = cli.bess.get_driver_info(drv_name)

--- a/core/Makefile
+++ b/core/Makefile
@@ -56,10 +56,15 @@ ifeq "$(shell expr $(CXXCOMPILER) = g++ \& $(CXXVERSION) \< 50000)" "0"
 	CXXFLAGS += -Wshadow
 endif
 
+# Disable GNU_UNIQUE symbol for g++
+ifeq "$(shell expr $(CXXCOMPILER) = g++)" "1"
+	CXXFLAGS += -fno-gnu-unique
+endif
+
 LDFLAGS += -rdynamic -L$(DPDK_LIB_DIR) -Wl,-rpath=$(DPDK_LIB_DIR) -pthread
 ifdef BESS_LINK_DYNAMIC
     LIBS_ALL_SHARED = -Wl,-call_shared
-    LIBS_DL_SHARED = 
+    LIBS_DL_SHARED =
 else # Used static libraries
     LIBS_ALL_SHARED =
     LIBS_DL_SHARED = -Wl,-call_shared
@@ -126,7 +131,7 @@ all: $(EXEC) modules tests benchmarks
 
 clean:
 	rm -rf $(EXEC) .deps/*.d .deps/*/*.d *_test */*_test *_bench */*_bench \
-		*.a *.pb.* *.o */*.o *.gcda *.gcno */*.gcda */*.gcno \
+		*.a *.pb.* *.o */*.o *.so */*.so *.gcda *.gcno */*.gcda */*.gcno \
 		coverage.info coverage_html
 
 tags:

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1254,11 +1254,21 @@ class BESSControlImpl final : public BESSControl::Service {
     return Status::OK;
   }
 
-  Status ImportMclass(ServerContext*, const ImportMclassRequest* request,
+  Status ImportPlugin(ServerContext*, const ImportPluginRequest* request,
                       EmptyResponse* response) override {
-    VLOG(1) << "Loading module: " << request->path();
-    if (!bess::bessd::LoadModule(request->path())) {
-      return return_with_error(response, -1, "Failed loading module %s",
+    VLOG(1) << "Loading plugin: " << request->path();
+    if (!bess::bessd::LoadPlugin(request->path())) {
+      return return_with_error(response, -1, "Failed loading plugin %s",
+                               request->path().c_str());
+    }
+    return Status::OK;
+  }
+
+  Status UnloadPlugin(ServerContext*, const UnloadPluginRequest* request,
+                      EmptyResponse* response) override {
+    VLOG(1) << "Unloading plugin: " << request->path();
+    if (!bess::bessd::UnloadPlugin(request->path())) {
+      return return_with_error(response, -1, "Failed loading plugin %s",
                                request->path().c_str());
     }
     return Status::OK;

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1256,6 +1256,10 @@ class BESSControlImpl final : public BESSControl::Service {
 
   Status ImportPlugin(ServerContext*, const ImportPluginRequest* request,
                       EmptyResponse* response) override {
+    if (is_any_worker_running()) {
+      return return_with_error(response, EBUSY, "There is a running worker");
+    }
+
     VLOG(1) << "Loading plugin: " << request->path();
     if (!bess::bessd::LoadPlugin(request->path())) {
       return return_with_error(response, -1, "Failed loading plugin %s",
@@ -1266,6 +1270,10 @@ class BESSControlImpl final : public BESSControl::Service {
 
   Status UnloadPlugin(ServerContext*, const UnloadPluginRequest* request,
                       EmptyResponse* response) override {
+    if (is_any_worker_running()) {
+      return return_with_error(response, EBUSY, "There is a running worker");
+    }
+
     VLOG(1) << "Unloading plugin: " << request->path();
     if (!bess::bessd::UnloadPlugin(request->path())) {
       return return_with_error(response, -1, "Failed unloading plugin %s",

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1268,7 +1268,7 @@ class BESSControlImpl final : public BESSControl::Service {
                       EmptyResponse* response) override {
     VLOG(1) << "Unloading plugin: " << request->path();
     if (!bess::bessd::UnloadPlugin(request->path())) {
-      return return_with_error(response, -1, "Failed loading plugin %s",
+      return return_with_error(response, -1, "Failed unloading plugin %s",
                                request->path().c_str());
     }
     return Status::OK;

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -437,10 +437,9 @@ class BESSControlImpl final : public BESSControl::Service {
     bess::TrafficClass* root = workers[wid]->scheduler()->root();
     if (root) {
       bool has_tasks = false;
-      root->Traverse(
-          [&has_tasks](bess::TCChildArgs* c) {
-            has_tasks |= c->child()->policy() == bess::POLICY_LEAF;
-          });
+      root->Traverse([&has_tasks](bess::TCChildArgs* c) {
+        has_tasks |= c->child()->policy() == bess::POLICY_LEAF;
+      });
       if (has_tasks) {
         return return_with_error(response, EBUSY, "Worker %d has active tasks ",
                                  wid);
@@ -489,49 +488,47 @@ class BESSControlImpl final : public BESSControl::Service {
                                  i);
       }
 
-      root->Traverse(
-          [&response, i](bess::TCChildArgs* args) {
-            bess::TrafficClass *c = args->child();
+      root->Traverse([&response, i](bess::TCChildArgs* args) {
+        bess::TrafficClass* c = args->child();
 
-            ListTcsResponse_TrafficClassStatus* status =
-                response->add_classes_status();
+        ListTcsResponse_TrafficClassStatus* status =
+            response->add_classes_status();
 
-            if (c->parent()) {
-              status->set_parent(c->parent()->name());
-            }
+        if (c->parent()) {
+          status->set_parent(c->parent()->name());
+        }
 
-            status->mutable_class_()->set_name(c->name());
-            status->mutable_class_()->set_blocked(c->blocked());
+        status->mutable_class_()->set_name(c->name());
+        status->mutable_class_()->set_blocked(c->blocked());
 
-            if (c->policy() >= 0 && c->policy() < bess::NUM_POLICIES) {
-              status->mutable_class_()->set_policy(
-                  bess::TrafficPolicyName[c->policy()]);
-            } else {
-              status->mutable_class_()->set_policy("invalid");
-            }
+        if (c->policy() >= 0 && c->policy() < bess::NUM_POLICIES) {
+          status->mutable_class_()->set_policy(
+              bess::TrafficPolicyName[c->policy()]);
+        } else {
+          status->mutable_class_()->set_policy("invalid");
+        }
 
-            status->mutable_class_()->set_wid(i);
+        status->mutable_class_()->set_wid(i);
 
-            if (c->policy() == bess::POLICY_RATE_LIMIT) {
-              const bess::RateLimitTrafficClass* rl =
-                  reinterpret_cast<const bess::RateLimitTrafficClass*>(c);
-              std::string resource = bess::ResourceName.at(rl->resource());
-              int64_t limit = rl->limit_arg();
-              int64_t max_burst = rl->max_burst_arg();
-              status->mutable_class_()->mutable_limit()->insert(
-                  {resource, limit});
-              status->mutable_class_()->mutable_max_burst()->insert(
-                  {resource, max_burst});
-            }
+        if (c->policy() == bess::POLICY_RATE_LIMIT) {
+          const bess::RateLimitTrafficClass* rl =
+              reinterpret_cast<const bess::RateLimitTrafficClass*>(c);
+          std::string resource = bess::ResourceName.at(rl->resource());
+          int64_t limit = rl->limit_arg();
+          int64_t max_burst = rl->max_burst_arg();
+          status->mutable_class_()->mutable_limit()->insert({resource, limit});
+          status->mutable_class_()->mutable_max_burst()->insert(
+              {resource, max_burst});
+        }
 
-            if (args->parent_type() == bess::POLICY_WEIGHTED_FAIR) {
-              auto ca = static_cast<bess::WeightedFairChildArgs *>(args);
-              status->mutable_class_()->set_share(ca->share());
-            } else if (args->parent_type() == bess::POLICY_PRIORITY) {
-              auto ca = static_cast<bess::PriorityChildArgs *>(args);
-              status->mutable_class_()->set_priority(ca->priority());
-            }
-          });
+        if (args->parent_type() == bess::POLICY_WEIGHTED_FAIR) {
+          auto ca = static_cast<bess::WeightedFairChildArgs*>(args);
+          status->mutable_class_()->set_share(ca->share());
+        } else if (args->parent_type() == bess::POLICY_PRIORITY) {
+          auto ca = static_cast<bess::PriorityChildArgs*>(args);
+          status->mutable_class_()->set_priority(ca->priority());
+        }
+      });
     }
 
     return Status::OK;
@@ -548,7 +545,7 @@ class BESSControlImpl final : public BESSControl::Service {
       return return_with_error(response, EINVAL, "Missing 'name' field");
     } else if (tc_name[0] == '!') {
       return return_with_error(response, EINVAL,
-          "TC names starting with \'!\' are reserved");
+                               "TC names starting with \'!\' are reserved");
     }
 
     if (TrafficClassBuilder::all_tcs().count(tc_name)) {
@@ -595,7 +592,8 @@ class BESSControlImpl final : public BESSControl::Service {
           TrafficClassBuilder::CreateTrafficClass<bess::RateLimitTrafficClass>(
               tc_name, bess::ResourceMap.at(resource), limit, max_burst));
     } else if (policy == bess::TrafficPolicyName[bess::POLICY_LEAF]) {
-      return return_with_error(response, EINVAL, "Cannot create leaf TC. Use "
+      return return_with_error(response, EINVAL,
+                               "Cannot create leaf TC. Use "
                                "UpdateTcParentRequest message");
     } else {
       return return_with_error(response, EINVAL, "Invalid traffic policy");
@@ -644,7 +642,8 @@ class BESSControlImpl final : public BESSControl::Service {
       }
       tc->set_resource(bess::ResourceMap.at(resource));
     } else {
-      return return_with_error(response, EINVAL, "Only 'rate_limit' and"
+      return return_with_error(response, EINVAL,
+                               "Only 'rate_limit' and"
                                " 'weighted_fair' can be updated");
     }
 
@@ -664,7 +663,8 @@ class BESSControlImpl final : public BESSControl::Service {
 
     if (c->policy() == bess::POLICY_LEAF) {
       if (!detach_tc(c)) {
-        return return_with_error(response, EINVAL, "Cannot detach '%s'"
+        return return_with_error(response, EINVAL,
+                                 "Cannot detach '%s'"
                                  " from parent",
                                  request->class_().name().c_str());
       }
@@ -673,9 +673,10 @@ class BESSControlImpl final : public BESSControl::Service {
     // XXX Leaf nodes can always be moved, other nodes can be moved only if
     // they're orphans. The scheduler maintains state which would need to be
     // updated otherwise.
-    if (c->policy() != bess::POLICY_LEAF) { 
+    if (c->policy() != bess::POLICY_LEAF) {
       if (!remove_tc_from_orphan(c)) {
-        return return_with_error(response, EINVAL, "Cannot detach '%s'."
+        return return_with_error(response, EINVAL,
+                                 "Cannot detach '%s'."
                                  " while it is part of a worker",
                                  request->class_().name().c_str());
       }
@@ -1293,6 +1294,8 @@ class BESSControlImpl final : public BESSControl::Service {
 
   Status GetMclassInfo(ServerContext*, const GetMclassInfoRequest* request,
                        GetMclassInfoResponse* response) override {
+    VLOG(1) << "GetMclassInfo from client:" << std::endl
+            << request->DebugString();
     if (!request->name().length()) {
       return return_with_error(response, EINVAL,
                                "Argument must be a name in str");
@@ -1334,16 +1337,18 @@ class BESSControlImpl final : public BESSControl::Service {
     *response = m->RunCommand(request->cmd(), request->arg());
     return Status::OK;
   }
+
  private:
   Status AttachTc(bess::TrafficClass* c_, const bess::pb::TrafficClass& class_,
-                  EmptyResponse *response) {
+                  EmptyResponse* response) {
     std::unique_ptr<bess::TrafficClass> c(c_);
     int wid = class_.wid();
 
     if (class_.parent().length() == 0) {
       if (wid >= MAX_WORKERS) {
         return return_with_error(response, EINVAL,
-            "'wid' must be between -1 and %d", MAX_WORKERS - 1);
+                                 "'wid' must be between -1 and %d",
+                                 MAX_WORKERS - 1);
       }
 
       if ((wid != -1 && !is_worker_active(wid)) ||
@@ -1361,7 +1366,8 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     if (wid != -1) {
-      return return_with_error(response, EINVAL, "Both 'parent' and 'wid'"
+      return return_with_error(response, EINVAL,
+                               "Both 'parent' and 'wid'"
                                "have been specified");
     }
 
@@ -1430,7 +1436,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
       c = it->second;
     } else if (class_.leaf_module_name().length() != 0) {
-      const std::string &module_name = class_.leaf_module_name();
+      const std::string& module_name = class_.leaf_module_name();
       const auto& it = ModuleBuilder::all_modules().find(module_name);
       if (it == ModuleBuilder::all_modules().end()) {
         return_with_error(response, ENOENT, "No module '%s' found",
@@ -1454,7 +1460,8 @@ class BESSControlImpl final : public BESSControl::Service {
 
       c = m->tasks()[tid]->GetTC();
     } else {
-      return_with_error(response, EINVAL, "One of 'name' or "
+      return_with_error(response, EINVAL,
+                        "One of 'name' or "
                         "'leaf_module_name' must be specified");
       return nullptr;
     }

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -383,6 +383,7 @@ bool LoadPlugin(const std::string &path) {
 bool UnloadPlugin(const std::string &path) {
   auto it = plugin_handles.find(path);
   if (it == plugin_handles.end()) {
+    VLOG(1) << "Plugin " << path << " not found.";
     return false;
   }
   bool result = (dlclose(it->second) == 0);

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -368,6 +368,8 @@ static inline bool HasSuffix(const std::string &s, const std::string &suffix) {
          std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
 }
 
+// Store handles of loaded plugins
+// key: plugin path (std::string), value: handle (void *)
 static std::unordered_map<std::string, void *> plugin_handles;
 
 bool LoadPlugin(const std::string &path) {
@@ -375,9 +377,8 @@ bool LoadPlugin(const std::string &path) {
   if (handle != nullptr) {
     plugin_handles.emplace(path, handle);
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 bool UnloadPlugin(const std::string &path) {
@@ -386,11 +387,11 @@ bool UnloadPlugin(const std::string &path) {
     VLOG(1) << "Plugin " << path << " not found.";
     return false;
   }
-  bool result = (dlclose(it->second) == 0);
-  if (result) {
+  bool success = (dlclose(it->second) == 0);
+  if (success) {
     plugin_handles.erase(it);
   }
-  return result;
+  return success;
 }
 
 bool LoadPlugins(const std::string &directory) {

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -40,11 +40,14 @@ int Daemonize();
 // Sets BESS's resource limit.  Returns true upon success.
 bool SetResourceLimit();
 
-// Load an indiviual module specified by module_path. Return true upon success.
-bool LoadModule(const std::string &module_path);
+// Load an indiviual plugin specified by path. Return true upon success.
+bool LoadPlugin(const std::string &path);
+
+// Unload a loaded plugin specified by path. Return true upon success.
+bool UnloadPlugin(const std::string &path);
 
 // Load all the .so files in the specified directory. Return true upon success.
-bool LoadModules(const std::string &directory);
+bool LoadPlugins(const std::string &directory);
 
 // Return the current executable's own directory. For example, if the location
 // of the executable is /opt/bess/core/bessd, returns /opt/bess/core/ (with the

--- a/core/main.cc
+++ b/core/main.cc
@@ -20,12 +20,6 @@ int main(int argc, char *argv[]) {
   google::SetUsageMessage("BESS Command Line Options:");
   google::ParseCommandLineFlags(&argc, &argv, true);
   bess::bessd::ProcessCommandLineArgs();
-
-  if (!bess::bessd::LoadPlugins(bess::bessd::GetCurrentDirectory() +
-                                "modules")) {
-    PLOG(FATAL) << "LoadPlugins() failed";
-  }
-
   bess::bessd::CheckRunningAsRoot();
 
   int pidfile_fd = bess::bessd::CheckUniqueInstance(FLAGS_i);
@@ -41,6 +35,12 @@ int main(int argc, char *argv[]) {
 
   // Store our PID (child's, if daemonized) in the PID file.
   bess::bessd::WritePidfile(pidfile_fd, getpid());
+
+  // Load plugins
+  if (!bess::bessd::LoadPlugins(bess::bessd::GetCurrentDirectory() +
+                                "modules")) {
+    PLOG(FATAL) << "LoadPlugins() failed";
+  }
 
   // TODO(barath): Make these DPDK calls generic, so as to not be so tied to
   // DPDK.

--- a/core/main.cc
+++ b/core/main.cc
@@ -21,9 +21,9 @@ int main(int argc, char *argv[]) {
   google::ParseCommandLineFlags(&argc, &argv, true);
   bess::bessd::ProcessCommandLineArgs();
 
-  if (!bess::bessd::LoadModules(bess::bessd::GetCurrentDirectory() +
+  if (!bess::bessd::LoadPlugins(bess::bessd::GetCurrentDirectory() +
                                 "modules")) {
-    PLOG(FATAL) << "LoadModules() failed";
+    PLOG(FATAL) << "LoadPlugins() failed";
   }
 
   bess::bessd::CheckRunningAsRoot();

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -38,7 +38,7 @@ Module *create_foo(const std::string name = "") {
   return m;
 }
 
-ADD_MODULE(Foo, "foo", "bip");
+DEF_MODULE(Foo, "foo", "bip");
 
 }  // namespace
 
@@ -47,28 +47,22 @@ namespace metadata {
 
 class MetadataTest : public ::testing::Test {
  protected:
-  MetadataTest() : m0(), m1() {}
+  MetadataTest() : m0(), m1(), Foo_singleton() {}
 
   virtual void SetUp() {
     default_pipeline.CleanupMetadataComputation();
     default_pipeline.registered_attrs_.clear();
-
-    Foo_init();
-
     m0 = ::create_foo();
     m1 = ::create_foo();
     ASSERT_TRUE(m0);
     ASSERT_TRUE(m1);
   }
 
-  virtual void TearDown() {
-    ModuleBuilder::DestroyAllModules();
-    Foo_fini();
-    ModuleBuilder::all_module_builders_holder(true);
-  }
+  virtual void TearDown() { ModuleBuilder::DestroyAllModules(); }
 
   Module *m0;
   Module *m1;
+  Foo_class Foo_singleton;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(MetadataTest);

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -37,6 +37,9 @@ Module *create_foo(const std::string name = "") {
 
   return m;
 }
+
+ADD_MODULE(Foo, "foo", "bip");
+
 }  // namespace
 
 namespace bess {
@@ -49,8 +52,9 @@ class MetadataTest : public ::testing::Test {
   virtual void SetUp() {
     default_pipeline.CleanupMetadataComputation();
     default_pipeline.registered_attrs_.clear();
-    ADD_MODULE(Foo, "foo", "bip")
-    ASSERT_TRUE(__module__Foo);
+
+    Foo_init();
+
     m0 = ::create_foo();
     m1 = ::create_foo();
     ASSERT_TRUE(m0);
@@ -59,6 +63,7 @@ class MetadataTest : public ::testing::Test {
 
   virtual void TearDown() {
     ModuleBuilder::DestroyAllModules();
+    Foo_fini();
     ModuleBuilder::all_module_builders_holder(true);
   }
 

--- a/core/module.cc
+++ b/core/module.cc
@@ -91,6 +91,25 @@ bool ModuleBuilder::RegisterModuleClass(
   return true;
 }
 
+bool ModuleBuilder::DeregisterModuleClass(const std::string &class_name) {
+  // Check if the module builder exists
+  auto it = all_module_builders_holder().find(class_name);
+  if (it == all_module_builders_holder().end()) {
+    return false;
+  }
+
+  // Check if any module of the class still exists
+  const ModuleBuilder *builder = &(it->second);
+  for (auto const &e : all_modules()) {
+    if (e.second->module_builder() == builder) {
+      return false;
+    }
+  }
+
+  all_module_builders_holder().erase(it);
+  return true;
+}
+
 std::string ModuleBuilder::GenerateDefaultName(
     const std::string &class_name, const std::string &default_template) {
   std::string name_template;

--- a/core/module.h
+++ b/core/module.h
@@ -501,16 +501,20 @@ INSTANTIATE_MT_FOR_TYPE(uint16_t)
 INSTANTIATE_MT_FOR_TYPE(uint32_t)
 INSTANTIATE_MT_FOR_TYPE(uint64_t)
 
-#define ADD_MODULE(_MOD, _NAME_TEMPLATE, _HELP)                                \
-  static void __attribute__((constructor)) _MOD##_init() {                     \
-    VLOG(1) << #_MOD << "_init()";                                             \
-    ModuleBuilder::RegisterModuleClass(                                        \
-        std::function<Module *()>([]() { return new _MOD(); }), #_MOD,         \
-        _NAME_TEMPLATE, _HELP, _MOD::kNumIGates, _MOD::kNumOGates, _MOD::cmds, \
-        MODULE_INIT_FUNC(&_MOD::Init));                                        \
-  }                                                                            \
-  static void __attribute__((destructor)) _MOD##_fini() {                      \
-    VLOG(1) << #_MOD << "_fini()";                                             \
-    ModuleBuilder::DeregisterModuleClass(#_MOD);                               \
-  }
+#define DEF_MODULE(_MOD, _NAME_TEMPLATE, _HELP)                          \
+  class _MOD##_class {                                                   \
+   public:                                                               \
+    _MOD##_class() {                                                     \
+      ModuleBuilder::RegisterModuleClass(                                \
+          std::function<Module *()>([]() { return new _MOD(); }), #_MOD, \
+          _NAME_TEMPLATE, _HELP, _MOD::kNumIGates, _MOD::kNumOGates,     \
+          _MOD::cmds, MODULE_INIT_FUNC(&_MOD::Init));                    \
+    }                                                                    \
+    ~_MOD##_class() { ModuleBuilder::DeregisterModuleClass(#_MOD); }     \
+  };
+
+#define ADD_MODULE(_MOD, _NAME_TEMPLATE, _HELP) \
+  DEF_MODULE(_MOD, _NAME_TEMPLATE, _HELP);      \
+  static _MOD##_class _MOD##_singleton;
+
 #endif  // BESS_MODULE_H_

--- a/core/module.h
+++ b/core/module.h
@@ -109,12 +109,13 @@ class ModuleBuilder {
                                   const gate_idx_t ogates, const Commands &cmds,
                                   module_init_func_t init_func);
 
+  static bool DeregisterModuleClass(const std::string &class_name);
+
   static std::map<std::string, ModuleBuilder> &all_module_builders_holder(
       bool reset = false);
   static const std::map<std::string, ModuleBuilder> &all_module_builders();
 
   static const std::map<std::string, Module *> &all_modules();
-
   gate_idx_t NumIGates() const { return num_igates_; }
   gate_idx_t NumOGates() const { return num_ogates_; }
 
@@ -243,9 +244,7 @@ class Module {
     return attrs_;
   }
 
-  const std::vector<ModuleTask *> &tasks() const {
-    return tasks_;
-  }
+  const std::vector<ModuleTask *> &tasks() const { return tasks_; }
 
   void set_attr_offset(size_t idx, bess::metadata::mt_offset_t offset) {
     if (idx < bess::metadata::kMaxAttrsPerModule) {
@@ -262,13 +261,9 @@ class Module {
     return attr_offsets_;
   }
 
-  const std::vector<bess::IGate *> &igates() const {
-    return igates_;
-  };
+  const std::vector<bess::IGate *> &igates() const { return igates_; }
 
-  const std::vector<bess::OGate *> &ogates() const {
-    return ogates_;
-  };
+  const std::vector<bess::OGate *> &ogates() const { return ogates_; }
 
  private:
   void DestroyAllTasks();
@@ -342,8 +337,8 @@ inline void Module::RunNextModule(bess::PacketBatch *batch) {
 class Task;
 
 namespace bess {
-  template <typename CallableTask>
-  class LeafTrafficClass;
+template <typename CallableTask>
+class LeafTrafficClass;
 }  // namespace bess
 
 // Stores the arguments of a task created by a module.
@@ -351,26 +346,19 @@ class ModuleTask {
  public:
   // Doesn't take ownership of 'arg' and 'c'.  'c' can be null and it
   // can be changed later with SetTC()
-  ModuleTask(void *arg, bess::LeafTrafficClass<Task> *c)
-      : arg_(arg), c_(c) {};
+  ModuleTask(void *arg, bess::LeafTrafficClass<Task> *c) : arg_(arg), c_(c) {}
 
-  ~ModuleTask() {};
+  ~ModuleTask() {}
 
-  void *arg() {
-    return arg_;
-  }
+  void *arg() { return arg_; }
 
-  void SetTC(bess::LeafTrafficClass<Task> *c) {
-    c_ = c;
-  }
+  void SetTC(bess::LeafTrafficClass<Task> *c) { c_ = c; }
 
-  bess::LeafTrafficClass<Task> *GetTC() {
-    return c_;
-  }
+  bess::LeafTrafficClass<Task> *GetTC() { return c_; }
 
  private:
-  void *arg_; // Auxiliary value passed to Module::RunTask().
-  bess::LeafTrafficClass<Task> *c_; // Leaf TC associated with this task.
+  void *arg_;  // Auxiliary value passed to Module::RunTask().
+  bess::LeafTrafficClass<Task> *c_;  // Leaf TC associated with this task.
 };
 
 // Functor used by a leaf in a Worker's Scheduler to run a task in a module.
@@ -378,7 +366,7 @@ class Task {
  public:
   // When this task is scheduled it will execute 'm' with 'arg'.
   // When the associated leaf is created/destroyed, 't' will be updated.
-  Task(Module *m, void *arg, ModuleTask *t) : module_(m), arg_(arg), t_(t) {};
+  Task(Module *m, void *arg, ModuleTask *t) : module_(m), arg_(arg), t_(t) {}
 
   // Called when the leaf that owns this task is destroyed.
   void Detach() {

--- a/core/module.h
+++ b/core/module.h
@@ -501,10 +501,16 @@ INSTANTIATE_MT_FOR_TYPE(uint16_t)
 INSTANTIATE_MT_FOR_TYPE(uint32_t)
 INSTANTIATE_MT_FOR_TYPE(uint64_t)
 
-#define ADD_MODULE(_MOD, _NAME_TEMPLATE, _HELP)                              \
-  bool __module__##_MOD = ModuleBuilder::RegisterModuleClass(                \
-      std::function<Module *()>([]() { return new _MOD(); }), #_MOD,         \
-      _NAME_TEMPLATE, _HELP, _MOD::kNumIGates, _MOD::kNumOGates, _MOD::cmds, \
-      MODULE_INIT_FUNC(&_MOD::Init));
-
+#define ADD_MODULE(_MOD, _NAME_TEMPLATE, _HELP)                                \
+  static void __attribute__((constructor)) _MOD##_init() {                     \
+    VLOG(1) << #_MOD << "_init()";                                             \
+    ModuleBuilder::RegisterModuleClass(                                        \
+        std::function<Module *()>([]() { return new _MOD(); }), #_MOD,         \
+        _NAME_TEMPLATE, _HELP, _MOD::kNumIGates, _MOD::kNumOGates, _MOD::cmds, \
+        MODULE_INIT_FUNC(&_MOD::Init));                                        \
+  }                                                                            \
+  static void __attribute__((destructor)) _MOD##_fini() {                      \
+    VLOG(1) << #_MOD << "_fini()";                                             \
+    ModuleBuilder::DeregisterModuleClass(#_MOD);                               \
+  }
 #endif  // BESS_MODULE_H_

--- a/core/module_bench.cc
+++ b/core/module_bench.cc
@@ -46,16 +46,17 @@ class DummyRelayModule : public Module {
   RunNextModule(batch);
 }
 
+ADD_MODULE(DummySourceModule, "src", "the most sophisticated modue ever");
+ADD_MODULE(DummyRelayModule, "relay", "the most sophisticated modue ever");
+
 // Simple harness for testing the Module class.
 class ModuleFixture : public benchmark::Fixture {
  protected:
   void SetUp(benchmark::State &state) override {
     const int chain_length = state.range(0);
 
-    ADD_MODULE(DummySourceModule, "src", "the most sophisticated modue ever");
-    ADD_MODULE(DummyRelayModule, "relay", "the most sophisticated modue ever");
-    DCHECK(__module__DummySourceModule);
-    DCHECK(__module__DummyRelayModule);
+    DummySourceModule_init();
+    DummyRelayModule_init();
 
     const auto &builders = ModuleBuilder::all_module_builders();
     const auto &builder_src = builders.find("DummySourceModule")->second;
@@ -81,6 +82,8 @@ class ModuleFixture : public benchmark::Fixture {
 
   void TearDown(benchmark::State &) override {
     ModuleBuilder::DestroyAllModules();
+    DummySourceModule_fini();
+    DummyRelayModule_fini();
     ModuleBuilder::all_module_builders_holder(true);
   }
 

--- a/core/module_bench.cc
+++ b/core/module_bench.cc
@@ -46,17 +46,16 @@ class DummyRelayModule : public Module {
   RunNextModule(batch);
 }
 
-ADD_MODULE(DummySourceModule, "src", "the most sophisticated modue ever");
-ADD_MODULE(DummyRelayModule, "relay", "the most sophisticated modue ever");
+DEF_MODULE(DummySourceModule, "src", "the most sophisticated modue ever");
+DEF_MODULE(DummyRelayModule, "relay", "the most sophisticated modue ever");
 
 // Simple harness for testing the Module class.
 class ModuleFixture : public benchmark::Fixture {
  protected:
+  ModuleFixture()
+      : DummySourceModule_singleton(), DummyRelayModule_singleton() {}
   void SetUp(benchmark::State &state) override {
     const int chain_length = state.range(0);
-
-    DummySourceModule_init();
-    DummyRelayModule_init();
 
     const auto &builders = ModuleBuilder::all_module_builders();
     const auto &builder_src = builders.find("DummySourceModule")->second;
@@ -82,13 +81,12 @@ class ModuleFixture : public benchmark::Fixture {
 
   void TearDown(benchmark::State &) override {
     ModuleBuilder::DestroyAllModules();
-    DummySourceModule_fini();
-    DummyRelayModule_fini();
-    ModuleBuilder::all_module_builders_holder(true);
   }
 
   Module *src_;
   std::vector<Module *> relays;
+  DummySourceModule_class DummySourceModule_singleton;
+  DummyRelayModule_class DummyRelayModule_singleton;
 };
 
 }  // namespace (unnamed)

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -31,17 +31,18 @@ class AcmeModule : public Module {
 const Commands AcmeModule::cmds = {
     {"foo", "EmptyArg", MODULE_CMD_FUNC(&AcmeModule::FooPb), 0}};
 
-ADD_MODULE(AcmeModule, "acme_module", "foo bar");
+DEF_MODULE(AcmeModule, "acme_module", "foo bar");
 
 // Simple harness for testing the Module class.
 class ModuleTester : public ::testing::Test {
  protected:
-  virtual void SetUp() { AcmeModule_init(); }
+  ModuleTester() : AcmeModule_singleton() {}
 
-  virtual void TearDown() {
-    ModuleBuilder::DestroyAllModules();
-    ModuleBuilder::all_module_builders_holder(true);
-  }
+  virtual void SetUp() {}
+
+  virtual void TearDown() { ModuleBuilder::DestroyAllModules(); }
+
+  AcmeModule_class AcmeModule_singleton;
 };
 
 int create_acme(const char *name, Module **m) {
@@ -80,10 +81,9 @@ int create_acme(const char *name, Module **m) {
 // Check that new module classes are actually created correctly and stored in
 // the table of module classes
 TEST(ModuleBuilderTest, RegisterModuleClass) {
-  ModuleBuilder::all_module_builders_holder(true);
   ASSERT_EQ(0, ModuleBuilder::all_module_builders().count("AcmeModule"));
 
-  AcmeModule_init();
+  AcmeModule_class AcmeModule_singleton;
   ASSERT_EQ(1, ModuleBuilder::all_module_builders().count("AcmeModule"));
 
   const ModuleBuilder &builder =
@@ -95,8 +95,6 @@ TEST(ModuleBuilderTest, RegisterModuleClass) {
   EXPECT_EQ(1, builder.NumIGates());
   EXPECT_EQ(1, builder.NumOGates());
   EXPECT_EQ(1, builder.cmds().size());
-
-  ModuleBuilder::all_module_builders_holder(true);
 }
 
 TEST(ModuleBuilderTest, GenerateDefaultNameTemplate) {

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -31,13 +31,12 @@ class AcmeModule : public Module {
 const Commands AcmeModule::cmds = {
     {"foo", "EmptyArg", MODULE_CMD_FUNC(&AcmeModule::FooPb), 0}};
 
+ADD_MODULE(AcmeModule, "acme_module", "foo bar");
+
 // Simple harness for testing the Module class.
 class ModuleTester : public ::testing::Test {
  protected:
-  virtual void SetUp() {
-    ADD_MODULE(AcmeModule, "acme_module", "foo bar");
-    ASSERT_TRUE(__module__AcmeModule);
-  }
+  virtual void SetUp() { AcmeModule_init(); }
 
   virtual void TearDown() {
     ModuleBuilder::DestroyAllModules();
@@ -81,11 +80,10 @@ int create_acme(const char *name, Module **m) {
 // Check that new module classes are actually created correctly and stored in
 // the table of module classes
 TEST(ModuleBuilderTest, RegisterModuleClass) {
-  size_t num_builders = ModuleBuilder::all_module_builders().size();
-  ADD_MODULE(AcmeModule, "acme_module", "foo bar");
-  ASSERT_TRUE(__module__AcmeModule);
+  ModuleBuilder::all_module_builders_holder(true);
+  ASSERT_EQ(0, ModuleBuilder::all_module_builders().count("AcmeModule"));
 
-  EXPECT_EQ(num_builders + 1, ModuleBuilder::all_module_builders().size());
+  AcmeModule_init();
   ASSERT_EQ(1, ModuleBuilder::all_module_builders().count("AcmeModule"));
 
   const ModuleBuilder &builder =
@@ -115,8 +113,6 @@ TEST(ModuleBuilderTest, GenerateDefaultNameTemplate) {
 // Check that module builders create modules correctly when given a name
 TEST_F(ModuleTester, CreateModuleWithName) {
   Module *m1, *m2;
-  ADD_MODULE(AcmeModule, "acme_module", "foo bar");
-  ASSERT_TRUE(__module__AcmeModule);
 
   EXPECT_EQ(0, create_acme("bar", &m1));
   ASSERT_NE(nullptr, m1);

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -217,10 +217,15 @@ class BESS(object):
         request.name = name
         return self._request('GetLinkStatus', request)
 
-    def import_mclass(self, path):
-        request = bess_msg.ImportMclassRequest()
+    def import_plugin(self, path):
+        request = bess_msg.ImportPluginRequest()
         request.path = path
-        return self._request('ImportMclass', request)
+        return self._request('ImportPlugin', request)
+
+    def unload_plugin(self, path):
+        request = bess_msg.UnloadPluginRequest()
+        request.path = path
+        return self._request('UnloadPlugin', request)
 
     def list_mclasses(self):
         return self._request('ListMclass')

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -24,7 +24,11 @@ message EmptyResponse {
   Error error = 1;
 }
 
-message ImportMclassRequest {
+message ImportPluginRequest {
+  string path = 1;  /// Path to the module library (*.so file)
+}
+
+message UnloadPluginRequest {
   string path = 1;  /// Path to the module library (*.so file)
 }
 

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -37,8 +37,13 @@ service BESSControl {
   ///
   /// At the moment plugins can only contain module types,
   /// but might also support drivers/hooks/schedulers in the future.
-  /// FIXME: rename (e.g., ImportPlugin)
-  rpc ImportMclass (ImportMclassRequest) returns (EmptyResponse) {}
+  rpc ImportPlugin (ImportPluginRequest) returns (EmptyResponse) {}
+
+  /// Unload a plugin
+  ///
+  /// At the moment plugins can only contain module types,
+  /// but might also support drivers/hooks/schedulers in the future.
+  rpc UnloadPlugin (UnloadPluginRequest) returns (EmptyResponse) {}
 
 
   //  -------------------------------------------------------------------------


### PR DESCRIPTION
- Use static object's constructor and destructor to initialize and destruct a module class.
- Check if workers are running before importing/unloading plugins.
- Misc. fixes (renaming, comments, etc.)