### PR TITLE
bessctl: allow pause/resume of individual workers

### DIFF
--- a/bessctl/conf/perftest/flowgen.bess
+++ b/bessctl/conf/perftest/flowgen.bess
@@ -28,17 +28,17 @@ pkt_template = str(eth/ip/tcp/payload)
 # This script is multi threaded but connects to a single port.
 myport = PMDPort(port_id=0, num_inc_q=num_cores, num_out_q=num_cores)
 
-flowgens = []
-for i in range(num_cores):
-    bess.add_worker(wid=i, core=i)
+flowgens = dict()
+for wid in range(num_cores):
+    bess.add_worker(wid=wid, core=wid)
     pkt_src = FlowGen(template = pkt_template, pps = init_pps / num_cores, flow_rate = num_flows / flow_time, flow_duration = flow_time, \
         arrival = 'uniform', duration='uniform', quick_rampup = True)
-    flowgens.append(pkt_src)
-    bess.attach_module(pkt_src.name, wid=i)
+    flowgens[wid] = pkt_src
+    bess.attach_module(pkt_src.name, wid=wid)
 
-    pkt_src -> IPChecksum() -> QueueOut(port=myport, qid = i)
+    pkt_src -> IPChecksum() -> QueueOut(port=myport, qid = wid)
 
-    QueueInc(port=myport, qid=i) -> Sink()
+    QueueInc(port=myport, qid=wid) -> Sink()
 
 bess.resume_all()
 
@@ -50,9 +50,9 @@ while True:
     delta = portstats - prev_portstats
     nextround = max(1e6, 1.1 * delta / sleeptime)
     print("Received " + str(delta / sleeptime) + " pps. Ramping up to: " + str(nextround))
-    bess.pause_all()
-    for pkt_src in flowgens:
+    for wid, pkt_src in flowgens.items():
+        bess.pause_worker(wid)
         pkt_src.update(pps = nextround / num_cores)
