### PR TITLE
Add WorkerSplit module

### DIFF
--- a/bessctl/conf/samples/worker_split.bess
+++ b/bessctl/conf/samples/worker_split.bess
@@ -1,0 +1,17 @@
+bess.add_worker(0, 0)
+bess.add_worker(1, 1)
+
+chokepoint = Bypass()
+src0::Source() -> chokepoint
+src1::Source() -> chokepoint
+src2::Source() -> chokepoint
+src3::Source() -> chokepoint
+
+chokepoint -> ws::WorkerSplit()
+ws:0 -> sink0::Sink()
+ws:1 -> sink1::Sink()
+
+bess.attach_module('src0', wid=0)
+bess.attach_module('src1', wid=0)
+bess.attach_module('src2', wid=1)
+bess.attach_module('src3', wid=1)

--- a/bessctl/conf/testing/module_tests/worker_split.py
+++ b/bessctl/conf/testing/module_tests/worker_split.py
@@ -1,0 +1,34 @@
+import time
+
+
+def test_workersplit():
+    NUM_WORKERS = 2
+
+    for i in range(NUM_WORKERS):
+        bess.add_worker(wid=i, core=i)
+
+    for wid in range(NUM_WORKERS):
+        src = Source()
+        ws = WorkerSplit()
+        src -> ws
+
+        for i in range(NUM_WORKERS):
+            ws:i -> Sink()
+
+        bess.attach_module(src.name, wid=wid)
+
+        bess.resume_all()
+        time.sleep(0.1)
+        bess.pause_all()
+
+        # packets should flow onto only one output gate...
+        ogates = bess.get_module_info(ws.name).ogates
+        for ogate in ogates:
+            if ogate.ogate == wid:
+                assert ogate.pkts > 0
+            else:
+                assert ogate.pkts == 0
+
+        bess.reset_modules()
+
+CUSTOM_TEST_FUNCTIONS.append(test_workersplit)

--- a/core/modules/worker_split.cc
+++ b/core/modules/worker_split.cc
@@ -1,0 +1,8 @@
+#include "worker_split.h"
+
+void WorkerSplit::ProcessBatch(bess::PacketBatch *batch) {
+  RunChooseModule(ctx.wid(), batch);
+}
+
+ADD_MODULE(WorkerSplit, "ws",
+           "send packets to output gate X, the id of current worker")

--- a/core/modules/worker_split.h
+++ b/core/modules/worker_split.h
@@ -1,0 +1,13 @@
+#ifndef BESS_MODULES_WORKERSPLIT_H_
+#define BESS_MODULES_WORKERSPLIT_H_
+
+#include "../module.h"
+
+class WorkerSplit final : public Module {
+ public:
+  static const gate_idx_t kNumOGates = Worker::kMaxWorkers;
+
+  void ProcessBatch(bess::PacketBatch *batch) override;
+};
+
+#endif  // BESS_MODULES_WORKERSPLIT_H_


### PR DESCRIPTION
This PR introduces a new module, WorkerSplit, which is simple yet strange. Let me justify its raison d'être with some backgrounds:

* Most stateful modules are not thread-safe.
  * Because...
    1. BESS does not provide an easy API to access per-task / per-worker storage for modules.
    1. Some modules are inherently not safe for threading (e.g., QueueOut running on a PMD port)
  * It's unlikely that this issue is resolved very soon for all modules.
* One way to work around the issue would be replicating such modules so that each worker thread has a dedicated module instance. It's not always straightforward though. For example,
```
A and B are bound to worker 0 and 1 respectively. 
C is thread-safe but not replicable. 
D is replicable but not thread-safe.

A
 \
  C - D 
 /
B

With the above set up D will be accessed by the both workers, potentially crashing.
```

What WorkerSplit module (`W`) does is like this:
```
A       D0
 \     /
  C - W 
 /     \
B       D1
```
On worker 0, `W` forwards packets to output gate 0. On worker 1, `W` forwards packets to output gate 1. On worker `X`, to output gate `X`.

One may emulate this behavior by adding `SetMetadata('foo', 0)` between `A` and `C` and `SetMetadata('foo', 1)` between `B` and `C`, to *remember* where packets came from. Then you can  replace `W` with `Split('foo')` to split packets based on the metadata. However this alternative incurs too much overheads for the same behavior.