### PR TITLE
Replace environment variable names in .bess files

### DIFF
--- a/bessctl/conf/perftest/l2fwd_bench.bess
+++ b/bessctl/conf/perftest/l2fwd_bench.bess
@@ -1,8 +1,8 @@
 import scapy.all as scapy
 import struct
 
-num_entries = int($SN_ENTRIES!'1000')
-use_exactmatch = bool(int(($SN_EXACTMATCH!'0')))
+num_entries = int($BESS_ENTRIES!'1000')
+use_exactmatch = bool(int(($BESS_EXACTMATCH!'0')))
 
 assert num_entries >= 1
 

--- a/bessctl/conf/perftest/loopback_vport.bess
+++ b/bessctl/conf/perftest/loopback_vport.bess
@@ -3,10 +3,10 @@ import multiprocessing
 
 num_cpus = multiprocessing.cpu_count()
 
-CORE_START = int($SN_CORE_START!'1')
-CORE_END = int($SN_CORE_END!num_cpus)   # not inclusive
-CORE_STEP = int($SN_CORE_STEP!'1')      # for SMT servers
-INTERVAL = int($SN_INTERVAL!'2')
+CORE_START = int($BESS_CORE_START!'1')
+CORE_END = int($BESS_CORE_END!num_cpus)   # not inclusive
+CORE_STEP = int($BESS_CORE_STEP!'1')      # for SMT servers
+INTERVAL = int($BESS_INTERVAL!'2')
 
 cpu_set = []
 ports = []

--- a/bessctl/conf/perftest/phy_forward.bess
+++ b/bessctl/conf/perftest/phy_forward.bess
@@ -1,9 +1,9 @@
-num_ports = int($SN_PORTS!'1')
-num_cores = int($SN_CORES!'1')
-mq_mode = int($SN_MQ!'0')
-fwd_mode = $SN_FWD!'pair'
-start_core = int($SN_START_CORE!'0')
-q_size = int($SN_QSIZE!'0')
+num_ports = int($BESS_PORTS!'1')
+num_cores = int($BESS_CORES!'1')
+mq_mode = int($BESS_MQ!'0')
+fwd_mode = $BESS_FWD!'pair'
+start_core = int($BESS_START_CORE!'0')
+q_size = int($BESS_QSIZE!'0')
 
 # parameter sanity check
 assert(num_cores in [1, 2, 4])

--- a/bessctl/conf/perftest/pktgen.bess
+++ b/bessctl/conf/perftest/pktgen.bess
@@ -1,17 +1,17 @@
 import scapy.all as scapy
 
-pkt_size = int($SN_PKT_SIZE!'60')
-num_ports = int($SN_PORTS!'1')
-num_cores = int($SN_CORES!'1')
+pkt_size = int($BESS_PKT_SIZE!'60')
+num_ports = int($BESS_PORTS!'1')
+num_cores = int($BESS_CORES!'1')
 rate_limit = int($BESS_RATELIMIT_MBPS!'0') # default no limit
-imix = int($SN_IMIX!'0')
+imix = int($BESS_IMIX!'0')
 
 assert(60 <= pkt_size <= 1522)
 assert(1 <= num_ports <= 16)
 assert(1 <= num_cores <= 4)
 
 # generate flows by varying dst IP addr
-num_flows = int($SN_FLOWS!'1')
+num_flows = int($BESS_FLOWS!'1')
 assert(1 <= num_flows <= 256 ** 3)
 
 def build_pkt(size):

--- a/bessctl/conf/perftest/vport_scaling.bess
+++ b/bessctl/conf/perftest/vport_scaling.bess
@@ -1,7 +1,7 @@
 import sys
 import time
 
-NUM_PORTS = int($SN_PORTS!'100')
+NUM_PORTS = int($BESS_PORTS!'100')
 
 for i in xrange(1, NUM_PORTS + 1):
     try:

--- a/bessctl/conf/samples/flowgen.bess
+++ b/bessctl/conf/samples/flowgen.bess
@@ -2,7 +2,7 @@ import scapy.all as scapy
 
 # 'show module' command shows detailed stats/parameters
 
-pkt_size = int($SN_PKT_SIZE!'60')
+pkt_size = int($BESS_PKT_SIZE!'60')
 assert(60 <= pkt_size <= 1522)
 
 eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')

--- a/bessctl/conf/samples/iplookup.bess
+++ b/bessctl/conf/samples/iplookup.bess
@@ -2,7 +2,7 @@
 
 import scapy.all as scapy
 
-pkt_size = int($SN_PKT_SIZE!'60')
+pkt_size = int($BESS_PKT_SIZE!'60')
 
 assert(60 <= pkt_size <= 1522)
 

--- a/bessctl/conf/samples/loopback.bess
+++ b/bessctl/conf/samples/loopback.bess
@@ -1,7 +1,7 @@
-dpdk_ports = int($SN_PORTS!'1')
-qsize = int($SN_QSIZE!'128')
+dpdk_ports = int($BESS_PORTS!'1')
+qsize = int($BESS_QSIZE!'128')
 
-print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
+print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
 print 'RX/TX queue size: %d packets per queue' % qsize
 print 'NOTE: not all DPDK ports support lookback mode'
 

--- a/bessctl/conf/samples/loopback_vport.bess
+++ b/bessctl/conf/samples/loopback_vport.bess
@@ -1,6 +1,6 @@
-num_ports = int($SN_PORTS!'1')
+num_ports = int($BESS_PORTS!'1')
 
-print 'Using %d virtual ports... (envvar "SN_PORTS")' % num_ports
+print 'Using %d virtual ports... (envvar "BESS_PORTS")' % num_ports
 
 for i in range(num_ports):
 	v = VPort(loopback=True)

--- a/bessctl/conf/samples/macswap.bess
+++ b/bessctl/conf/samples/macswap.bess
@@ -1,5 +1,5 @@
-dpdk_ports = int($SN_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
+dpdk_ports = int($BESS_PORTS!'1')
+print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/samples/p2s.bess
+++ b/bessctl/conf/samples/p2s.bess
@@ -1,5 +1,5 @@
-dpdk_ports = int($SN_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
+dpdk_ports = int($BESS_PORTS!'1')
+print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/samples/s2p.bess
+++ b/bessctl/conf/samples/s2p.bess
@@ -1,5 +1,5 @@
-dpdk_ports = int($SN_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
+dpdk_ports = int($BESS_PORTS!'1')
+print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/samples/s2p2s.bess
+++ b/bessctl/conf/samples/s2p2s.bess
@@ -1,5 +1,5 @@
-dpdk_ports = int($SN_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "SN_PORTS")' % dpdk_ports
+dpdk_ports = int($BESS_PORTS!'1')
+print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/samples/s2s.bess
+++ b/bessctl/conf/samples/s2s.bess
@@ -1,4 +1,4 @@
-psize = int($SN_PKT_SIZE!'60')
-print 'Using packet size %d (envvar "SN_PKT_SIZE")' % psize
+psize = int($BESS_PKT_SIZE!'60')
+print 'Using packet size %d (envvar "BESS_PKT_SIZE")' % psize
 
 Source(pkt_size=psize) -> Sink()


### PR DESCRIPTION
- Do not use `SN_*`, but use `BESS_*`