### PR TITLE
Do not use "name" as a field name

### DIFF
--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -23,9 +23,8 @@ pb_error_t Split::Init(const bess::pb::SplitArg &arg) {
   mask_ = (size_ == 8) ? 0xffffffffffffffffull
                        : (1ull << (size_ * 8)) - 1;
 
-  const char *name = arg.name().c_str();
-  if (arg.name().length()) {
-    attr_id_ = AddMetadataAttr(name, size_,
+  if (arg.type_case() == bess::pb::SplitArg::kAttribute) {
+    attr_id_ = AddMetadataAttr(arg.attribute().c_str(), size_,
                                bess::metadata::Attribute::AccessMode::kRead);
     if (attr_id_ < 0) {
       return pb_error(-attr_id_, "add_metadata_attr() failed");

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -860,8 +860,10 @@ message SourceArg {
  */
 message SplitArg {
   uint64 size = 1; /// The size of the value to read in bytes
-  string name = 2; /// The name of the metadata field to read.
-  int64 offset = 3; /// The offset (in bytes) of the data field to read.
+  oneof type {
+    string attribute = 2; /// The name of the metadata field to read.
+    int64 offset = 3; /// The offset (in bytes) of the data field to read.
+  }
 }
 
 /**


### PR DESCRIPTION
The Split module has a protobuf type called `SplitArg`, which has `name` field for attribute name. `name` shouldn't be used as a field name though, since it is reserved for module name, e.g., `Split(name='split0', name='attr_foo', size=4)` has two `name`s in its parameter list, causing an error.

This PR changes the field name to `attribute`, which is the field name used by other modules, including `ExactMatch`, `SetMetadata`, etc.

I think there should be some systematic way to check if `name` is misused in `module_msg.proto`, but I am not sure what the best way would be...