### PR TITLE
Minor updates to git pre-commit hook

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -44,6 +44,8 @@ get_patch() {
 }
 
 apply_and_commit() {
+	# The "git add" we use below do not work with non-default index file,
+	# which is used by "git commit -a" or "git commit <files>"
 	if [[ $GIT_INDEX_FILE != ".git/index" ]]; then
 		echo "Error: Non-default index file is being used (GIT_INDEX_FILE is set)." >&2
 		echo "       Are you using 'git commit [--only] -- <files>' to bypass staging?" >&2

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -40,12 +40,12 @@ refresh_commit() {
 }
 
 if ! command_exists $CXX_FORMAT; then
-	echo "Error: $CXX_FORMAT executable not found.\n" >&2
+	echo "Error: '$CXX_FORMAT' not found." >&2
 	exit 1
 fi
 
 if ! command_exists $PY_FORMAT; then
-	echo "Error: $PY_FORMAT executable not found. Try 'pip install $PY_FORMAT'?\n" >&2
+	echo "Error: '$PY_FORMAT' not found. Try 'pip install $PY_FORMAT'?" >&2
 	exit 1
 fi
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-CXX_FORMAT="clang-format"
-CXX_EXTS=".c .h .cpp .hpp .cc .hh .cxx .hxx"
 
-PY_FORMAT="autopep8"
+: ${CXX_FORMAT:=clang-format}
+: ${PY_FORMAT:=autopep8}
+
+CXX_EXTS=".c .h .cpp .hpp .cc .hh .cxx .hxx"
 PY_EXTS=".py"
 
 command_exists() {

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -61,7 +61,7 @@ if [[ ! -z $patch ]]; then
 	echo "y - commit without reformatting (not recommended)"
 	echo "r - apply the patch and commit"
 	echo "n - abort"
-	read -p "Do you want to commit anyway? [y/r/N]" yn
+	read -p "Do you want to commit anyway? [y/r/N] " yn
 	case $yn in
 		[Yy]* ) exit 0;;
 		[Rr]* ) (echo "$patch" | git apply -) && refresh_commit && exit 0;;

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -41,11 +41,13 @@ refresh_commit() {
 
 if ! command_exists $CXX_FORMAT; then
 	echo "Error: '$CXX_FORMAT' not found." >&2
+	echo "       Use '--no-verify' to bypass format checker (not recommended)" >&2
 	exit 1
 fi
 
 if ! command_exists $PY_FORMAT; then
 	echo "Error: '$PY_FORMAT' not found. Try 'pip install $PY_FORMAT'?" >&2
+	echo "       Use '--no-verify' to bypass format checker (not recommended)" >&2
 	exit 1
 fi
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -19,14 +19,13 @@ match_extension() {
 	return 1
 }
 
-show_patch() {
-	local diff=""
+get_patch() {
 	local reformatted=""
 	local file
+	patch=""
 
 	for file in $files; do
 		if match_extension $file "$CXX_EXTS"; then
-			echo "hi"
 			reformatted=`$CXX_FORMAT -style=file $file`
 		elif match_extension $file "$PY_EXTS"; then
 			reformatted=`$PY_FORMAT $file`
@@ -38,13 +37,14 @@ show_patch() {
 		echo "$reformatted" | git diff --no-index --color=always $file -
 
 		# ... and save non-colored patch for git-apply
-		diff+=`echo "$reformatted" | diff -u $file - | \
+		patch+=`echo "$reformatted" | diff -u $file - | \
 			sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|"`
+		patch+=$'\n'
 	done
 }
 
 apply_and_commit() {
-	if [[ ! -z $GIT_INDEX_FILE ]]; then
+	if [[ $GIT_INDEX_FILE != ".git/index" ]]; then
 		echo "Error: Non-default index file is being used (GIT_INDEX_FILE is set)." >&2
 		echo "       Are you using 'git commit [--only] -- <files>' to bypass staging?" >&2
 		exit 1
@@ -76,9 +76,8 @@ fi
 exec < /dev/tty
 
 files=`git diff-index --cached --name-only HEAD`
-patch=$(show_patch)
+get_patch
 if [[ ! -z $patch ]]; then
-	echo "$patch"
 	echo "==========================================="
 	echo "Files in the commit do not comply with the formatting rules. Options:"
 	echo "y - commit without reformatting (not recommended)"

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -21,7 +21,7 @@ match_extension() {
 
 show_patch() {
 	local diff=""
-	for file in `git diff-index --cached --name-only HEAD` ; do
+	for file in $files; do
 		if match_extension $file "$CXX_EXTS"; then
 			diff+=$($CXX_FORMAT -style=file $file | diff -u $file - | \
 				sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|")
@@ -34,9 +34,7 @@ show_patch() {
 }
 
 refresh_commit() {
-	for file in `git diff-index --cached --name-only HEAD` ; do
-		git add $file
-	done
+	git add -- $files
 }
 
 if ! command_exists $CXX_FORMAT; then
@@ -54,6 +52,7 @@ fi
 # Allows us to read user input below, assigns stdin to keyboard
 exec < /dev/tty
 
+files=`git diff-index --cached --name-only HEAD`
 patch=$(show_patch)
 if [[ ! -z $patch ]]; then
 	echo "$patch"

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -21,16 +21,26 @@ match_extension() {
 
 show_patch() {
 	local diff=""
+	local reformatted=""
+	local file
+
 	for file in $files; do
 		if match_extension $file "$CXX_EXTS"; then
-			diff+=$($CXX_FORMAT -style=file $file | diff -u $file - | \
-				sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|")
+			echo "hi"
+			reformatted=`$CXX_FORMAT -style=file $file`
 		elif match_extension $file "$PY_EXTS"; then
-			diff+=$($PY_FORMAT $file | diff -u $file - | \
-				sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|")
+			reformatted=`$PY_FORMAT $file`
+		else
+			continue
 		fi
+
+		# show colored version to the user
+		echo "$reformatted" | git diff --no-index --color=always $file -
+
+		# ... and save non-colored patch for git-apply
+		diff+=`echo "$reformatted" | diff -u $file - | \
+			sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|"`
 	done
-	echo "$diff"
 }
 
 apply_and_commit() {
@@ -47,7 +57,7 @@ apply_and_commit() {
 	fi
 
 	(echo "$patch" | git apply -)
-	git add -- $file
+	git add -- $files
 }
 
 if ! command_exists $CXX_FORMAT; then

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -33,8 +33,15 @@ show_patch() {
 	echo "$diff"
 }
 
-refresh_commit() {
-	git add -- $files
+apply_and_commit() {
+	if [[ ! -z $GIT_INDEX_FILE ]]; then
+		echo "Error: Non-default index file is being used (GIT_INDEX_FILE is set)." >&2
+		echo "       Are you using 'git commit [--only] -- <files>' to bypass staging?" >&2
+		exit 1
+	fi
+
+	(echo "$patch" | git apply -)
+	git add -- $file
 }
 
 if ! command_exists $CXX_FORMAT; then
@@ -64,7 +71,7 @@ if [[ ! -z $patch ]]; then
 	read -p "Do you want to commit anyway? [y/r/N] " yn
 	case $yn in
 		[Yy]* ) exit 0;;
-		[Rr]* ) (echo "$patch" | git apply -) && refresh_commit && exit 0;;
+		[Rr]* ) apply_and_commit && exit 0;;
 		* ) exit 1;;
 	esac
 fi

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -40,6 +40,12 @@ apply_and_commit() {
 		exit 1
 	fi
 
+	# Do some files have partial commits? (only some portion of a file is staged)
+	if [[ ! -z $(git diff -- $files) ]]; then
+		echo "Error: Partial commits are not supported." >&2
+		exit 1
+	fi
+
 	(echo "$patch" | git apply -)
 	git add -- $file
 }


### PR DESCRIPTION
* Fix errors caused by `@echo`
* Formatters are now customizable (e.g., `clang-format-3.7` instead of `clang-format`)
* Detect corner cases that are not correctly handled by the script:
  * Bypassed staging with `git commit -a` or `git commit -- <files>`
  * Partial staging with `git add --patch`
* Show reformatting differences in color

Will need to rebase this PR once #426 is merged, since there are some overlaps.