### PR TITLE
IPLookup: Parameterize max_rules and max_tbl8s

### DIFF
--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -21,9 +21,11 @@ const Commands IPLookup::cmds = {
     {"add", "IPLookupCommandAddArg", MODULE_CMD_FUNC(&IPLookup::CommandAdd), 0},
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&IPLookup::CommandClear), 0}};
 
-pb_error_t IPLookup::Init(const bess::pb::EmptyArg &) {
+pb_error_t IPLookup::Init(const bess::pb::IPLookupArg &arg) {
   struct rte_lpm_config conf = {
-      .max_rules = 1024, .number_tbl8s = 128, .flags = 0,
+      .max_rules = arg.max_rules() ? arg.max_rules() : 1024,
+      .number_tbl8s = arg.max_tbl8s() ? arg.max_tbl8s() : 128,
+      .flags = 0,
   };
 
   default_gate_ = DROP_GATE;
@@ -142,7 +144,8 @@ pb_cmd_response_t IPLookup::CommandAdd(
 
   if (prefix_len > 32) {
     set_cmd_response_error(
-        &response, pb_error(EINVAL, "Invalid prefix length: %" PRIu64, prefix_len));
+        &response,
+        pb_error(EINVAL, "Invalid prefix length: %" PRIu64, prefix_len));
     return response;
   }
 
@@ -151,8 +154,8 @@ pb_cmd_response_t IPLookup::CommandAdd(
 
   if (ip_addr & ~netmask) {
     set_cmd_response_error(
-        &response, pb_error(EINVAL, "Invalid IP prefix %s/%" PRIu64 " %x %x", prefix,
-                            prefix_len, ip_addr, netmask));
+        &response, pb_error(EINVAL, "Invalid IP prefix %s/%" PRIu64 " %x %x",
+                            prefix, prefix_len, ip_addr, netmask));
     return response;
   }
 

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -12,7 +12,7 @@ class IPLookup final : public Module {
 
   IPLookup() : Module(), lpm_(), default_gate_() {}
 
-  pb_error_t Init(const bess::pb::EmptyArg &arg);
+  pb_error_t Init(const bess::pb::IPLookupArg &arg);
 
   void DeInit() override;
 

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -547,6 +547,8 @@ message IPEncapArg {
  * __Output Gates__: many (configurable, depending on rule values)
  */
 message IPLookupArg {
+  uint32 max_rules = 1; /// Maximum number of rules (default: 1024)
+  uint32 max_tbl8s = 2; /// Maximum number of IP prefixes with smaller than /24 (default: 128)
 }
 
 /**


### PR DESCRIPTION
`max_rules` and `number_tbl8s` of `rte_lpm` were hardcoded. This PR makes them parameters of the module.