### PR TITLE
travis: output coverage percentage from genhtml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 install:
   - sudo apt-get install -y python
   - pip install grpcio scapy
+  - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y lcov"
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"
   - ln -s /build/dpdk-17.02 deps
@@ -48,6 +49,8 @@ script:
 
 after_success:
   - "[[ ${DEBUG:-0} == 0 ]] || bash <(curl -s https://codecov.io/bash)"
+  - "lcov --capture --directory . --output-file coverage.info && \
+    genhtml coverage.info --output-directory coverage_html"
 
 after_failure:
   - more /tmp/bessd.*.INFO.* | cat      # dump all bessd log files


### PR DESCRIPTION
Adding this output should make it clearer whether our fluctuating
code coverage is a problem with codecov.io or a problem with our
tests.

The coverage percentage generated by genhtml will not be the same as
the percentage generated by codecov.io (because aren't looking at
all of the same files and count differently for some line types),
but is roughly proportional.