### PR TITLE
Remove print statement confirming no-violations.

### DIFF
--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -209,8 +209,6 @@ class BESS(object):
             for module in response.modules:
                 print 'constraints violated for module %s --'\
                     ' please check bessd log' % module.name
-        else:
-            print 'No violations found'
         if response.fatal:
             raise self.ConstraintError("Fatal violation of "
                                        "scheduling constraints")


### PR DESCRIPTION
The new safety checking features print out "No violations" every time one runs a command in bessctl. This gets tedious -- it's likely easier to have the code only print if violations are found, and just silently succeed when there are no problems.