### PR TITLE
rewrite: Honor round robin behavior.

### DIFF
--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -107,7 +107,7 @@ inline void Rewrite::DoRewrite(bess::PacketBatch *batch) {
 
   next_turn_ = start + cnt;
   if (next_turn_ >= bess::PacketBatch::kMaxBurst) {
-    next_turn_ -= bess::PacketBatch::kMaxBurst;
+    next_turn_ = next_turn_ % num_templates_;
   }
 }
 


### PR DESCRIPTION
The Rewrite module is not really round robin (e.g., by looking at the
`show pipeline` numbers for `samples/exactmatch`, we can notice a
slight difference between gates that are supposed to have the same
rate).

This commit fixes the problem.