### PR TITLE
traffic_class: Fix descendant removal from RR TC.

### DIFF
--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -322,6 +322,10 @@ bool RoundRobinTrafficClass::RemoveChild(TrafficClass *child) {
       if (next_child_ > i) {
         next_child_--;
       }
+      // Wrap around for round robin.
+      if (next_child_ >= children_.size()) {
+        next_child_ = 0;
+      }
       BlockTowardsRoot();
 
       return true;
@@ -356,6 +360,10 @@ void RoundRobinTrafficClass::BlockTowardsRoot() {
       children_.erase(children_.begin() + i);
       if (next_child_ > i) {
         next_child_--;
+      }
+      // Wrap around for round robin.
+      if (next_child_ >= children_.size()) {
+        next_child_ = 0;
       }
     } else {
       ++i;


### PR DESCRIPTION
If the last unblocked child is blocked or removed, `next_child_` must
wrap around, otherwise bessd may crash.

To reproduce:

```
daemon start
run samples/roundrobin
add module Queue queue0
delete module queue0
add module Queue queue0
delete module queue0
...
```