-    bess.resume_all()
+        bess.resume_worker(wid)
     time.sleep(sleeptime) # give it some time to warm up to the new rate
     prev_portstats = myport.get_port_stats().inc.packets

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -424,6 +424,11 @@ class BESSControlImpl final : public BESSControl::Service {
   Status PauseWorker(ServerContext*, const PauseWorkerRequest* req,
                      EmptyResponse*) override {
     int wid = req->wid();
+    // TODO: It should be made harder to wreak havoc on the rest of the daemon
+    // when using PauseWorker(). For now a warning and suggestion that this is
+    // for experts only is sufficient.
+    LOG(WARNING) << "PauseWorker() is an experimental operation and should be"
+                 << " used with care. Long-term support not guaranteed.";
     pause_worker(wid);
     LOG(INFO) << "*** Worker " << wid << " has been paused ***";
     return Status::OK;

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -421,6 +421,14 @@ class BESSControlImpl final : public BESSControl::Service {
     return Status::OK;
   }
 
+  Status PauseWorker(ServerContext*, const PauseWorkerRequest* req,
+                     EmptyResponse*) override {
+    int wid = req->wid();
+    pause_worker(wid);
+    LOG(INFO) << "*** Worker " << wid << " has been paused ***";
+    return Status::OK;
+  }
+
   Status ResumeAll(ServerContext*, const EmptyRequest*,
                    EmptyResponse*) override {
     LOG(INFO) << "*** Resuming ***";
@@ -428,6 +436,14 @@ class BESSControlImpl final : public BESSControl::Service {
       attach_orphans();
     }
     resume_all_workers();
+    return Status::OK;
+  }
+
+  Status ResumeWorker(ServerContext*, const ResumeWorkerRequest* req,
+                      EmptyResponse*) override {
+    int wid = req->wid();
+    LOG(INFO) << "*** Resuming worker " << wid << " ***";
+    resume_worker(wid);
     return Status::OK;
   }
 

--- a/core/module.cc
+++ b/core/module.cc
@@ -170,7 +170,11 @@ pb_cmd_response_t ModuleBuilder::RunCommand(
   pb_cmd_response_t response;
   for (auto &cmd : cmds_) {
     if (user_cmd == cmd.cmd) {
-      if (!cmd.mt_safe && is_any_worker_running()) {
+      bool workers_running = false;
+      for (const auto wid : m->active_workers_) {
+        workers_running |= is_worker_running(wid);
+      }
+      if (!cmd.mt_safe && workers_running) {
         set_cmd_response_error(&response,
                                pb_error(EBUSY,
                                         "There is a running worker "

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -71,7 +71,7 @@ int is_worker_core(int cpu) {
   return 0;
 }
 
-static void pause_worker(int wid) {
+void pause_worker(int wid) {
   if (workers[wid] && workers[wid]->status() == WORKER_RUNNING) {
     workers[wid]->set_status(WORKER_PAUSING);
 
@@ -92,7 +92,7 @@ enum class worker_signal : uint64_t {
   quit,
 };
 
-static void resume_worker(int wid) {
+void resume_worker(int wid) {
   if (workers[wid] && workers[wid]->status() == WORKER_PAUSED) {
     int ret;
     worker_signal sig = worker_signal::unblock;

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -169,15 +169,16 @@ void destroy_all_workers() {
     destroy_worker(wid);
 }
 
-int is_any_worker_running() {
+bool is_any_worker_running() {
   int wid;
 
   for (wid = 0; wid < Worker::kMaxWorkers; wid++) {
-    if (workers[wid] && workers[wid]->status() == WORKER_RUNNING)
-      return 1;
+    if (is_worker_running(wid)) {
+      return true;
+    }
   }
 
-  return 0;
+  return false;
 }
 
 void Worker::SetNonWorker() {

--- a/core/worker.h
+++ b/core/worker.h
@@ -143,12 +143,14 @@ extern Worker *volatile workers[Worker::kMaxWorkers];
  * ------------------------------------------------------------------------ */
 int is_worker_core(int cpu);
 
+void pause_worker(int wid);
 void pause_all_workers();
 
 /*!
  * Attach orphan TCs to workers. Note this does not ensure optimal placement.
  */
 void attach_orphans();
+void resume_worker(int wid);
 void resume_all_workers();
 void destroy_worker(int wid);
 void destroy_all_workers();

--- a/core/worker.h
+++ b/core/worker.h
@@ -155,7 +155,7 @@ void resume_all_workers();
 void destroy_worker(int wid);
 void destroy_all_workers();
 
-int is_any_worker_running();
+bool is_any_worker_running();
 
 int is_cpu_present(unsigned int core_id);
 
@@ -163,7 +163,7 @@ static inline int is_worker_active(int wid) {
   return workers[wid] != nullptr;
 }
 
-static inline int is_worker_running(int wid) {
+inline bool is_worker_running(int wid) {
   return workers[wid] && workers[wid]->status() == WORKER_RUNNING;
 }
 

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -187,6 +187,11 @@ class BESS(object):
     def pause_all(self):
         return self._request('PauseAll')
 
+    def pause_worker(self, wid):
+        request = bess_msg.PauseWorkerRequest()
+        request.wid = wid
+        return self._request('PauseWorker', request)
+
     def check_constraints(self):
         response = self.check_scheduling_constraints()
         if len(response.violations) != 0 or len(response.modules) != 0:
@@ -228,6 +233,11 @@ class BESS(object):
             return self.check_resume_all()
         else:
             return self.uncheck_resume_all()
+
+    def resume_worker(self, wid):
+        request = bess_msg.ResumeWorkerRequest()
+        request.wid = wid
+        return self._request('ResumeWorker', request)
 
     def check_scheduling_constraints(self):
         return self._request('CheckSchedulingConstraints')

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -435,3 +435,15 @@ message DisableTcpdumpRequest {
 
   // FIXME: use oneof {igate, ogate)
 }
+
+//  -------------------------------------------------------------------------
+//  Worker maniuplation
+//  -------------------------------------------------------------------------
+
+message PauseWorkerRequest {
+  int64 wid = 1;    /// ID of the worker to be paused
+}
+
+message ResumeWorkerRequest {
+  int64 wid = 1;    /// ID of the worker to be resumed
+}

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -72,6 +72,22 @@ service BESSControl {
   /// Keep the duration as short as possible, to avoid packet drops.
   rpc PauseAll (EmptyRequest) returns (EmptyResponse) {}
 
+  /// Pause the specified worker temporarily
+  ///
+  /// Some RPC commands to BESS or individual modules/ports require that
+  /// threads must be inactive, to avoid race conditions.
+  /// For such commands, use PauseWorker at the beginning and ResumeWorker at the end.
+  ///  PauseWorker(0)
+  ///   SomeCommand1()
+  ///   SomeCommand2()
+  ///   ...
+  ///  ResumeWorker(0)
+  /// Keep the duration as short as possible, to avoid packet drops.
+  rpc PauseWorker (PauseWorkerRequest) returns (EmptyResponse) {}
+
+  /// Resume the specified worker
+  rpc ResumeWorker (ResumeWorkerRequest) returns (EmptyResponse) {}
+
   /// Resume all paused workers
   rpc ResumeAll (EmptyRequest) returns (EmptyResponse) {}
 


### PR DESCRIPTION
Some operations only operate on datastructure within a single worker
(e.g., poking the Measure module). Pausing all workers for such
operations can lead to unecessary packet drops by workers that have
nothing to do with the operation anyway. To the end of making this
behavior avoidable , this patch exposes `pause_worker()` and
`resume_worker()` and adds corresponding RPCs.