### PR TITLE
Fix bessctl auto completion with special chars

### DIFF
--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -215,12 +215,6 @@ class CLI(object):
         candidates = []
         num_full_matches = 0
 
-        # ignore partial_word set by readline
-        if len(line) > 0 and line[-1] != ' ':
-            partial_word = line.split()[-1]
-        else:
-            partial_word = ''
-
         for cmd in self.cmdlist:
             syntax = cmd[0]
             match_type, sub_candidates, \
@@ -254,13 +248,7 @@ class CLI(object):
 
             if common_prefix and len(partial_word) < len(common_prefix):
                 if partial_word == common_prefix[:len(partial_word)]:
-                    ret = []
-                    skip = partial_word.rfind('/') + 1
-                    for candidate in candidates:
-                        candidate = candidate[skip:]
-                        ret.append(candidate)
-
-                    return ret
+                    return candidates
 
         buf = []
 
@@ -465,6 +453,10 @@ class CLI(object):
             self.rl.parse_and_bind('tab: complete')
 
         self.rl.set_completer(self.complete)
+
+        # Remove `~!@#$%^&*()-=+[{]}\|;:'",<>?/ from readline delimiters
+        # leaving only space, tab, LF
+        self.rl.set_completer_delims(' \x09\x0a')
 
         try:
             if self.history_file and os.path.exists(self.history_file):


### PR DESCRIPTION
`readline` treats some special characters (including backtick and `~!@#$%^&*()-=+[{]}\|;:'",<>?/` as delimiters. This behavior interferes with `bessctl` causing incorrect auto completions. Examples:

```
localhost:10514 $ track disable *<tab>
localhost:10514 $ track disable ** _
...
localhost:10514 $ run file ~/my-modu<tab>
localhost:10514 $ run file ~/my-my-modules/_
```

This PR fixes the issue by declaring such characters non-delimiters.