### PR TITLE
Recalculate checksum with TTL update

### DIFF
--- a/bessctl/conf/testing/module_tests/update_ttl.py
+++ b/bessctl/conf/testing/module_tests/update_ttl.py
@@ -12,9 +12,8 @@ CRASH_TEST_INPUTS.append([m0, 1, 1])
 # Decrement Test
 m1 = UpdateTTL()
 in_packet = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=2)
-out_packet = scapy.Ether(in_packet)
-out_packet.ttl -= 1
-out_packet = str(out_packet)
+out_packet = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=1)
+
 OUTPUT_TEST_INPUTS.append([m1, 1, 1,
                            [{'input_port': 0,
                              'input_packet': in_packet,
@@ -24,8 +23,8 @@ OUTPUT_TEST_INPUTS.append([m1, 1, 1,
 # Drop test
 m2 = UpdateTTL()
 drop_packet0 = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=0)
-
 drop_packet1 = gen_packet(scapy.TCP, '22.22.22.22', '22.22.22.22', ip_ttl=1)
+
 OUTPUT_TEST_INPUTS.append([m2, 1, 1,
                            [{'input_port': 0,
                              'input_packet': drop_packet0,
@@ -39,6 +38,3 @@ OUTPUT_TEST_INPUTS.append([m2, 1, 1,
                              'input_packet': drop_packet1,
                              'output_port': 0,
                              'output_packet': None}]])
-
-# TODO: If Checksum code is modified and integrated make sure to write tests for it
-

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -1,4 +1,6 @@
 #include "update_ttl.h"
+
+#include "../utils/checksum.h"
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 
@@ -7,9 +9,9 @@ using bess::utils::Ipv4Header;
 
 void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
   bess::PacketBatch out_batch;
-  bess::PacketBatch free_batch;
+  bess::PacketBatch drop_batch;
   out_batch.clear();
-  free_batch.clear();
+  drop_batch.clear();
 
   int cnt = batch->cnt();
 
@@ -20,19 +22,20 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
     struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
 
     if (ip->ttl > 1) {
-      // Current design choice: implement a checksum at a downstream module
-      // instead of updating here. If efficent code for checksumming at each
-      // module is a future change, RFC 1624 will be helpful for implementation
-      // in this module.
-      ip->ttl -= 1;  // TODO: make this a customizable parameter
+      // The incremental checksum only cares the difference from old_value to
+      // new_value, so putting 1, 0 than ip->ttl, ip->ttl - 1 offers more
+      // optimization opportunities
+      ip->checksum =
+          bess::utils::CalculateChecksumIncremental16(ip->checksum, 1, 0);
+      ip->ttl -= 1;
       out_batch.add(pkt);
     } else {
-      free_batch.add(pkt);  // drop the packet since it's TTL is 1 or 0
+      drop_batch.add(pkt);  // drop the packet since it's TTL is 1 or 0
     }
   }
 
-  bess::Packet::Free(&free_batch);
-  RunNextModule(&out_batch);
+  RunChooseModule(0, &out_batch);
+  RunChooseModule(1, &drop_batch);
 }
 
 ADD_MODULE(UpdateTTL, "update_ttl", "decreases the IP TTL field by 1")


### PR DESCRIPTION
- TTL always be decreased by 1, so remove TODO for customizable parameter.
- Change free_batch to drop_batch and forward dropped packets into
output gate 1, so that someone may take the dropped packet later.
(E.g., sending ICMP TTL exceeded in transit messages)