### PR TITLE
Avoid undefined bit shift operations

### DIFF
--- a/core/modules/dump.cc
+++ b/core/modules/dump.cc
@@ -5,7 +5,7 @@
 
 #include <rte_hexdump.h>
 
-#define NS_PER_SEC 1000000000ul
+#define NS_PER_SEC 1000000000ull
 
 static const uint64_t DEFAULT_INTERVAL_NS = 1 * NS_PER_SEC; /* 1 sec */
 

--- a/core/modules/hash_lb.cc
+++ b/core/modules/hash_lb.cc
@@ -22,7 +22,7 @@ static inline uint16_t hash_range(uint32_t hashval, uint16_t range) {
   } tmp;
 
   /* the resulting number is 1.(b0)(b1)..(b31)00000..00 */
-  tmp.i = 0x3ff0000000000000ul | ((uint64_t)hashval << 20);
+  tmp.i = 0x3ff0000000000000ull | (static_cast<uint64_t>(hashval) << 20);
 
   return (tmp.d - 1.0) * range;
 #else

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -147,7 +147,7 @@ pb_cmd_response_t IPLookup::CommandAdd(
   }
 
   ip_addr = rte_be_to_cpu_32(ip_addr_be.s_addr);
-  netmask = ~0 ^ ((1 << (32 - prefix_len)) - 1);
+  netmask = ~((1ull << (32 - prefix_len)) - 1);
 
   if (ip_addr & ~netmask) {
     set_cmd_response_error(

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -99,6 +99,7 @@ const union {
 } _mask = {.val = {0x8000ffffFFFFffffull, 0x8000ffffFFFFffffull,
                    0x8000ffffFFFFffffull, 0x8000ffffFFFFffffull}};
 
+// Do not call these functions directly. Use find_index() instead. See below.
 static inline int find_index_avx(uint64_t addr, uint64_t *table) {
   __m256d _addr = (__m256d)_mm256_set1_epi64x(addr | (1ull << 63));
   __m256d _table = _mm256_load_pd((double *)table);
@@ -119,6 +120,8 @@ static inline int find_index_basic(uint64_t addr, uint64_t *table) {
 }
 #endif
 
+// Finds addr from a 4-way bucket *table and returns its index + 1.
+// Returns zero if not found.
 static inline int find_index(uint64_t addr, uint64_t *table, const uint64_t) {
 #if __AVX__
   return find_index_avx(addr, table);

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -96,11 +96,11 @@ static uint32_t l2_alt_index(uint32_t hash, uint32_t size_power,
 const union {
   uint64_t val[4];
   __m256d _mask;
-} _mask = {.val = {0x8000ffffFFFFfffflu, 0x8000ffffFFFFfffflu,
-                   0x8000ffffFFFFfffflu, 0x8000ffffFFFFfffflu}};
+} _mask = {.val = {0x8000ffffFFFFffffull, 0x8000ffffFFFFffffull,
+                   0x8000ffffFFFFffffull, 0x8000ffffFFFFffffull}};
 
 static inline int find_index_avx(uint64_t addr, uint64_t *table) {
-  __m256d _addr = (__m256d)_mm256_set1_epi64x(addr | ((uint64_t)1 << 63));
+  __m256d _addr = (__m256d)_mm256_set1_epi64x(addr | (1ull << 63));
   __m256d _table = _mm256_load_pd((double *)table);
   _table = _mm256_and_pd(_table, _mask._mask);
   __m256d cmp = _mm256_cmp_pd(_addr, _table, _CMP_EQ_OQ);
@@ -110,7 +110,7 @@ static inline int find_index_avx(uint64_t addr, uint64_t *table) {
 #else
 static inline int find_index_basic(uint64_t addr, uint64_t *table) {
   for (int i = 0; i < 4; i++) {
-    if ((addr | ((uint64_t)1 << 63)) == (table[i] & 0x8000ffffFFFFffffUL)) {
+    if ((addr | (1ull << 63)) == (table[i] & 0x8000ffffFFFFffffull)) {
       return i + 1;
     }
   }

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -31,7 +31,7 @@ const Commands Measure::cmds = {
 
 pb_error_t Measure::Init(const bess::pb::MeasureArg &arg) {
   // seconds from nanoseconds
-  warmup_ns_ = arg.warmup() * 1000000000ul;
+  warmup_ns_ = arg.warmup() * 1000000000ull;
 
   if (arg.offset()) {
     offset_ = arg.offset();

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -24,7 +24,7 @@ using bess::utils::CuckooMap;
 
 const uint16_t MIN_PORT = 1024;
 const uint16_t MAX_PORT = 65535;
-const uint64_t TIME_OUT_NS = (uint64_t)120 * 1000 * 1000 * 1000;
+const uint64_t TIME_OUT_NS = 120ull * 1000 * 1000 * 1000;
 
 enum Protocol : uint8_t {
   ICMP = 0x01,

--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -19,13 +19,17 @@ pb_error_t Split::Init(const bess::pb::SplitArg &arg) {
   if (size_ < 1 || size_ > MAX_SIZE) {
     return pb_error(EINVAL, "'size' must be 1-%d", MAX_SIZE);
   }
-  mask_ = ((uint64_t)1 << (size_ * 8)) - 1;
+
+  mask_ = (size_ == 8) ? 0xffffffffffffffffull
+                       : (1ull << (size_ * 8)) - 1;
+
   const char *name = arg.name().c_str();
   if (arg.name().length()) {
     attr_id_ = AddMetadataAttr(name, size_,
                                bess::metadata::Attribute::AccessMode::kRead);
-    if (attr_id_ < 0)
+    if (attr_id_ < 0) {
       return pb_error(-attr_id_, "add_metadata_attr() failed");
+    }
   } else {
     attr_id_ = -1;
     offset_ = arg.offset();

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -78,7 +78,7 @@ pb_cmd_response_t Update::CommandAdd(const bess::pb::UpdateArg &arg) {
     }
 
     offset -= (8 - size);
-    mask = ((uint64_t)1 << ((8 - size) * 8)) - 1;
+    mask = (1ull << ((8 - size) * 8)) - 1;
 
     if (offset + 8 > SNBUF_DATA) {
       set_cmd_response_error(&response, pb_error(EINVAL, "too large 'offset'"));

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -12,7 +12,7 @@ using bess::utils::EthHeader;
 using bess::utils::Ipv4Header;
 using bess::utils::TcpHeader;
 
-const uint64_t TIME_OUT_NS = (uint64_t)10 * 1000 * 1000 * 1000;  // 10 seconds
+const uint64_t TIME_OUT_NS = 10ull * 1000 * 1000 * 1000;  // 10 seconds
 
 const Commands UrlFilter::cmds = {
     {"add", "UrlFilterArg", MODULE_CMD_FUNC(&UrlFilter::CommandAdd), 0},

--- a/core/utils/ip.cc
+++ b/core/utils/ip.cc
@@ -26,7 +26,7 @@ CIDRNetwork::CIDRNetwork(const std::string &cidr) {
   } else if (len >= 32) {
     mask = 0xffffffff;
   } else {
-    mask = ~((1 << (32 - len)) - 1);
+    mask = ~((1u << (32 - len)) - 1);
   }
   mask = htonl(mask);
 }

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -10,13 +10,16 @@ using bess::utils::CIDRNetwork;
 // Check if CIDRNetwork can be correctly constructed from strings
 TEST(IPTest, CIDRInStr) {
   CIDRNetwork cidr_1("192.168.0.1/24");
-
   EXPECT_EQ(htonl((192 << 24) + (168 << 16) + 1), cidr_1.addr);
   EXPECT_EQ(htonl(0xffffff00), cidr_1.mask);
 
   CIDRNetwork cidr_2("0.0.0.0/0");
   EXPECT_EQ(htonl(0), cidr_2.addr);
   EXPECT_EQ(htonl(0x0), cidr_2.mask);
+
+  CIDRNetwork cidr_3("128.0.0.0/1");
+  EXPECT_EQ(htonl(128 << 24), cidr_3.addr);
+  EXPECT_EQ(htonl(0x80000000), cidr_3.mask);
 }
 
 // Check if CIDRNetwork::Match() behaves correctly


### PR DESCRIPTION
This PR fixes subtle bugs caused by undefined bit shift operations. For example in the following code from `core/modules/exact_match.cc`
```
if (field.mask() == 0) {
    /* by default all bits are considered */
    f->mask = ((uint64_t)1 << (f->size * 8)) - 1;
```

The code behavior is unknown when `f->size == 8`, since `1ull << 64` is an undefined operation in C++. On pre-Haswell machines the code works as intended (`f->mask` becomes `0b111111...111`). However, on Haswell or later `f->mask` results in `0b000000...000`. This difference comes from the use of new bit instructions (BMI) on newer processors. As a result, the ExactMatch module does not work correctly with 8-byte fields on some machines.