### PR TITLE
scheduler: Fix destructor of an empty Scheduler.

### DIFF
--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -61,7 +61,9 @@ class Scheduler final {
 
   // TODO(barath): Do real cleanup, akin to sched_free() from the old impl.
   virtual ~Scheduler() {
-    TrafficClassBuilder::Clear(root_);
+    if (root_) {
+      TrafficClassBuilder::Clear(root_);
+    }
     delete root_;
   }
 


### PR DESCRIPTION
Since the previous commit, the scheduler can be empty (root_ == nullptr).
The destructor must handle this case correctly, otherwise bessd will
crash.

The bug can be simply reproduced with:

./bessctl daemon start -- add worker 0 0 -- delete worker 0 -- daemon stop

Reported by Sangjin (thanks!)