### PR TITLE
protobuf: Convert camelCase to snake_case

### DIFF
--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -54,7 +54,7 @@ message ExactMatchCommandClearArg {
 }
 
 /**
- * The ExactMatch module has a command `setDefaultGate(...)` which takes one parameter.
+ * The ExactMatch module has a command `set_default_gate(...)` which takes one parameter.
  * This command routes all traffic which does _not_ match a rule to a specified gate.
  * Example use in bessctl: `setDefaultGate(gate=2)`
  */
@@ -63,9 +63,10 @@ message ExactMatchCommandSetDefaultGateArg {
 }
 
 /**
- * The HashLB module has a command `setMode(...)` which takes one parameter.
- * The mode specifies whether the load balancer will hash over the src/dest ethernet header (l2),
- * over the src/dest IP addresses (l3), or over the flow 5-tuple (l4).
+ * The HashLB module has a command `set_mode(...)` which takes one parameter.
+ * The mode specifies whether the load balancer will hash over the src/dest
+ * ethernet header (l2), over the src/dest IP addresses (l3), or over the flow
+ * 5-tuple (l4).
  * Example use in bessctl: `lb.setMode('l2')`
  */
 message HashLBCommandSetModeArg {
@@ -73,7 +74,7 @@ message HashLBCommandSetModeArg {
 }
 
 /**
- * The HashLB module has a command `setGates(...)` which takes one parameter.
+ * The HashLB module has a command `set_gates(...)` which takes one parameter.
  * This function takes in a list of gate numbers to send hashed traffic out over.
  * Example use in bessctl: `lb.setGates(gates=[0,1,2,3])`
  */
@@ -83,8 +84,8 @@ message HashLBCommandSetGatesArg {
 
 /**
  * The IPLookup module has a command `add(...)` which takes three paramters.
- * This function accepts the routing rules -- CIDR prefix, CIDR prefix length, and what gate to forward
- * matching traffic out on.
+ * This function accepts the routing rules -- CIDR prefix, CIDR prefix length,
+ * and what gate to forward matching traffic out on.
  * Example use in bessctl: `table.add(prefix='10.0.0.0', prefix_len=8, gate=2)`
  */
 message IPLookupCommandAddArg {
@@ -124,7 +125,7 @@ message L2ForwardCommandDeleteArg {
 
 /**
  * For traffic reaching the L2Forward module which does not match a MAC rule,
- * the function `setDefaultGate(...)` allows you to specify a default gate
+ * the function `set_default_gate(...)` allows you to specify a default gate
  * to direct unmatched traffic to.
  */
 message L2ForwardCommandSetDefaultGateArg {
@@ -171,8 +172,8 @@ message MeasureCommandGetSummaryArg {
 }
 
 /**
- * The Measure module function `getSummary()` takes no parameters and returns the following
- * values.
+ * The Measure module function `get_summary()` takes no parameters and returns
+ * the following values.
  */
 message MeasureCommandGetSummaryResponse {
   double timestamp = 1; /// Seconds since boot.
@@ -206,7 +207,7 @@ message DRRArg {
 }
 
 /**
- * the SetQuantumSize function sets a new quantum for DRR module to operate on. 
+ * the SetQuantumSize function sets a new quantum for DRR module to operate on.
  */
 message DRRQuantumArg {
   uint32 quantum = 1;  /// the number of bytes to allocate to each on every round
@@ -214,61 +215,73 @@ message DRRQuantumArg {
 
 /**
  * The SetMaxQueueSize function sets a new maximum flow queue size for DRR module.
- * If the flow's queue gets to this size, the module starts dropping packets to 
- * that flow until the queue is below this size.  
+ * If the flow's queue gets to this size, the module starts dropping packets to
+ * that flow until the queue is below this size.
  */
 message DRRMaxFlowQueueSizeArg {
   uint32 max_queue_size = 1;  /// the max size that any Flows queue can get
 }
 
 /**
- * The module PortInc has a function SetBurst that allows you to specify the maximum number of packets to be stored in a single PacketBatch released by the module.
+ * The module PortInc has a function `set_burst(...)` that allows you to specify the
+ * maximum number of packets to be stored in a single PacketBatch released by
+ * the module.
  */
 message PortIncCommandSetBurstArg {
   int64 burst = 1; /// The maximum "burst" of packets (ie, the maximum batch size)
 }
 
 /**
- * The module QueueInc has a function `setBurst(...)` that allows you to specify the maximum number of packets to be stored in a single PacketBatch released by the module.
+ * The module QueueInc has a function `set_burst(...)` that allows you to specify
+ * the maximum number of packets to be stored in a single PacketBatch released
+ * by the module.
  */
 message QueueIncCommandSetBurstArg {
   int64 burst = 1; /// The maximum "burst" of packets (ie, the maximum batch size)
 }
 
 /**
- * The module QueueInc has a function `setBurst(...)` that allows you to specify the maximum number of packets to be stored in a single PacketBatch released by the module.
+ * The module QueueInc has a function `set_burst(...)` that allows you to specify
+ * the maximum number of packets to be stored in a single PacketBatch released
+ * by the module.
  */
 message QueueCommandSetBurstArg {
   int64 burst = 1; /// The maximum "burst" of packets (ie, the maximum batch size)
 }
 
 /**
- * The module QueueInc has a function `setSize(...)` that allows specifying the size of the queue in total number of packets.
+ * The module QueueInc has a function `set_size(...)` that allows specifying the
+ * size of the queue in total number of packets.
  */
 message QueueCommandSetSizeArg {
   uint64 size = 1; /// The maximum number of packets to store in the queue.
 }
 
 /**
- * The function `clear()` for RandomUpdate takes no parameters and clears all state in the module.
+ * The function `clear()` for RandomUpdate takes no parameters and clears all
+ * state in the module.
  */
 message RandomUpdateCommandClearArg {
 }
 
 /**
- * The function `clear()` for Rewrite takes no parameters and clears all state in the module.
+ * The function `clear()` for Rewrite takes no parameters and clears all state
+ * in the module.
  */
 message RewriteCommandClearArg {
 }
 
 /**
- * The function `clear()` for Update takes no parameters and clears all state in the module.
+ * The function `clear()` for Update takes no parameters and clears all state in
+ * the module.
  */
 message UpdateCommandClearArg {
 }
 
 /**
- * The module WildcardMatch has a command `add(...)` which inserts a new rule into the WildcardMatch module. For an example of code using WilcardMatch see `bess/bessctl/conf/samples/wildcardmatch.bess`.
+ * The module WildcardMatch has a command `add(...)` which inserts a new rule
+ * into the WildcardMatch module. For an example of code using WilcardMatch see
+ * `bess/bessctl/conf/samples/wildcardmatch.bess`.
  */
 message WildcardMatchCommandAddArg {
   uint64 gate = 1; /// Traffic matching this new rule will be sent to this gate.
@@ -294,14 +307,14 @@ message WildcardMatchCommandClearArg {
 
 /**
  * For traffic which does not match any rule in the WildcardMatch module,
- * the `setDefaultGate(...)` function specifies which gate to send this extra traffic to.
+ * the `set_default_gate(...)` function specifies which gate to send this extra traffic to.
  */
 message WildcardMatchCommandSetDefaultGateArg {
   uint64 gate = 1;
 }
 
 /**
- * A rule from the WildcardMatch module. 
+ * A rule from the WildcardMatch module.
  */
 message WildcardMatchRule {
   uint64 gate = 1; /// Traffic matching this new rule will be sent to this gate.
@@ -657,7 +670,7 @@ message QueueIncArg {
   string port = 1; /// The portname to connect to (read from).
   uint64 qid = 2; /// The queue on that port to read from. qid starts from 0.
   int64 burst = 3; /// The maximum number of packets to release in a batch.
-  bool prefetch = 4; ///When prefetch is enabled, the module will perform CPU prefetch on the first 64B of each packet onto CPU L1 cache. Default value is false. 
+  bool prefetch = 4; ///When prefetch is enabled, the module will perform CPU prefetch on the first 64B of each packet onto CPU L1 cache. Default value is false.
 }
 
 /**
@@ -730,7 +743,7 @@ message RewriteArg {
 }
 
 /**
- * The RoundRobin module has a function `setGates(...)` which changes
+ * The RoundRobin module has a function `set_gates(...)` which changes
  * the total number of output gates in the module.
  */
 message RoundRobinCommandSetGatesArg {
@@ -738,7 +751,7 @@ message RoundRobinCommandSetGatesArg {
 }
 
 /**
- * The RoundRobin module has a function `setMode(...)` which specifies whether
+ * The RoundRobin module has a function `set_mode(...)` which specifies whether
  * to balance traffic across gates per-packet or per-batch.
  */
 message RoundRobinCommandSetModeArg {
@@ -769,7 +782,7 @@ message ReplicateArg {
 }
 
 /**
- * The Replicate module has a function `setGates(...)` which changes
+ * The Replicate module has a function `set_gates(...)` which changes
  * the total number of output gates in the module.
  */
 message ReplicateCommandSetGatesArg {
@@ -810,7 +823,7 @@ message SinkArg {
 }
 
 /**
- * The Source module has a function `setBurst(...)` which
+ * The Source module has a function `set_burst(...)` which
  * specifies the maximum number of packets to release in a single packetbatch
  * from the module.
  *
@@ -822,7 +835,7 @@ message SourceCommandSetBurstArg {
 }
 
 /**
- * The Source module has a function `setPktSize(...)` which specifies the size
+ * The Source module has a function `set_pkt_size(...)` which specifies the size
  * of packets to be produced by the Source module.
  */
 message SourceCommandSetPktSizeArg {


### PR DESCRIPTION
Modules commands in the comments are in camelCase. BESS code uses
snake_case.