### PR TITLE
Add command `show plugin`

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1028,6 +1028,7 @@ def show_status(cli):
     workers = sorted(cli.bess.list_workers().workers_status,
                      key=lambda x: x.wid)
     drivers = sorted(cli.bess.list_drivers().driver_names)
+    plugins = sorted(cli.bess.list_plugins().paths)
     mclasses = sorted(cli.bess.list_mclasses().names)
     modules = sorted(cli.bess.list_modules().modules, key=lambda x: x.name)
     ports = sorted(cli.bess.list_ports().ports, key=lambda x: x.name)
@@ -1043,6 +1044,12 @@ def show_status(cli):
     cli.fout.write('  Available drivers: ')
     if drivers:
         cli.fout.write('%s\n' % ', '.join(drivers))
+    else:
+        cli.fout.write('(none)\n')
+
+    cli.fout.write('  Available plugins: ')
+    if drivers:
+        cli.fout.write('%s\n' % ', '.join(plugins))
     else:
         cli.fout.write('(none)\n')
 
@@ -1310,6 +1317,13 @@ def import_plugin(cli, plugin):
 @cmd('unload plugin PLUGIN_FILE', 'Unload the specified plugin (*.so)')
 def unload_plugin(cli, plugin):
     cli.bess.unload_plugin(plugin)
+
+
+@cmd('show plugin', 'Show all imported plugins')
+def show_plugin_all(cli):
+    plugins = cli.bess.list_plugins().paths
+    for plugin_name in plugins:
+        cli.fout.write('%-16s\n' % (plugin_name))
 
 
 def _show_driver(cli, drv_name, detail):

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1283,6 +1283,15 @@ class BESSControlImpl final : public BESSControl::Service {
     return Status::OK;
   }
 
+  Status ListPlugins(ServerContext*, const EmptyRequest*,
+                     ListPluginsResponse* response) override {
+    auto list = bess::bessd::ListPlugins();
+    for (auto& path : list) {
+      response->add_paths(path);
+    }
+    return Status::OK;
+  }
+
   Status ListMclass(ServerContext*, const EmptyRequest*,
                     ListMclassResponse* response) override {
     for (const auto& pair : ModuleBuilder::all_module_builders()) {

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -372,6 +372,14 @@ static inline bool HasSuffix(const std::string &s, const std::string &suffix) {
 // key: plugin path (std::string), value: handle (void *)
 static std::unordered_map<std::string, void *> plugin_handles;
 
+std::vector<std::string> ListPlugins() {
+  std::vector<std::string> list;
+  for (auto &kv : plugin_handles) {
+    list.push_back(kv.first);
+  }
+  return list;
+}
+
 bool LoadPlugin(const std::string &path) {
   void *handle = dlopen(path.c_str(), RTLD_NOW);
   if (handle != nullptr) {

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <tuple>
+#include <vector>
 
 namespace bess {
 namespace bessd {
@@ -48,6 +49,9 @@ bool UnloadPlugin(const std::string &path);
 
 // Load all the .so files in the specified directory. Return true upon success.
 bool LoadPlugins(const std::string &directory);
+
+// List all imported .so files.
+std::vector<std::string> ListPlugins();
 
 // Return the current executable's own directory. For example, if the location
 // of the executable is /opt/bess/core/bessd, returns /opt/bess/core/ (with the

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -230,6 +230,9 @@ class BESS(object):
         request.path = path
         return self._request('UnloadPlugin', request)
 
+    def list_plugins(self):
+        return self._request('ListPlugins')
+
     def list_mclasses(self):
         return self._request('ListMclass')
 

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -32,6 +32,11 @@ message UnloadPluginRequest {
   string path = 1;  /// Path to the module library (*.so file)
 }
 
+message ListPluginsResponse {
+  Error error = 1;
+  repeated string paths = 2; /// Paths to the module library (*.so file)
+}
+
 message ListWorkersResponse {
   message WorkerStatus {
     int64 wid = 1;      /// Worker ID, starting from 0

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -45,6 +45,12 @@ service BESSControl {
   /// but might also support drivers/hooks/schedulers in the future.
   rpc UnloadPlugin (UnloadPluginRequest) returns (EmptyResponse) {}
 
+  /// List imported plugins
+  ///
+  /// At the moment plugins can only contain module types,
+  /// but might also support drivers/hooks/schedulers in the future.
+  rpc ListPlugins (EmptyRequest) returns (ListPluginsResponse) {}
+
 
   //  -------------------------------------------------------------------------
   //  Worker


### PR DESCRIPTION
which shows all imported plugins:
```
localhost:10514 $ show plugin
/bess/core/modules/vlan_push.so
/bess/core/modules/vxlan_encap.so
/bess/core/modules/vxlan_decap.so
/bess/core/modules/drr.so
/bess/core/modules/measure.so
/bess/core/modules/split.so
/bess/core/modules/bypass.so
/bess/core/modules/update_ttl.so
/bess/core/modules/url_filter.so
/bess/core/modules/acl.so
/bess/core/modules/vlan_split.so
/bess/core/modules/generic_decap.so
/bess/core/modules/wildcard_match.so
/bess/core/modules/ip_lookup.so
/bess/core/modules/rewrite.so
/bess/core/modules/random_update.so
/bess/core/modules/update.so
/bess/core/modules/sink.so
/bess/core/modules/port_out.so
/bess/core/modules/queue.so
/bess/core/modules/vlan_pop.so
/bess/core/modules/random_drop.so
/bess/core/modules/set_metadata.so
/bess/core/modules/macswap.so
/bess/core/modules/source.so
/bess/core/modules/flowgen.so
/bess/core/modules/timestamp.so
/bess/core/modules/buffer.so
/bess/core/modules/ether_encap.so
/bess/core/modules/exact_match.so
/bess/core/modules/generic_encap.so
/bess/core/modules/hash_lb.so
/bess/core/modules/replicate.so
/bess/core/modules/port_inc.so
/bess/core/modules/ip_checksum.so
/bess/core/modules/ip_encap.so
/bess/core/modules/ipswap.so
/bess/core/modules/l2_forward.so
/bess/core/modules/round_robin.so
/bess/core/modules/mttest.so
/bess/core/modules/merge.so
/bess/core/modules/dump.so
/bess/core/modules/noop.so
/bess/core/modules/queue_inc.so
/bess/core/modules/queue_out.so
```