### PR TITLE
Detect scheduling constraint violations - Step 1

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -464,6 +464,7 @@ def bind_var(cli, var_type, line):
 
     return val, remainder
 
+
 cmdlist = []
 
 
@@ -991,6 +992,20 @@ def _build_tcs_tree(tcs):
     return root
 
 
+@cmd('check constraints', 'Check constraints')
+def check_constraints(cli):
+    response = cli.bess.check_scheduling_constraints()
+    if len(response.violations) != 0:
+        print 'Placement violations found'
+        for violation in response.violations:
+            print 'name %s constraint %d socket %d core %d' % (violation.name,
+                                                               violation.constraint,
+                                                               violation.assigned_node,
+                                                               violation.assigned_core)
+    else:
+        print 'No violations found'
+
+
 def _show_tc_list(cli, tcs):
     wids = sorted(list(set(map(lambda tc: getattr(tc, 'class').wid, tcs))))
 
@@ -1384,6 +1399,7 @@ def monitor_pipeline(cli):
      'Monitor batch counters in the datapath pipeline')
 def monitor_pipeline_batch(cli):
     _monitor_pipeline(cli, 'cnt')
+
 
 PortRate = collections.namedtuple('PortRate',
                                   ['inc_packets', 'inc_dropped', 'inc_bytes',

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -996,14 +996,14 @@ def _build_tcs_tree(tcs):
 def check_constraints(cli):
     response = cli.bess.check_scheduling_constraints()
     if len(response.violations) != 0:
-        print 'Placement violations found'
+        cli.fout.write('Placement violations found\n')
         for violation in response.violations:
-            print 'name %s constraint %d socket %d core %d' % (violation.name,
-                                                               violation.constraint,
-                                                               violation.assigned_node,
-                                                               violation.assigned_core)
+            cli.fout.write('name %s constraint %d socket %d core %d\n' % (violation.name,
+                                                                          violation.constraint,
+                                                                          violation.assigned_node,
+                                                                          violation.assigned_core))
     else:
-        print 'No violations found'
+        cli.fout.write('No violations found\n')
 
 
 def _show_tc_list(cli, tcs):

--- a/bessctl/conf/samples/multicore-phy.bess
+++ b/bessctl/conf/samples/multicore-phy.bess
@@ -1,0 +1,38 @@
+# TODO:
+# 1. multi-queue port support
+# 2. syntactic sugars
+# 3. "daemon reset" should remove workers as well
+
+# Syntax: bind worker:<worker ID> => core:<core ID>
+# Bind a worker thread to the specified CPU core.
+# It creates a new worker thread if not already exists.
+#bind worker:0 => core:0
+#bind worker:1 => core:1
+#
+bess.add_worker(0, 0)
+p = PMDPort(pci='82:00.0')
+src0::PortInc(port=p.name) -> Sink()
+
+
+
+## Syntax: attach <task name> => worker:<worker ID>
+## Create a dummy traffic class for the specified task, 
+## and attach it to the worker.
+##
+## <task name> could be formatted as either
+##       1. module
+##       2. module:*
+##	3. module:<task ID>
+
+##attach src0:0 => worker:0 
+##attach src1:0 => worker:1
+
+bess.attach_module('src0', wid=0)
+
+## Future work
+##
+## 1. creating a traffic class
+##    Syntax: tc <TC name> [parent <TC name>] ...
+##
+## 2. attaching task to a traffic class
+##    Syntax: attach <task name> => tc:<traffic class ID>

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -73,7 +73,7 @@ static pb_error_t enable_track_for_module(const Module* m, gate_idx_t gate_idx,
   int ret;
 
   if (use_gate) {
-    if (is_igate) { 
+    if (is_igate) {
       if (!is_active_gate(m->igates(), gate_idx)) {
         return pb_error(EINVAL, "Input gate '%hu' does not exist", gate_idx);
       }
@@ -94,7 +94,7 @@ static pb_error_t enable_track_for_module(const Module* m, gate_idx_t gate_idx,
   if (is_igate) {
     for (auto& gate : m->igates()) {
       if (!gate) {
-          continue;
+        continue;
       }
       if ((ret = gate->AddHook(new TrackGate()))) {
         return pb_error(ret, "Failed to track input gate '%hu'",
@@ -104,7 +104,7 @@ static pb_error_t enable_track_for_module(const Module* m, gate_idx_t gate_idx,
   } else {
     for (auto& gate : m->ogates()) {
       if (!gate) {
-          continue;
+        continue;
       }
       if ((ret = gate->AddHook(new TrackGate()))) {
         return pb_error(ret, "Failed to track output gate '%hu'",
@@ -137,14 +137,14 @@ static pb_error_t disable_track_for_module(const Module* m, gate_idx_t gate_idx,
   if (is_igate) {
     for (auto& gate : m->igates()) {
       if (!gate) {
-          continue;
+        continue;
       }
       gate->RemoveHook(kGateHookTrackGate);
     }
   } else {
     for (auto& gate : m->ogates()) {
       if (!gate) {
-          continue;
+        continue;
       }
       gate->RemoveHook(kGateHookTrackGate);
     }
@@ -497,8 +497,7 @@ class BESSControlImpl final : public BESSControl::Service {
     for (; i <= wid_filter; i++) {
       bess::TrafficClass* root = workers[i]->scheduler()->root();
       if (!root) {
-        return return_with_error(response, ENOENT, "worker:%d has no root tc",
-                                 i);
+        continue;
       }
 
       root->Traverse([&response, i](bess::TCChildArgs* args) {
@@ -555,34 +554,30 @@ class BESSControlImpl final : public BESSControl::Service {
       int socket = workers[i]->socket();
       int core = workers[i]->core();
       bess::TrafficClass* root = workers[i]->scheduler()->root();
-      if (!root) {
-        return return_with_error(response, ENOENT, 
-                "worker:%d has no root tc ",
-                                 i);
-      }
-
-      root->Traverse([&response, i, socket, core](bess::TCChildArgs* args) {
-        bess::TrafficClass* c = args->child();
-        if (c->policy() == bess::POLICY_LEAF) {
-          auto leaf = static_cast<bess::LeafTrafficClass<Task>*>(c);
-          int constraints = leaf->Task().GetSocketConstraints();
-          if (constraints != ModuleTask::UNCONSTRAINED_SOCKET &&
-              constraints != socket) {
-            LOG(WARNING) << "Scheduler constraints are violated for wid " << i
-                         << " socket " << socket << " constraint "
-                         << constraints;
-            auto violation = response->add_violations();
-            violation->set_name(c->name());
-            violation->set_constraint(constraints);
-            violation->set_assigned_node(socket);
-            violation->set_assigned_core(core);
-          } else {
-            LOG(WARNING) << "Scheduler constraints hold wid " << i
-                         << " socket " << socket << " constraint "
-                         << constraints;
+      if (root) {
+        root->Traverse([&response, i, socket, core](bess::TCChildArgs* args) {
+          bess::TrafficClass* c = args->child();
+          if (c->policy() == bess::POLICY_LEAF) {
+            auto leaf = static_cast<bess::LeafTrafficClass<Task>*>(c);
+            int constraints = leaf->Task().GetSocketConstraints();
+            if (constraints != ModuleTask::UNCONSTRAINED_SOCKET &&
+                constraints != socket) {
+              LOG(WARNING) << "Scheduler constraints are violated for wid " << i
+                           << " socket " << socket << " constraint "
+                           << constraints;
+              auto violation = response->add_violations();
+              violation->set_name(c->name());
+              violation->set_constraint(constraints);
+              violation->set_assigned_node(socket);
+              violation->set_assigned_core(core);
+            } else {
+              LOG(WARNING) << "Scheduler constraints hold wid " << i
+                           << " socket " << socket << " constraint "
+                           << constraints;
+            }
           }
-        }
-      });
+        });
+      }
     }
     return Status::OK;
   }

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -50,6 +50,7 @@ void PMDPort::InitDriver() {
     struct rte_eth_dev_info dev_info;
     std::string pci_info;
     int numa_node = -1;
+    bess::utils::EthHeader::Address lladdr;
 
     rte_eth_dev_info_get(i, &dev_info);
 
@@ -59,10 +60,9 @@ void PMDPort::InitDriver() {
           dev_info.pci_dev->addr.domain, dev_info.pci_dev->addr.bus,
           dev_info.pci_dev->addr.devid, dev_info.pci_dev->addr.function,
           dev_info.pci_dev->id.vendor_id, dev_info.pci_dev->id.device_id);
-      numa_node = rte_eth_dev_socket_id(static_cast<int>(i));
     }
 
-    bess::utils::EthHeader::Address lladdr;
+    numa_node = rte_eth_dev_socket_id(static_cast<int>(i));
     rte_eth_macaddr_get(i, reinterpret_cast<ether_addr *>(lladdr.bytes));
 
     LOG(INFO) << "DPDK port_id " << static_cast<int>(i) << " ("

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -7,6 +7,7 @@
 #include <rte_errno.h>
 #include <rte_ethdev.h>
 
+#include "../module.h"
 #include "../port.h"
 
 typedef uint8_t dpdk_port_t;
@@ -18,7 +19,11 @@ typedef uint8_t dpdk_port_t;
  */
 class PMDPort final : public Port {
  public:
-  PMDPort() : Port(), dpdk_port_id_(DPDK_PORT_UNKNOWN), hot_plugged_(false) {}
+  PMDPort()
+      : Port(),
+        dpdk_port_id_(DPDK_PORT_UNKNOWN),
+        hot_plugged_(false),
+        node_placement_(ModuleTask::UNCONSTRAINED_SOCKET) {}
 
   void InitDriver() override;
 
@@ -92,10 +97,19 @@ class PMDPort final : public Port {
 
   LinkStatus GetLinkStatus() override;
 
+  /*!
+   * Get any placement constraints that need to be met when receiving from this
+   * port.
+   */
+  virtual int GetNodePlacementConstraint() const override {
+    return node_placement_;
+  }
+
  private:
   /*!
    * The DPDK port ID number (set after binding).
    */
+
   dpdk_port_t dpdk_port_id_;
 
   /*!
@@ -103,7 +117,12 @@ class PMDPort final : public Port {
    */
   bool hot_plugged_;
 
-  std::string driver_;    // ixgbe, i40e, ...
+  /*!
+   * The NUMA node to which device is attached
+   */
+  int node_placement_;
+
+  std::string driver_;  // ixgbe, i40e, ...
 };
 
 #endif  // BESS_DRIVERS_PMD_H_

--- a/core/module.cc
+++ b/core/module.cc
@@ -214,14 +214,17 @@ void Module::ProcessBatch(bess::PacketBatch *) {
 }
 
 task_id_t Module::RegisterTask(void *arg) {
-  ModuleTask *t = new ModuleTask(arg, nullptr);
+  return RegisterTask(arg, ModuleTask::UNCONSTRAINED_SOCKET);
+}
 
-  std::string leafname = std::string("!leaf_") + name_ + std::string(":")
-                         + std::to_string(tasks_.size());
-  bess::LeafTrafficClass<Task> *c = 
-      bess::TrafficClassBuilder::
-          CreateTrafficClass<bess::LeafTrafficClass<Task>>(
-              leafname, Task(this, arg, t));
+task_id_t Module::RegisterTask(void *arg, int constraints) {
+  ModuleTask *t = new ModuleTask(arg, nullptr, constraints);
+
+  std::string leafname = std::string("!leaf_") + name_ + std::string(":") +
+                         std::to_string(tasks_.size());
+  bess::LeafTrafficClass<Task> *c =
+      bess::TrafficClassBuilder::CreateTrafficClass<
+          bess::LeafTrafficClass<Task>>(leafname, Task(this, arg, t));
 
   add_tc_to_orphan(c, -1);
 

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -11,6 +11,7 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
   queue_t num_inc_q;
   int ret;
   pb_error_t err;
+  int placement_constraint;
 
   burst_ = bess::PacketBatch::kMaxBurst;
 
@@ -37,8 +38,10 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
     return pb_error(ENODEV, "Port %s has no incoming queue", port_name);
   }
 
+  placement_constraint = port_->GetNodePlacementConstraint();
+
   for (queue_t qid = 0; qid < num_inc_q; qid++) {
-    task_id_t tid = RegisterTask((void *)(uintptr_t)qid);
+    task_id_t tid = RegisterTask((void *)(uintptr_t)qid, placement_constraint);
 
     if (tid == INVALID_TASK_ID) {
       return pb_error(ENOMEM, "Task creation failed");

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -35,7 +35,7 @@ pb_error_t QueueInc::Init(const bess::pb::QueueIncArg &arg) {
     prefetch_ = 1;
   }
 
-  tid = RegisterTask((void *)(uintptr_t)qid_);
+  tid = RegisterTask((void *)(uintptr_t)qid_, port_->GetNodePlacementConstraint());
   if (tid == INVALID_TASK_ID)
     return pb_error(ENOMEM, "Task creation failed");
 

--- a/core/port.h
+++ b/core/port.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "message.h"
+#include "module.h"
 #include "packet.h"
 #include "port_msg.pb.h"
 #include "utils/common.h"
@@ -190,6 +191,14 @@ class Port {
   virtual size_t DefaultOutQueueSize() const { return kDefaultOutQueueSize; }
 
   virtual uint64_t GetFlags() const { return 0; }
+
+  /*!
+   * Get any placement constraints that need to be met when receiving from this
+   * port.
+   */
+  virtual int GetNodePlacementConstraint() const {
+    return ModuleTask::UNCONSTRAINED_SOCKET;
+  }
 
   virtual LinkStatus GetLinkStatus() {
     return LinkStatus{

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -244,6 +244,8 @@ class TrafficClass {
   // eligible) all nodes from this node to the root.
   virtual void BlockTowardsRoot() = 0;
 
+  virtual void SetParent(TrafficClass *parent) { parent_ = parent; }
+
   // Parent of this class; nullptr for root.
   TrafficClass *parent_;
 

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -244,8 +244,6 @@ class TrafficClass {
   // eligible) all nodes from this node to the root.
   virtual void BlockTowardsRoot() = 0;
 
-  virtual void SetParent(TrafficClass *parent) { parent_ = parent; }
-
   // Parent of this class; nullptr for root.
   TrafficClass *parent_;
 

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -173,6 +173,9 @@ class BESS(object):
     def resume_all(self):
         return self._request('ResumeAll')
 
+    def check_scheduling_constraints(self):
+        return self._request('CheckSchedulingConstraints')
+
     def list_drivers(self):
         return self._request('ListDrivers')
 

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -124,6 +124,17 @@ message ListTcsResponse {
   repeated TrafficClassStatus classes_status = 2;
 }
 
+message CheckSchedulingConstraintsResponse {
+  message ViolatingClass {
+    string name = 1;
+    int32 constraint = 2;
+    int32 assigned_node = 3;
+    int32 assigned_core = 4;
+  }
+  Error error = 1;
+  repeated ViolatingClass violations = 2;
+}
+
 message AddTcRequest {
   TrafficClass class = 1;
 }

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -103,6 +103,9 @@ service BESSControl {
   /// Enumerate all existing workers
   rpc ListTcs (ListTcsRequest) returns (ListTcsResponse) {}
 
+  /// Check scheduling contraints
+  rpc CheckSchedulingConstraints (EmptyRequest) returns (CheckSchedulingConstraintsResponse) {}
+
   /// Create a new traffic class
   ///
   /// NOTE: There should be no running worker to run this command.


### PR DESCRIPTION
This change begins tracking placement constraints for tasks, e.g.,
recording when a physical port is best placed on a particular NUMA node.
We also add support for `bessctl` command `check violations` that can be
used to detect and find violations. This is the first step of this
change, and I am going to expand it to other port types, and also record
other types of violations.

Note I am submitting this early since the changes are quite extensive, and
I wanted to reduce code review overhead.