### PR TITLE
Set & query version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ doxygen/doxygen.errors
 doxygen/html/
 doxygen/latex/
 
+# Auto-genereated by make
+core/version.h
+
 # Code coverage files
 core/*.gcda
 core/*.gcno

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1337,6 +1337,12 @@ def show_driver_list(cli, drv_names):
         _show_driver(cli, drv_name, True)
 
 
+@cmd('show version', 'Show the version of BESS daemon')
+def show_version(cli):
+    version = cli.bess.get_version()
+    cli.fout.write('%s\n' % version.version)
+
+
 def _monitor_pipeline(cli, field):
     modules = sorted(cli.bess.list_modules().modules, key=lambda x: x.name)
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -151,11 +151,15 @@ protobuf: $(PROTO_SRCS)
 
 modules: protobuf $(MODULE_OBJS) $(MODULE_LIBS)
 
-GIT_VERSION := \#define VERSION \
-	\"$(shell git describe --abbrev=4 --dirty --always --tags)\"
+# Generate version string from the current status of the git working copy
+VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null)
 
+# Default if previous command fails (e.g., when building from a tarball)
+DEFAULT_VERSION := v0.2.1
+
+VERSION_LINE := \#define VERSION \"$(or $(VERSION), $(DEFAULT_VERSION))\"
 version.h: force
-	@echo "$(GIT_VERSION)"| cmp -s - $@ || echo "$(GIT_VERSION)" > $@
+	@echo "$(VERSION_LINE)"| cmp -s - $@ || echo "$(VERSION_LINE)" > $@
 
 # This build wrapper takes 4 parameters:
 # $(1): build type (CXX, LD, ...)

--- a/core/Makefile
+++ b/core/Makefile
@@ -155,7 +155,7 @@ modules: protobuf $(MODULE_OBJS) $(MODULE_LIBS)
 VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null)
 
 # Default if previous command fails (e.g., when building from a tarball)
-DEFAULT_VERSION := v0.2.1
+DEFAULT_VERSION := unknown
 
 VERSION_LINE := \#define VERSION \"$(or $(VERSION), $(DEFAULT_VERSION))\"
 version.h: force

--- a/core/Makefile
+++ b/core/Makefile
@@ -125,9 +125,9 @@ EXEC := bessd
 
 GTEST_DIR := /usr/src/gtest
 
-.PHONY: all clean tags cscope tests benchmarks protobuf
+.PHONY: all clean tags cscope tests benchmarks protobuf force
 
-all: $(EXEC) modules tests benchmarks
+all: version.h $(EXEC) modules tests benchmarks
 
 clean:
 	rm -rf $(EXEC) .deps/*.d .deps/*/*.d *_test */*_test *_bench */*_bench \
@@ -150,6 +150,12 @@ benchmarks: $(BENCH_OBJS) $(BENCH_EXEC)
 protobuf: $(PROTO_SRCS)
 
 modules: protobuf $(MODULE_OBJS) $(MODULE_LIBS)
+
+GIT_VERSION := \#define VERSION \
+	\"$(shell git describe --abbrev=4 --dirty --always --tags)\"
+
+version.h: force
+	@echo "$(GIT_VERSION)"| cmp -s - $@ || echo "$(GIT_VERSION)" > $@
 
 # This build wrapper takes 4 parameters:
 # $(1): build type (CXX, LD, ...)

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <thread>
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <grpc++/server.h>
 #include <grpc++/server_builder.h>
@@ -332,6 +333,12 @@ static Module* create_module(const std::string& name,
 
 class BESSControlImpl final : public BESSControl::Service {
  public:
+  Status GetVersion(ServerContext*, const EmptyRequest*,
+                    VersionResponse* response) override {
+    response->set_version(google::VersionString());
+    return Status::OK;
+  }
+
   Status ResetAll(ServerContext* context, const EmptyRequest* request,
                   EmptyResponse* response) override {
     Status status;

--- a/core/main.cc
+++ b/core/main.cc
@@ -9,6 +9,7 @@
 #include "opts.h"
 #include "packet.h"
 #include "port.h"
+#include "version.h"
 
 int main(int argc, char *argv[]) {
   FLAGS_logbuflevel = -1;
@@ -17,6 +18,7 @@ int main(int argc, char *argv[]) {
   google::InstallFailureFunction(bess::debug::GoPanic);
   bess::debug::SetTrapHandler();
 
+  google::SetVersionString(VERSION);
   google::SetUsageMessage("BESS Command Line Options:");
   google::ParseCommandLineFlags(&argc, &argv, true);
   bess::bessd::ProcessCommandLineArgs();

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -164,6 +164,9 @@ class BESS(object):
         self.disconnect()
         return response
 
+    def get_version(self):
+        return self._request('GetVersion')
+
     def reset_all(self):
         return self._request('ResetAll')
 

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -24,6 +24,11 @@ message EmptyResponse {
   Error error = 1;
 }
 
+message VersionResponse {
+  Error error = 1;
+  string version = 2;  /// Version of bessd
+}
+
 message ImportPluginRequest {
   string path = 1;  /// Path to the module library (*.so file)
 }

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -10,6 +10,9 @@ service BESSControl {
   //  System
   //  -------------------------------------------------------------------------
 
+  /// Query version of bessd
+  rpc GetVersion (EmptyRequest) returns (VersionResponse) {}
+
   /// Reset the current packet processing datapath to the initial state.
   ///
   /// This command is identical to the following sequence:


### PR DESCRIPTION
Hi,

This PR allows us to easily check whether we forgot to update one of the bessd instances we use.  Additionally, this makes straightforward to record the version we used during a measurement. 

Bess should be installed from git, hence the PR generates the version information by executing a git command.  (However, the effect on build time is negligible.)  The version string will be similar to this: v0.2.0-409-gee04-dirty.  (The latest tag, number of commits since the latest tag, the beginning of the hash of the current HEAD, and "dirty" if there are uncommitted  changes.)

The auto-generated version.h simply contains one #define.  I can modify this to have a proper include header guard, a "const std::string kBessVersion = "...", etc, but I think I already over-engineered it. 