### PR TITLE
Add clear() command to Measure module

### DIFF
--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -27,6 +27,7 @@ static bool IsTimestamped(bess::Packet *pkt, size_t offset, uint64_t *time) {
 const Commands Measure::cmds = {
     {"get_summary", "EmptyArg", MODULE_CMD_FUNC(&Measure::CommandGetSummary),
      0},
+    {"clear", "EmptyArg", MODULE_CMD_FUNC(&Measure::CommandClear), 0},
 };
 
 pb_error_t Measure::Init(const bess::pb::MeasureArg &arg) {
@@ -118,6 +119,12 @@ pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
   response.mutable_other()->PackFrom(r);
 
   return response;
+}
+
+pb_cmd_response_t Measure::CommandClear(const bess::pb::EmptyArg &) {
+  rtt_hist_.reset();
+  jitter_hist_.reset();
+  return pb_cmd_response_t();
 }
 
 ADD_MODULE(Measure, "measure",

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -27,6 +27,7 @@ class Measure final : public Module {
   void ProcessBatch(bess::PacketBatch *batch) override;
 
   pb_cmd_response_t CommandGetSummary(const bess::pb::EmptyArg &arg);
+  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
 
   static const Commands cmds;
 

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -163,12 +163,6 @@ message L2ForwardCommandPopulateArg {
   int64 gate_count = 3; /// How many gates to create in the L2Forward module.
 }
 
-/**
- * This function requests a summary of the statistics stored in the Measure module.
- * It takes no parameters and returns a GetSummaryResponse.
- */
-message MeasureCommandGetSummaryArg {
-}
 
 /**
  * The Measure module function `getSummary()` takes no parameters and returns the following


### PR DESCRIPTION
At the moment, `Measure` resets the two histograms (RTT and jitter) (with 1M elements each) only when `Histogram::Insert()` is called, i.e., when packets are received. It takes about 10ms, artificially inflating the latency of pending packets. The measurement results will show higher tail latency than it should be.

As a quick fix, this PR adds `clear()` command to reset histograms in an explicit manner, so that the Measure module can perform `Histogram::Insert()` without delayed by histogram reset.

```
bess.pause_all()
stats = measure.get_summary()
measure.clear()                 <- histograms are reset here
bess.resume_all()
...                             <- not here
```