### PR TITLE
Add a modules option to load the modules from an arbitrary directory

### DIFF
--- a/core/main.cc
+++ b/core/main.cc
@@ -40,8 +40,8 @@ int main(int argc, char *argv[]) {
 
   // Load plugins
   if (!bess::bessd::LoadPlugins(FLAGS_modules)) {
-    PLOG(FATAL) << "LoadPlugins() failed to load from directory: " <<
-      FLAGS_modules;
+    PLOG(FATAL) << "LoadPlugins() failed to load from directory: "
+                << FLAGS_modules;
   }
 
   // TODO(barath): Make these DPDK calls generic, so as to not be so tied to

--- a/core/main.cc
+++ b/core/main.cc
@@ -39,9 +39,9 @@ int main(int argc, char *argv[]) {
   bess::bessd::WritePidfile(pidfile_fd, getpid());
 
   // Load plugins
-  if (!bess::bessd::LoadPlugins(bess::bessd::GetCurrentDirectory() +
-                                "modules")) {
-    PLOG(FATAL) << "LoadPlugins() failed";
+  if (!bess::bessd::LoadPlugins(FLAGS_modules)) {
+    PLOG(FATAL) << "LoadPlugins() failed to load from directory: " <<
+      FLAGS_modules;
   }
 
   // TODO(barath): Make these DPDK calls generic, so as to not be so tied to

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -22,6 +22,7 @@ DEFINE_bool(a, false, "Allow multiple instances");
 DEFINE_bool(no_huge, false, "Disable hugepages");
 DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
 	      "Load modules from the specified directory");
+
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {
     LOG(ERROR) << "Invalid core ID: " << value;

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "worker.h"
+#include "bessd.h"
 
 // Port this BESS instance listens on.
 // Panda came up with this default number
@@ -19,7 +20,8 @@ DEFINE_bool(s, false, "Show TC statistics every second");
 DEFINE_bool(d, false, "Run BESS in debug mode (with debug log messages)");
 DEFINE_bool(a, false, "Allow multiple instances");
 DEFINE_bool(no_huge, false, "Disable hugepages");
-
+DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
+	      "Load modules from the specified directory");
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {
     LOG(ERROR) << "Invalid core ID: " << value;

--- a/core/opts.h
+++ b/core/opts.h
@@ -14,5 +14,6 @@ DECLARE_int32(c);
 DECLARE_int32(p);
 DECLARE_int32(m);
 DECLARE_bool(no_huge);
+DECLARE_string(modules);
 
 #endif  // BESS_OPTS_H_


### PR DESCRIPTION
This option provides a degree of flexibility to BESS installations where the location of bessd is decouple from the location of the module .so's. For example, for consistency with other system daemons, one might install bessd in /usr/bin but the module .so's in /usr/lib/bess/modules. Under such circumstances bessd may be started as such: bessd -modules /usr/lib/bess/modules