### PR TITLE
Refactor return type of Module/Port Init() and commands

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -77,13 +77,13 @@ class BESSCLI(cli.CLI):
         except self.bess.Error as e:
             self.err(e.errmsg)
 
-            if e.err in errno.errorcode:
-                err_code = errno.errorcode[e.err]
+            if e.code in errno.errorcode:
+                err_code = errno.errorcode[e.code]
             else:
                 err_code = '<unknown>'
 
             self.ferr.write('  BESS daemon response - errno=%d (%s: %s)\n' %
-                            (e.err, err_code, os.strerror(e.err)))
+                            (e.code, err_code, os.strerror(e.code)))
 
             raise self.HandledError()
 

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -85,17 +85,6 @@ class BESSCLI(cli.CLI):
             self.ferr.write('  BESS daemon response - errno=%d (%s: %s)\n' %
                             (e.err, err_code, os.strerror(e.err)))
 
-            if e.details:
-                details = pprint.pformat(e.details)
-                initial_indent = '  error details: '
-                subsequent_indent = ' ' * len(initial_indent)
-
-                for i, line in enumerate(details.splitlines()):
-                    if i == 0:
-                        self.fout.write('%s%s\n' % (initial_indent, line))
-                    else:
-                        self.fout.write('%s%s\n' % (subsequent_indent, line))
-
             raise self.HandledError()
 
     def _print_crashlog(self):

--- a/bessctl/conf/samples/l2_forward.bess
+++ b/bessctl/conf/samples/l2_forward.bess
@@ -7,7 +7,6 @@ def test_lookup():
     ret = l2fib.add(entries=[{'addr':'00:01:02:03:04:05', 'gate':64},
                             {'addr':'aa:bb:cc:dd:ee:ff', 'gate':1},
                             {'addr':'11:11:11:11:11:22', 'gate':2}])
-    assert ret.error.err == 0, 'Incorrect response'
     print '  OK. Response:', ret
 
     print '2. Adding entry again expecting failure'
@@ -25,7 +24,6 @@ def test_lookup():
 
     print '4. Removing Entry'
     ret = l2fib.delete(addrs=['00:01:02:03:04:05'])
-    assert ret.error.err == 0, 'Incorrect response'
     print '  OK. Response:', ret
 
     print '5. Querying entry again expecting failure'

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -56,7 +56,7 @@ static inline Status return_with_error(T* response, int code, const char* fmt,
                                        ...) {
   va_list ap;
   va_start(ap, fmt);
-  response->mutable_error()->set_err(code);
+  response->mutable_error()->set_code(code);
   response->mutable_error()->set_errmsg(bess::utils::FormatVarg(fmt, ap));
   va_end(ap);
   return Status::OK;
@@ -64,7 +64,7 @@ static inline Status return_with_error(T* response, int code, const char* fmt,
 
 template <typename T>
 static inline Status return_with_errno(T* response, int code) {
-  response->mutable_error()->set_err(code);
+  response->mutable_error()->set_code(code);
   response->mutable_error()->set_errmsg(strerror(code));
   return Status::OK;
 }
@@ -252,7 +252,7 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
 
   if (mac_addr_str.length() > 0) {
     if (!mac_addr.FromString(mac_addr_str)) {
-      perr->set_err(EINVAL);
+      perr->set_code(EINVAL);
       perr->set_errmsg(
           "MAC address should be "
           "formatted as a string "
@@ -264,13 +264,13 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
   }
 
   if (num_inc_q > MAX_QUEUES_PER_DIR || num_out_q > MAX_QUEUES_PER_DIR) {
-    perr->set_err(EINVAL);
+    perr->set_code(EINVAL);
     perr->set_errmsg("Invalid number of queues");
     return nullptr;
   }
 
   if (size_inc_q > MAX_QUEUE_SIZE || size_out_q > MAX_QUEUE_SIZE) {
-    perr->set_err(EINVAL);
+    perr->set_code(EINVAL);
     perr->set_errmsg("Invalid queue size");
     return nullptr;
   }
@@ -279,7 +279,7 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
 
   if (name.length() > 0) {
     if (PortBuilder::all_ports().count(name)) {
-      perr->set_err(EEXIST);
+      perr->set_code(EEXIST);
       perr->set_errmsg(
           bess::utils::Format("Port '%s' already exists", name.c_str()));
       return nullptr;
@@ -311,7 +311,7 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
   ctx.SetNonWorker();
 
   *perr = p->InitWithGenericArg(arg);
-  if (perr->err() != 0) {
+  if (perr->code() != 0) {
     return nullptr;
   }
 
@@ -331,7 +331,7 @@ static Module* create_module(const std::string& name,
   // DPDK functions may be called, so be prepared
   ctx.SetNonWorker();
   *perr = m->InitWithGenericArg(arg);
-  if (perr->err() != 0) {
+  if (perr->code() != 0) {
     VLOG(1) << perr->DebugString();
     ModuleBuilder::DestroyModule(m);
     return nullptr;
@@ -392,22 +392,22 @@ class BESSControlImpl final : public BESSControl::Service {
     LOG(INFO) << "*** ResetAll requested ***";
 
     status = ResetModules(context, request, response);
-    if (response->error().err() != 0) {
+    if (response->error().code() != 0) {
       return status;
     }
 
     status = ResetPorts(context, request, response);
-    if (response->error().err() != 0) {
+    if (response->error().code() != 0) {
       return status;
     }
 
     status = ResetTcs(context, request, response);
-    if (response->error().err() != 0) {
+    if (response->error().code() != 0) {
       return status;
     }
 
     status = ResetWorkers(context, request, response);
-    if (response->error().err() != 0) {
+    if (response->error().code() != 0) {
       return status;
     }
 
@@ -1325,7 +1325,7 @@ class BESSControlImpl final : public BESSControl::Service {
         *error =
             enable_track_for_module(it.second, request->gate(),
                                     request->is_igate(), request->use_gate());
-        if (error->err() != 0) {
+        if (error->code() != 0) {
           return Status::OK;
         }
       }
@@ -1354,7 +1354,7 @@ class BESSControlImpl final : public BESSControl::Service {
         *error =
             disable_track_for_module(it.second, request->gate(),
                                      request->is_igate(), request->use_gate());
-        if (error->err() != 0) {
+        if (error->code() != 0) {
           return Status::OK;
         }
       }

--- a/core/bessd_test.cc
+++ b/core/bessd_test.cc
@@ -225,9 +225,11 @@ TEST(TryAcquirePidfileLock, AlreadyHeldPidReadFails) {
 // Checks that trying to check for a unique instance with a bad pidfile path
 // dies.
 TEST(CheckUniqueInstance, BadPidfilePath) {
-  // Assume we don't have permission to write to this path:
-  const std::string kNoPermissionPath("/dev/nopermission");
-  EXPECT_DEATH(CheckUniqueInstance(kNoPermissionPath), "");
+  if (geteuid()) {
+    // Assume we don't have permission to write to this path:
+    const std::string kNoPermissionPath("/dev/nopermission");
+    EXPECT_DEATH(CheckUniqueInstance(kNoPermissionPath), "");
+  }
 }
 
 // Checks that the combined routine to check for a unique instance works when

--- a/core/drivers/pcap.cc
+++ b/core/drivers/pcap.cc
@@ -2,23 +2,23 @@
 
 #include "../utils/pcap.h"
 
-pb_error_t PCAPPort::Init(const bess::pb::PCAPPortArg& arg) {
+CommandResponse PCAPPort::Init(const bess::pb::PCAPPortArg& arg) {
   if (pcap_handle_.is_initialized()) {
-    return pb_error(EINVAL, "Device already initialized.");
+    return CommandFailure(EINVAL, "Device already initialized.");
   }
 
   const std::string dev = arg.dev();
   pcap_handle_ = PcapHandle(dev);
 
   if (!pcap_handle_.is_initialized()) {
-    return pb_error(EINVAL, "Error initializing device.");
+    return CommandFailure(EINVAL, "Error initializing device.");
   }
 
   if (pcap_handle_.SetBlocking(false)) {
-    return pb_error(EINVAL, "Error initializing device.");
+    return CommandFailure(EINVAL, "Error initializing device.");
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void PCAPPort::DeInit() {

--- a/core/drivers/pcap.h
+++ b/core/drivers/pcap.h
@@ -13,7 +13,7 @@
 // needs more tests!
 class PCAPPort final : public Port {
  public:
-  pb_error_t Init(const bess::pb::PCAPPortArg &arg);
+  CommandResponse Init(const bess::pb::PCAPPortArg &arg);
 
   void DeInit() override;
   // PCAP has no notion of queue so unlike parent (port.cc) quid is ignored.

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -205,7 +205,7 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
       return pb_error(EINVAL, "No port specified");
   }
 
-  if (err.err() != 0) {
+  if (err.code() != 0) {
     return err;
   }
 
@@ -280,7 +280,8 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
   dpdk_port_id_ = ret_port_id;
 
   numa_node = rte_eth_dev_socket_id(static_cast<int>(ret_port_id));
-  node_placement_ = numa_node == -1 ? UNCONSTRAINED_SOCKET : (1ull << numa_node);
+  node_placement_ =
+      numa_node == -1 ? UNCONSTRAINED_SOCKET : (1ull << numa_node);
 
   rte_eth_macaddr_get(dpdk_port_id_, reinterpret_cast<ether_addr *>(&mac_addr));
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -76,17 +76,17 @@ void PMDPort::InitDriver() {
 // returns 0 and sets *ret_port_id to "port_id" if the port is valid and
 // available.
 // returns > 0 on error.
-static pb_error_t find_dpdk_port_by_id(dpdk_port_t port_id,
-                                       dpdk_port_t *ret_port_id) {
+static CommandResponse find_dpdk_port_by_id(dpdk_port_t port_id,
+                                            dpdk_port_t *ret_port_id) {
   if (port_id >= RTE_MAX_ETHPORTS) {
-    return pb_error(EINVAL, "Invalid port id %d", port_id);
+    return CommandFailure(EINVAL, "Invalid port id %d", port_id);
   }
   if (!rte_eth_devices[port_id].attached) {
-    return pb_error(ENODEV, "Port id %d is not available", port_id);
+    return CommandFailure(ENODEV, "Port id %d is not available", port_id);
   }
 
   *ret_port_id = port_id;
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 // Find a port attached to DPDK by its PCI address.
@@ -94,21 +94,21 @@ static pb_error_t find_dpdk_port_by_id(dpdk_port_t port_id,
 // "pci" if it is valid and available. *ret_hot_plugged is set to true if the
 // device was attached to DPDK as a result of calling this function.
 // returns > 0 on error.
-static pb_error_t find_dpdk_port_by_pci_addr(const std::string &pci,
-                                             dpdk_port_t *ret_port_id,
-                                             bool *ret_hot_plugged) {
+static CommandResponse find_dpdk_port_by_pci_addr(const std::string &pci,
+                                                  dpdk_port_t *ret_port_id,
+                                                  bool *ret_hot_plugged) {
   dpdk_port_t port_id = DPDK_PORT_UNKNOWN;
   struct rte_pci_addr addr;
 
   if (pci.length() == 0) {
-    return pb_error(EINVAL, "No PCI address specified");
+    return CommandFailure(EINVAL, "No PCI address specified");
   }
 
   if (eal_parse_pci_DomBDF(pci.c_str(), &addr) != 0 &&
       eal_parse_pci_BDF(pci.c_str(), &addr) != 0) {
-    return pb_error(EINVAL,
-                    "PCI address must be like "
-                    "dddd:bb:dd.ff or bb:dd.ff");
+    return CommandFailure(EINVAL,
+                          "PCI address must be like "
+                          "dddd:bb:dd.ff or bb:dd.ff");
   }
 
   dpdk_port_t num_dpdk_ports = rte_eth_dev_count();
@@ -134,14 +134,14 @@ static pb_error_t find_dpdk_port_by_pci_addr(const std::string &pci,
     ret = rte_eth_dev_attach(name, &port_id);
 
     if (ret < 0) {
-      return pb_error(ENODEV, "Cannot attach PCI device %s", name);
+      return CommandFailure(ENODEV, "Cannot attach PCI device %s", name);
     }
 
     *ret_hot_plugged = true;
   }
 
   *ret_port_id = port_id;
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 // Find a DPDK vdev by name.
@@ -149,28 +149,28 @@ static pb_error_t find_dpdk_port_by_pci_addr(const std::string &pci,
 // available. *ret_hot_plugged is set to true if the device was attached to
 // DPDK as a result of calling this function.
 // returns > 0 on error.
-static pb_error_t find_dpdk_vdev(const std::string &vdev,
-                                 dpdk_port_t *ret_port_id,
-                                 bool *ret_hot_plugged) {
+static CommandResponse find_dpdk_vdev(const std::string &vdev,
+                                      dpdk_port_t *ret_port_id,
+                                      bool *ret_hot_plugged) {
   dpdk_port_t port_id = DPDK_PORT_UNKNOWN;
 
   if (vdev.length() == 0) {
-    return pb_error(EINVAL, "No vdev specified");
+    return CommandFailure(EINVAL, "No vdev specified");
   }
 
   const char *name = vdev.c_str();
   int ret = rte_eth_dev_attach(name, &port_id);
 
   if (ret < 0) {
-    return pb_error(ENODEV, "Cannot attach vdev %s", name);
+    return CommandFailure(ENODEV, "Cannot attach vdev %s", name);
   }
 
   *ret_hot_plugged = true;
   *ret_port_id = port_id;
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
-pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
+CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
   dpdk_port_t ret_port_id = DPDK_PORT_UNKNOWN;
 
   struct rte_eth_dev_info dev_info;
@@ -187,7 +187,7 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
 
   int numa_node = -1;
 
-  pb_error_t err;
+  CommandResponse err;
   switch (arg.port_case()) {
     case bess::pb::PMDPortArg::kPortId: {
       err = find_dpdk_port_by_id(arg.port_id(), &ret_port_id);
@@ -202,15 +202,15 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
       break;
     }
     default:
-      return pb_error(EINVAL, "No port specified");
+      return CommandFailure(EINVAL, "No port specified");
   }
 
-  if (err.code() != 0) {
+  if (err.error().code() != 0) {
     return err;
   }
 
   if (ret_port_id == DPDK_PORT_UNKNOWN) {
-    return pb_error(ENOENT, "Port not found");
+    return CommandFailure(ENOENT, "Port not found");
   }
 
   eth_conf = default_eth_conf();
@@ -240,7 +240,7 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
 
   ret = rte_eth_dev_configure(ret_port_id, num_rxq, num_txq, &eth_conf);
   if (ret != 0) {
-    return pb_error(-ret, "rte_eth_dev_configure() failed");
+    return CommandFailure(-ret, "rte_eth_dev_configure() failed");
   }
   rte_eth_promiscuous_enable(ret_port_id);
 
@@ -252,7 +252,7 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
     ret = rte_eth_tx_queue_setup(ret_port_id, i, queue_size[PACKET_DIR_OUT],
                                  sid, &eth_txconf);
     if (ret != 0) {
-      return pb_error(-ret, "rte_eth_tx_queue_setup() failed");
+      return CommandFailure(-ret, "rte_eth_tx_queue_setup() failed");
     }
   }
 
@@ -268,13 +268,13 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
         rte_eth_rx_queue_setup(ret_port_id, i, queue_size[PACKET_DIR_INC], sid,
                                &eth_rxconf, bess::get_pframe_pool_socket(sid));
     if (ret != 0) {
-      return pb_error(-ret, "rte_eth_rx_queue_setup() failed");
+      return CommandFailure(-ret, "rte_eth_rx_queue_setup() failed");
     }
   }
 
   ret = rte_eth_dev_start(ret_port_id);
   if (ret != 0) {
-    return pb_error(-ret, "rte_eth_dev_start() failed");
+    return CommandFailure(-ret, "rte_eth_dev_start() failed");
   }
 
   dpdk_port_id_ = ret_port_id;
@@ -288,7 +288,7 @@ pb_error_t PMDPort::Init(const bess::pb::PMDPortArg &arg) {
   // Reset hardware stat counters, as they may still contain previous data
   CollectStats(true);
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void PMDPort::DeInit() {

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -41,7 +41,7 @@ class PMDPort final : public Port {
    * EXPECTS:
    * * Must specify exactly one of port_id or PCI or vdev.
    */
-  pb_error_t Init(const bess::pb::PMDPortArg &arg);
+  CommandResponse Init(const bess::pb::PMDPortArg &arg);
 
   /*!
    * Release the device.

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -36,7 +36,7 @@ class UnixSocketPort final : public Port {
    * PARAMETERS:
    * * string path : file name to bind the socket ti.
    */
-  pb_error_t Init(const bess::pb::UnixSocketPortArg &arg);
+  CommandResponse Init(const bess::pb::UnixSocketPortArg &arg);
 
   /*!
    * Close the socket / shut down the port.

--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -141,12 +141,8 @@ static pb_error_t docker_container_pid(const std::string &cid,
 
   fp = popen(buf, "r");
   if (!fp) {
-    const std::string details =
-        bess::utils::Format("popen() errno=%d (%s)", errno, strerror(errno));
-
-    return pb_error_details(
-        ESRCH, details.c_str(),
-        "Command 'docker' is not available. (not installed?)");
+    return pb_error(ESRCH,
+                    "Command 'docker' is not available. (not installed?)");
   }
 
   ret = fread(buf, 1, sizeof(buf) - 1, fp);
@@ -162,12 +158,7 @@ static pb_error_t docker_container_pid(const std::string &cid,
   exit_code = WEXITSTATUS(ret);
 
   if (exit_code != 0 || sscanf(buf, "%d", container_pid) == 0) {
-    // TODO(clan): Need to fully replicate the map in details
-    // snobj_map_set(details, "exit_code", snobj_int(exit_code));
-    // snobj_map_set(details, "docker_err", snobj_str(buf));
-
-    return pb_error_details(ESRCH, buf, "Cannot find the PID of container %s",
-                            cid.c_str());
+    return pb_error(ESRCH, "Cannot find the PID of container %s", cid.c_str());
   }
 
   return pb_errno(0);
@@ -493,7 +484,7 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
 
   ret = ioctl(fd_, SN_IOC_CREATE_HOSTNIC, &phy_addr);
   if (ret < 0) {
-    err = pb_errno_details(-ret, "SN_IOC_CREATE_HOSTNIC failure");
+    err = pb_error(-ret, "SN_IOC_CREATE_HOSTNIC failure");
     goto fail;
   }
 

--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -448,7 +448,7 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
 
   if (arg.cpid_case() == bess::pb::VPortArg::kDocker) {
     err = docker_container_pid(arg.docker(), &container_pid_);
-    if (err.err() != 0)
+    if (err.code() != 0)
       goto fail;
   } else if (arg.cpid_case() == bess::pb::VPortArg::kContainerPid) {
     container_pid_ = arg.container_pid();
@@ -491,7 +491,7 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
   if (arg.ip_addrs_size() > 0) {
     err = SetIPAddr(arg);
 
-    if (err.err() != 0) {
+    if (err.code() != 0) {
       DeInit();
       goto fail;
     }

--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -116,8 +116,8 @@ static void reclaim_packets(struct llring *ring) {
   }
 }
 
-static pb_error_t docker_container_pid(const std::string &cid,
-                                       int *container_pid) {
+static CommandResponse docker_container_pid(const std::string &cid,
+                                            int *container_pid) {
   char buf[1024];
 
   FILE *fp;
@@ -126,31 +126,31 @@ static pb_error_t docker_container_pid(const std::string &cid,
   int exit_code;
 
   if (cid.length() == 0)
-    return pb_error(EINVAL,
-                    "field 'docker' should be "
-                    "a containder ID or name in string");
+    return CommandFailure(EINVAL,
+                          "field 'docker' should be "
+                          "a containder ID or name in string");
 
   ret = snprintf(buf, static_cast<int>(sizeof(buf)),
                  "docker inspect --format '{{.State.Pid}}' "
                  "%s 2>&1",
                  cid.c_str());
   if (ret >= static_cast<int>(sizeof(buf)))
-    return pb_error(EINVAL,
-                    "The specified Docker "
-                    "container ID or name is too long");
+    return CommandFailure(EINVAL,
+                          "The specified Docker "
+                          "container ID or name is too long");
 
   fp = popen(buf, "r");
   if (!fp) {
-    return pb_error(ESRCH,
-                    "Command 'docker' is not available. (not installed?)");
+    return CommandFailure(
+        ESRCH, "Command 'docker' is not available. (not installed?)");
   }
 
   ret = fread(buf, 1, sizeof(buf) - 1, fp);
   if (ret == 0)
-    return pb_error(ENOENT,
-                    "Cannot find the PID of "
-                    "container %s",
-                    cid.c_str());
+    return CommandFailure(ENOENT,
+                          "Cannot find the PID of "
+                          "container %s",
+                          cid.c_str());
 
   buf[ret] = '\0';
 
@@ -158,10 +158,11 @@ static pb_error_t docker_container_pid(const std::string &cid,
   exit_code = WEXITSTATUS(ret);
 
   if (exit_code != 0 || sscanf(buf, "%d", container_pid) == 0) {
-    return pb_error(ESRCH, "Cannot find the PID of container %s", cid.c_str());
+    return CommandFailure(ESRCH, "Cannot find the PID of container %s",
+                          cid.c_str());
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 static int next_cpu;
@@ -323,7 +324,7 @@ int VPort::SetIPAddrSingle(const std::string &ip_addr) {
   return 0;
 }
 
-pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
+CommandResponse VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
   int child_pid = 0;
 
   int ret = 0;
@@ -335,7 +336,7 @@ pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
 
     child_pid = fork();
     if (child_pid < 0) {
-      return pb_errno(-child_pid);
+      return CommandFailure(-child_pid);
     }
 
     if (child_pid == 0) {
@@ -401,12 +402,12 @@ pb_error_t VPort::SetIPAddr(const bess::pb::VPortArg &arg) {
   }
 
   if (ret < 0) {
-    return pb_error(-ret,
-                    "Failed to set IP addresses "
-                    "(incorrect IP address format?)");
+    return CommandFailure(-ret,
+                          "Failed to set IP addresses "
+                          "(incorrect IP address format?)");
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void VPort::DeInit() {
@@ -420,8 +421,8 @@ void VPort::DeInit() {
   FreeBar();
 }
 
-pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
-  pb_error_t err;
+CommandResponse VPort::Init(const bess::pb::VPortArg &arg) {
+  CommandResponse err;
   int ret;
   phys_addr_t phy_addr;
 
@@ -433,10 +434,10 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
   container_pid_ = 0;
 
   if (arg.ifname().length() >= IFNAMSIZ) {
-    err = pb_error(EINVAL,
-                   "Linux interface name should be "
-                   "shorter than %d characters",
-                   IFNAMSIZ);
+    err = CommandFailure(EINVAL,
+                         "Linux interface name should be "
+                         "shorter than %d characters",
+                         IFNAMSIZ);
     goto fail;
   }
 
@@ -448,28 +449,28 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
 
   if (arg.cpid_case() == bess::pb::VPortArg::kDocker) {
     err = docker_container_pid(arg.docker(), &container_pid_);
-    if (err.code() != 0)
+    if (err.error().code() != 0)
       goto fail;
   } else if (arg.cpid_case() == bess::pb::VPortArg::kContainerPid) {
     container_pid_ = arg.container_pid();
   } else if (arg.cpid_case() == bess::pb::VPortArg::kNetns) {
     netns_fd_ = open(arg.netns().c_str(), O_RDONLY);
     if (netns_fd_ < 0) {
-      err =
-          pb_error(EINVAL, "Invalid network namespace %s", arg.netns().c_str());
+      err = CommandFailure(EINVAL, "Invalid network namespace %s",
+                           arg.netns().c_str());
       goto fail;
     }
   }
 
   if (arg.rxq_cpus_size() > 0 &&
       arg.rxq_cpus_size() != num_queues[PACKET_DIR_OUT]) {
-    err = pb_error(EINVAL, "Must specify as many cores as rxqs");
+    err = CommandFailure(EINVAL, "Must specify as many cores as rxqs");
     goto fail;
   }
 
   fd_ = open("/dev/bess", O_RDONLY);
   if (fd_ == -1) {
-    err = pb_error(ENODEV, "the kernel module is not loaded");
+    err = CommandFailure(ENODEV, "the kernel module is not loaded");
     goto fail;
   }
 
@@ -484,14 +485,14 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
 
   ret = ioctl(fd_, SN_IOC_CREATE_HOSTNIC, &phy_addr);
   if (ret < 0) {
-    err = pb_error(-ret, "SN_IOC_CREATE_HOSTNIC failure");
+    err = CommandFailure(-ret, "SN_IOC_CREATE_HOSTNIC failure");
     goto fail;
   }
 
   if (arg.ip_addrs_size() > 0) {
     err = SetIPAddr(arg);
 
-    if (err.code() != 0) {
+    if (err.error().code() != 0) {
       DeInit();
       goto fail;
     }
@@ -522,7 +523,7 @@ pb_error_t VPort::Init(const bess::pb::VPortArg &arg) {
     PLOG(ERROR) << "ioctl(SN_IOC_SET_QUEUE_MAPPING)";
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 
 fail:
   if (fd_ >= 0)

--- a/core/drivers/vport.h
+++ b/core/drivers/vport.h
@@ -9,7 +9,7 @@ class VPort final : public Port {
   VPort() : fd_(), bar_(), map_(), netns_fd_(), container_pid_() {}
   void InitDriver() override;
 
-  pb_error_t Init(const bess::pb::VPortArg &arg);
+  CommandResponse Init(const bess::pb::VPortArg &arg);
   void DeInit() override;
 
   virtual int RecvPackets(queue_t qid, bess::Packet **pkts,
@@ -30,7 +30,7 @@ class VPort final : public Port {
   void *AllocBar(struct tx_queue_opts *txq_opts,
                  struct rx_queue_opts *rxq_opts);
   int SetIPAddrSingle(const std::string &ip_addr);
-  pb_error_t SetIPAddr(const bess::pb::VPortArg &arg);
+  CommandResponse SetIPAddr(const bess::pb::VPortArg &arg);
 
   int fd_;
 

--- a/core/drivers/vport_zc.cc
+++ b/core/drivers/vport_zc.cc
@@ -12,7 +12,7 @@
 
 #define ROUND_TO_64(x) ((x + 32) & (~0x3f))
 
-pb_error_t ZeroCopyVPort::Init(const bess::pb::EmptyArg &) {
+CommandResponse ZeroCopyVPort::Init(const bess::pb::EmptyArg &) {
   struct vport_bar *bar = nullptr;
 
   int num_inc_q = num_queues[PACKET_DIR_INC];
@@ -101,7 +101,7 @@ pb_error_t ZeroCopyVPort::Init(const bess::pb::EmptyArg &) {
   fwrite(&bar_address, 8, 1, fp);
   fclose(fp);
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void ZeroCopyVPort::DeInit() {

--- a/core/drivers/vport_zc.h
+++ b/core/drivers/vport_zc.h
@@ -50,7 +50,7 @@ struct vport_bar {
 
 class ZeroCopyVPort final : public Port {
  public:
-  pb_error_t Init(const bess::pb::EmptyArg &arg);
+  CommandResponse Init(const bess::pb::EmptyArg &arg);
 
   void DeInit();
 

--- a/core/drivers/vport_zc_test.cc
+++ b/core/drivers/vport_zc_test.cc
@@ -32,7 +32,7 @@ class ZeroCopyVPortTest : public ::testing::Test {
     ASSERT_NE(nullptr, port);
     port->num_queues[PACKET_DIR_INC] = 1;
     port->num_queues[PACKET_DIR_OUT] = 1;
-    ASSERT_EQ(0, port->Init(arg).code());
+    ASSERT_EQ(0, port->Init(arg).error().code());
   }
 
   virtual void TearDown() {

--- a/core/drivers/vport_zc_test.cc
+++ b/core/drivers/vport_zc_test.cc
@@ -32,7 +32,7 @@ class ZeroCopyVPortTest : public ::testing::Test {
     ASSERT_NE(nullptr, port);
     port->num_queues[PACKET_DIR_INC] = 1;
     port->num_queues[PACKET_DIR_OUT] = 1;
-    ASSERT_EQ(0, port->Init(arg).err());
+    ASSERT_EQ(0, port->Init(arg).code());
   }
 
   virtual void TearDown() {

--- a/core/message.cc
+++ b/core/message.cc
@@ -7,7 +7,7 @@
 pb_error_t pb_error(int code, const char *fmt, ...) {
   pb_error_t p;
 
-  p.set_err(code);
+  p.set_code(code);
 
   if (fmt) {
     va_list ap;
@@ -18,4 +18,41 @@ pb_error_t pb_error(int code, const char *fmt, ...) {
   }
 
   return p;
+}
+
+using CommandError = bess::pb::Error;
+
+CommandResponse CommandSuccess() {
+  return CommandResponse();
+}
+
+CommandResponse CommandSuccess(const google::protobuf::Message &return_data) {
+  CommandResponse ret;
+  ret.mutable_data()->PackFrom(return_data);
+  return ret;
+}
+
+CommandResponse CommandFailure(int code) {
+  CommandResponse ret;
+  CommandError *error = ret.mutable_error();
+  error->set_code(code);
+  error->set_errmsg(strerror(code));
+  return ret;
+}
+
+CommandResponse CommandFailure(int code, const char *fmt, ...) {
+  CommandResponse ret;
+  CommandError *error = ret.mutable_error();
+
+  error->set_code(code);
+
+  if (fmt) {
+    va_list ap;
+    va_start(ap, fmt);
+    const std::string message = bess::utils::FormatVarg(fmt, ap);
+    va_end(ap);
+    error->set_errmsg(message);
+  }
+
+  return ret;
 }

--- a/core/message.cc
+++ b/core/message.cc
@@ -4,8 +4,7 @@
 
 #include "utils/format.h"
 
-pb_error_t pb_error_details(int code, const char *details, const char *fmt,
-                            ...) {
+pb_error_t pb_error(int code, const char *fmt, ...) {
   pb_error_t p;
 
   p.set_err(code);
@@ -16,10 +15,6 @@ pb_error_t pb_error_details(int code, const char *details, const char *fmt,
     const std::string message = bess::utils::FormatVarg(fmt, ap);
     va_end(ap);
     p.set_errmsg(message);
-  }
-
-  if (details) {
-    p.set_details(details);
   }
 
   return p;

--- a/core/message.h
+++ b/core/message.h
@@ -7,7 +7,16 @@
 #include "error.pb.h"
 
 typedef bess::pb::Error pb_error_t;
-typedef bess::pb::ModuleCommandResponse pb_cmd_response_t;
+
+using CommandResponse = bess::pb::ModuleCommandResponse;
+
+CommandResponse CommandSuccess();
+CommandResponse CommandSuccess(const google::protobuf::Message &return_data);
+
+CommandResponse CommandFailure(int code);
+[[gnu::format(printf, 2, 3)]] CommandResponse CommandFailure(int code,
+                                                             const char *fmt,
+                                                             ...);
 
 template <typename T, typename M, typename A>
 using pb_func_t = std::function<T(M *, const A &)>;

--- a/core/message.h
+++ b/core/message.h
@@ -19,45 +19,4 @@ static inline pb_error_t pb_errno(int code) {
   return pb_error(code, "%s", strerror(code));
 }
 
-static inline int uint64_to_bin(uint8_t *ptr, int size, uint64_t val, int be) {
-  memset(ptr, 0, size);
-
-  if (be) {
-    for (int i = size - 1; i >= 0; i--) {
-      ptr[i] = val & 0xff;
-      val >>= 8;
-    }
-  } else {
-    for (int i = 0; i < size; i++) {
-      ptr[i] = val & 0xff;
-      val >>= 8;
-    }
-  }
-
-  if (val) {
-    return -EINVAL; /* the value is too large for the size */
-  } else {
-    return 0;
-  }
-}
-
-// move data from *ptr to *val. set "be" if *ptr stores big endian data
-static inline int bin_to_uint64(uint64_t *val, uint8_t *ptr, int size, bool be) {
-  if(size > 8 || size < 1){
-    return -EINVAL; /* Size must be 1-8 */
-  }
-
-  *val = 0;
-
-  if (be) {
-    for (int i = 0; i < size; i++) {
-      *val = (*val << 8) | ptr[i];
-    }
-  } else {
-    for (int i = size - 1; i >= 0; i--) {
-      *val = (*val << 8) | ptr[i];
-    }
-  }
-  return 0;
-}
 #endif  // BESS_MESSAGE_H_

--- a/core/message.h
+++ b/core/message.h
@@ -12,19 +12,11 @@ typedef bess::pb::ModuleCommandResponse pb_cmd_response_t;
 template <typename T, typename M, typename A>
 using pb_func_t = std::function<T(M *, const A &)>;
 
-[[gnu::format(printf, 3, 4)]] pb_error_t pb_error_details(int code,
-                                                          const char *details,
-                                                          const char *fmt, ...);
-
-#define pb_error(code, fmt, ...) \
-  pb_error_details(code, nullptr, fmt, ##__VA_ARGS__)
-
-static inline pb_error_t pb_errno_details(int code, const char *details) {
-  return pb_error_details(code, details, "%s", strerror(code));
-}
+[[gnu::format(printf, 2, 3)]] pb_error_t pb_error(int code, const char *fmt,
+                                                  ...);
 
 static inline pb_error_t pb_errno(int code) {
-  return pb_errno_details(code, nullptr);
+  return pb_error(code, "%s", strerror(code));
 }
 
 static inline int uint64_to_bin(uint8_t *ptr, int size, uint64_t val, int be) {

--- a/core/message.h
+++ b/core/message.h
@@ -8,7 +8,7 @@
 
 typedef bess::pb::Error pb_error_t;
 
-using CommandResponse = bess::pb::ModuleCommandResponse;
+using CommandResponse = bess::pb::CommandResponse;
 
 CommandResponse CommandSuccess();
 CommandResponse CommandSuccess(const google::protobuf::Message &return_data);

--- a/core/module.cc
+++ b/core/module.cc
@@ -188,18 +188,18 @@ CommandResponse ModuleBuilder::RunCommand(
                         class_name_.c_str(), user_cmd.c_str());
 }
 
-pb_error_t ModuleBuilder::RunInit(Module *m,
-                                  const google::protobuf::Any &arg) const {
+CommandResponse ModuleBuilder::RunInit(Module *m,
+                                       const google::protobuf::Any &arg) const {
   return init_func_(m, arg);
 }
 
 // -------------------------------------------------------------------------
-pb_error_t Module::InitWithGenericArg(const google::protobuf::Any &arg) {
+CommandResponse Module::InitWithGenericArg(const google::protobuf::Any &arg) {
   return module_builder_->RunInit(this, arg);
 }
 
-pb_error_t Module::Init(const bess::pb::EmptyArg &) {
-  return pb_errno(0);
+CommandResponse Module::Init(const bess::pb::EmptyArg &) {
+  return CommandSuccess();
 }
 
 void Module::DeInit() {}

--- a/core/module.h
+++ b/core/module.h
@@ -15,11 +15,6 @@
 
 using bess::gate_idx_t;
 
-static inline void set_cmd_response_error(pb_cmd_response_t *response,
-                                          const pb_error_t &error) {
-  response->mutable_error()->CopyFrom(error);
-}
-
 #define MAX_NUMA_NODE 16
 #define UNCONSTRAINED_SOCKET ((0x1ull << MAX_NUMA_NODE) - 1)
 
@@ -35,12 +30,12 @@ typedef uint64_t placement_constraint;
 #define INVALID_TASK_ID ((task_id_t)-1)
 
 using module_cmd_func_t =
-    pb_func_t<pb_cmd_response_t, Module, google::protobuf::Any>;
+    pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 using module_init_func_t = pb_func_t<pb_error_t, Module, google::protobuf::Any>;
 
 template <typename T, typename M>
 static inline module_cmd_func_t MODULE_CMD_FUNC(
-    pb_cmd_response_t (M::*fn)(const T &)) {
+    CommandResponse (M::*fn)(const T &)) {
   return [fn](Module *m, const google::protobuf::Any &arg) {
     T arg_;
     arg.UnpackTo(&arg_);
@@ -136,8 +131,8 @@ class ModuleBuilder {
   static std::string GenerateDefaultName(const std::string &class_name,
                                          const std::string &default_template);
 
-  pb_cmd_response_t RunCommand(Module *m, const std::string &user_cmd,
-                               const google::protobuf::Any &arg) const;
+  CommandResponse RunCommand(Module *m, const std::string &user_cmd,
+                             const google::protobuf::Any &arg) const;
 
   pb_error_t RunInit(Module *m, const google::protobuf::Any &arg) const;
 
@@ -254,8 +249,8 @@ class Module {
 
   int DisableTcpDump(int is_igate, gate_idx_t gate_idx);
 
-  pb_cmd_response_t RunCommand(const std::string &cmd,
-                               const google::protobuf::Any &arg) {
+  CommandResponse RunCommand(const std::string &cmd,
+                             const google::protobuf::Any &arg) {
     return module_builder_->RunCommand(this, cmd, arg);
   }
 

--- a/core/module.h
+++ b/core/module.h
@@ -20,7 +20,6 @@ static inline void set_cmd_response_error(pb_cmd_response_t *response,
   response->mutable_error()->CopyFrom(error);
 }
 
-#define MODULE_NAME_LEN 128
 #define MAX_NUMA_NODE 16
 #define UNCONSTRAINED_SOCKET ((0x1ull << MAX_NUMA_NODE) - 1)
 
@@ -62,8 +61,6 @@ static inline module_init_func_t MODULE_INIT_FUNC(
 }
 
 class Module;
-
-#define CALL_MEMBER_FN(obj, ptr_to_member_func) ((obj).*(ptr_to_member_func))
 
 struct Command {
   std::string cmd;

--- a/core/module.h
+++ b/core/module.h
@@ -31,7 +31,8 @@ typedef uint64_t placement_constraint;
 
 using module_cmd_func_t =
     pb_func_t<CommandResponse, Module, google::protobuf::Any>;
-using module_init_func_t = pb_func_t<pb_error_t, Module, google::protobuf::Any>;
+using module_init_func_t =
+    pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 
 template <typename T, typename M>
 static inline module_cmd_func_t MODULE_CMD_FUNC(
@@ -46,7 +47,7 @@ static inline module_cmd_func_t MODULE_CMD_FUNC(
 
 template <typename T, typename M>
 static inline module_init_func_t MODULE_INIT_FUNC(
-    pb_error_t (M::*fn)(const T &)) {
+    CommandResponse (M::*fn)(const T &)) {
   return [fn](Module *m, const google::protobuf::Any &arg) {
     T arg_;
     arg.UnpackTo(&arg_);
@@ -75,7 +76,7 @@ class ModuleBuilder {
       std::function<Module *()> module_generator, const std::string &class_name,
       const std::string &name_template, const std::string &help_text,
       const gate_idx_t igates, const gate_idx_t ogates, const Commands &cmds,
-      std::function<pb_error_t(Module *, const google::protobuf::Any &)>
+      std::function<CommandResponse(Module *, const google::protobuf::Any &)>
           init_func)
       : module_generator_(module_generator),
         num_igates_(igates),
@@ -134,7 +135,7 @@ class ModuleBuilder {
   CommandResponse RunCommand(Module *m, const std::string &user_cmd,
                              const google::protobuf::Any &arg) const;
 
-  pb_error_t RunInit(Module *m, const google::protobuf::Any &arg) const;
+  CommandResponse RunInit(Module *m, const google::protobuf::Any &arg) const;
 
  private:
   const std::function<Module *()> module_generator_;
@@ -182,7 +183,7 @@ class Module {
         propagate_workers_(true) {}
   virtual ~Module() {}
 
-  pb_error_t Init(const bess::pb::EmptyArg &arg);
+  CommandResponse Init(const bess::pb::EmptyArg &arg);
 
   // NOTE: this function will be called even if Init() has failed.
   virtual void DeInit();
@@ -203,7 +204,7 @@ class Module {
  public:
   friend class ModuleBuilder;
 
-  pb_error_t InitWithGenericArg(const google::protobuf::Any &arg);
+  CommandResponse InitWithGenericArg(const google::protobuf::Any &arg);
 
   const ModuleBuilder *module_builder() const { return module_builder_; }
 

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -18,7 +18,9 @@ class AcmeModule : public Module {
 
   static const Commands cmds;
 
-  pb_error_t Init(const bess::pb::EmptyArg &) { return pb_errno(42); }
+  CommandResponse Init(const bess::pb::EmptyArg &) {
+    return CommandFailure(42);
+  }
 
   CommandResponse FooPb(const bess::pb::EmptyArg &) {
     n += 1;
@@ -65,8 +67,8 @@ int create_acme(const char *name, Module **m) {
   bess::pb::EmptyArg arg_;
   google::protobuf::Any arg;
   arg.PackFrom(arg_);
-  pb_error_t err = (*m)->InitWithGenericArg(arg);
-  EXPECT_EQ(42, err.code());
+  CommandResponse ret = (*m)->InitWithGenericArg(arg);
+  EXPECT_EQ(42, ret.error().code());
 
   ModuleBuilder::AddModule(*m);
 

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -20,9 +20,9 @@ class AcmeModule : public Module {
 
   pb_error_t Init(const bess::pb::EmptyArg &) { return pb_errno(42); }
 
-  pb_cmd_response_t FooPb(const bess::pb::EmptyArg &) {
+  CommandResponse FooPb(const bess::pb::EmptyArg &) {
     n += 1;
-    return pb_cmd_response_t();
+    return CommandResponse();
   }
 
   int n = {};
@@ -66,7 +66,7 @@ int create_acme(const char *name, Module **m) {
   google::protobuf::Any arg;
   arg.PackFrom(arg_);
   pb_error_t err = (*m)->InitWithGenericArg(arg);
-  EXPECT_EQ(42, err.err());
+  EXPECT_EQ(42, err.code());
 
   ModuleBuilder::AddModule(*m);
 
@@ -142,16 +142,16 @@ TEST_F(ModuleTester, RunCommand) {
   google::protobuf::Any arg;
   arg.PackFrom(arg_);
 
-  pb_cmd_response_t response;
+  CommandResponse response;
 
   for (int i = 0; i < 10; i++) {
     response = m->RunCommand("foo", arg);
-    EXPECT_EQ(0, response.error().err());
+    EXPECT_EQ(0, response.error().code());
   }
   EXPECT_EQ(10, (static_cast<AcmeModule *>(m))->n);
 
   response = m->RunCommand("bar", arg);
-  EXPECT_EQ(ENOTSUP, response.error().err());
+  EXPECT_EQ(ENOTSUP, response.error().code());
 }
 
 TEST_F(ModuleTester, ConnectModules) {

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -10,7 +10,7 @@ const Commands ACL::cmds = {
     {"add", "ACLArg", MODULE_CMD_FUNC(&ACL::CommandAdd), 0},
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&ACL::CommandClear), 0}};
 
-pb_error_t ACL::Init(const bess::pb::ACLArg &arg) {
+CommandResponse ACL::Init(const bess::pb::ACLArg &arg) {
   for (const auto &rule : arg.rules()) {
     ACLRule new_rule = {
         .src_ip = CIDRNetwork(rule.src_ip()),
@@ -21,7 +21,7 @@ pb_error_t ACL::Init(const bess::pb::ACLArg &arg) {
         .drop = rule.drop()};
     rules_.push_back(new_rule);
   }
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 CommandResponse ACL::CommandAdd(const bess::pb::ACLArg &arg) {

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -24,15 +24,14 @@ pb_error_t ACL::Init(const bess::pb::ACLArg &arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t ACL::CommandAdd(const bess::pb::ACLArg &arg) {
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, Init(arg));
-  return response;
+CommandResponse ACL::CommandAdd(const bess::pb::ACLArg &arg) {
+  Init(arg);
+  return CommandSuccess();
 }
 
-pb_cmd_response_t ACL::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse ACL::CommandClear(const bess::pb::EmptyArg &) {
   rules_.clear();
-  return pb_cmd_response_t();
+  return CommandSuccess();
 }
 
 void ACL::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/acl.h
+++ b/core/modules/acl.h
@@ -34,8 +34,8 @@ class ACL final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::ACLArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::ACLArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   std::vector<ACLRule> rules_;

--- a/core/modules/acl.h
+++ b/core/modules/acl.h
@@ -30,7 +30,7 @@ class ACL final : public Module {
 
   static const Commands cmds;
 
-  pb_error_t Init(const bess::pb::ACLArg &arg);
+  CommandResponse Init(const bess::pb::ACLArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -1114,7 +1114,7 @@ const Commands BPF::cmds = {
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&BPF::CommandClear), 0}};
 
 pb_error_t BPF::Init(const bess::pb::BPFArg &arg) {
-  pb_cmd_response_t response = CommandAdd(arg);
+  CommandResponse response = CommandAdd(arg);
   return response.error();
 }
 
@@ -1127,12 +1127,9 @@ void BPF::DeInit() {
   n_filters_ = 0;
 }
 
-pb_cmd_response_t BPF::CommandAdd(const bess::pb::BPFArg &arg) {
-  pb_cmd_response_t response;
-
+CommandResponse BPF::CommandAdd(const bess::pb::BPFArg &arg) {
   if (n_filters_ + arg.filters_size() > MAX_FILTERS) {
-    set_cmd_response_error(&response, pb_error(EINVAL, "Too many filters"));
-    return response;
+    return CommandFailure(EINVAL, "Too many filters");
   }
 
   struct filter *filter = &filters_[n_filters_];
@@ -1142,15 +1139,12 @@ pb_cmd_response_t BPF::CommandAdd(const bess::pb::BPFArg &arg) {
     const char *exp = f.filter().c_str();
     int64_t gate = f.gate();
     if (gate < 0 || gate >= MAX_GATES) {
-      set_cmd_response_error(&response, pb_error(EINVAL, "Invalid gate"));
-      return response;
+      return CommandFailure(EINVAL, "Invalid gate");
     }
     if (pcap_compile_nopcap(SNAPLEN, DLT_EN10MB,  // Ethernet
                             &il_code, exp, 1,     // optimize (IL only)
                             PCAP_NETMASK_UNKNOWN) == -1) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "BPF compilation error"));
-      return response;
+      return CommandFailure(EINVAL, "BPF compilation error");
     }
     filter->priority = f.priority();
     filter->gate = f.gate();
@@ -1160,24 +1154,20 @@ pb_cmd_response_t BPF::CommandAdd(const bess::pb::BPFArg &arg) {
     pcap_freecode(&il_code);
     if (!filter->func) {
       free(filter->exp);
-      set_cmd_response_error(&response,
-                             pb_error(ENOMEM, "BPF JIT compilation error"));
-      return response;
+      return CommandFailure(ENOMEM, "BPF JIT compilation error");
     }
     n_filters_++;
     qsort(filters_, n_filters_, sizeof(struct filter), &compare_filter);
 
     filter++;
   }
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+
+  return CommandSuccess();
 }
 
-pb_cmd_response_t BPF::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse BPF::CommandClear(const bess::pb::EmptyArg &) {
   DeInit();
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 inline void BPF::process_batch_1filter(bess::PacketBatch *batch) {

--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -1113,9 +1113,8 @@ const Commands BPF::cmds = {
     {"add", "BPFArg", MODULE_CMD_FUNC(&BPF::CommandAdd), 0},
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&BPF::CommandClear), 0}};
 
-pb_error_t BPF::Init(const bess::pb::BPFArg &arg) {
-  CommandResponse response = CommandAdd(arg);
-  return response.error();
+CommandResponse BPF::Init(const bess::pb::BPFArg &arg) {
+  return CommandAdd(arg);
 }
 
 void BPF::DeInit() {

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -23,7 +23,7 @@ class BPF final : public Module {
 
   static const Commands cmds;
 
-  pb_error_t Init(const bess::pb::BPFArg &arg);
+  CommandResponse Init(const bess::pb::BPFArg &arg);
   void DeInit() override;
 
   void ProcessBatch(bess::PacketBatch *batch) override;

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -28,8 +28,8 @@ class BPF final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::BPFArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::BPFArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   struct filter filters_[MAX_FILTERS + 1] = {};

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -55,14 +55,14 @@ pb_error_t DRR::Init(const bess::pb::DRRArg& arg) {
 
   if (arg.max_flow_queue_size() != 0) {
     err = SetMaxFlowQueueSize(arg.max_flow_queue_size());
-    if (err.err() != 0) {
+    if (err.code() != 0) {
       return err;
     }
   }
 
   if (arg.quantum() != 0) {
     err = SetQuantumSize(arg.quantum());
-    if (err.err() != 0) {
+    if (err.code() != 0) {
       return err;
     }
   }
@@ -82,17 +82,23 @@ pb_error_t DRR::Init(const bess::pb::DRRArg& arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t DRR::CommandQuantumSize(const bess::pb::DRRQuantumArg& arg) {
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, SetQuantumSize(arg.quantum()));
-  return response;
+CommandResponse DRR::CommandQuantumSize(const bess::pb::DRRQuantumArg& arg) {
+  pb_error_t ret = SetQuantumSize(arg.quantum());
+  if (ret.code() != 0) {
+    return CommandFailure(ret.code(), "%s", ret.errmsg().c_str());
+  } else {
+    return CommandSuccess();
+  }
 }
 
-pb_cmd_response_t DRR::CommandMaxFlowQueueSize(
+CommandResponse DRR::CommandMaxFlowQueueSize(
     const bess::pb::DRRMaxFlowQueueSizeArg& arg) {
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, SetMaxFlowQueueSize(arg.max_queue_size()));
-  return response;
+  pb_error_t ret = SetMaxFlowQueueSize(arg.max_queue_size());
+  if (ret.code() != 0) {
+    return CommandFailure(ret.code(), "%s", ret.errmsg().c_str());
+  } else {
+    return CommandSuccess();
+  }
 }
 
 void DRR::ProcessBatch(bess::PacketBatch* batch) {

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -136,8 +136,8 @@ class DRR final : public Module {
 
   struct task_result RunTask(void*) override;
 
-  pb_cmd_response_t CommandQuantumSize(const bess::pb::DRRQuantumArg& arg);
-  pb_cmd_response_t CommandMaxFlowQueueSize(
+  CommandResponse CommandQuantumSize(const bess::pb::DRRQuantumArg& arg);
+  CommandResponse CommandMaxFlowQueueSize(
       const bess::pb::DRRMaxFlowQueueSizeArg& arg);
 
  private:

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -130,7 +130,7 @@ class DRR final : public Module {
 
   static const Commands cmds;
 
-  pb_error_t Init(const bess::pb::DRRArg& arg);
+  CommandResponse Init(const bess::pb::DRRArg& arg);
 
   void ProcessBatch(bess::PacketBatch* batch) override;
 
@@ -146,7 +146,7 @@ class DRR final : public Module {
     Takes the size to set the quantum to. Returns 0 on success and error value
     otherwise.
   */
-  pb_error_t SetQuantumSize(uint32_t size);
+  CommandResponse SetQuantumSize(uint32_t size);
 
   /*
     Sets the maximum size that any Flows queue can get before the module will
@@ -154,7 +154,7 @@ class DRR final : public Module {
     queue.
     Returns 0 on success and error value otherwise.
   */
-  pb_error_t SetMaxFlowQueueSize(uint32_t queue_size);
+  CommandResponse SetMaxFlowQueueSize(uint32_t queue_size);
 
   /*
     Creates a new larger llring queue of the specifed size and moves over all

--- a/core/modules/dump.cc
+++ b/core/modules/dump.cc
@@ -13,11 +13,10 @@ const Commands Dump::cmds = {
     {"set_interval", "DumpArg", MODULE_CMD_FUNC(&Dump::CommandSetInterval), 0},
 };
 
-pb_error_t Dump::Init(const bess::pb::DumpArg &arg) {
+CommandResponse Dump::Init(const bess::pb::DumpArg &arg) {
   min_interval_ns_ = DEFAULT_INTERVAL_NS;
   next_ns_ = ctx.current_tsc();
-  CommandResponse response = CommandSetInterval(arg);
-  return response.error();
+  return CommandSetInterval(arg);
 }
 
 void Dump::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/dump.cc
+++ b/core/modules/dump.cc
@@ -16,7 +16,7 @@ const Commands Dump::cmds = {
 pb_error_t Dump::Init(const bess::pb::DumpArg &arg) {
   min_interval_ns_ = DEFAULT_INTERVAL_NS;
   next_ns_ = ctx.current_tsc();
-  pb_cmd_response_t response = CommandSetInterval(arg);
+  CommandResponse response = CommandSetInterval(arg);
   return response.error();
 }
 
@@ -34,20 +34,15 @@ void Dump::ProcessBatch(bess::PacketBatch *batch) {
   RunChooseModule(get_igate(), batch);
 }
 
-pb_cmd_response_t Dump::CommandSetInterval(const bess::pb::DumpArg &arg) {
-  pb_cmd_response_t response;
-
+CommandResponse Dump::CommandSetInterval(const bess::pb::DumpArg &arg) {
   double sec = arg.interval();
 
   if (std::isnan(sec) || sec <= 0.0) {
-    set_cmd_response_error(&response, pb_error(EINVAL, "invalid interval"));
-    return response;
+    return CommandFailure(EINVAL, "invalid interval");
   }
 
   min_interval_ns_ = static_cast<uint64_t>(sec * NS_PER_SEC);
-
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 ADD_MODULE(Dump, "dump", "Dump packet data and metadata attributes")

--- a/core/modules/dump.h
+++ b/core/modules/dump.h
@@ -6,7 +6,7 @@
 
 class Dump final : public Module {
  public:
-  pb_error_t Init(const bess::pb::DumpArg &arg);
+  CommandResponse Init(const bess::pb::DumpArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/dump.h
+++ b/core/modules/dump.h
@@ -10,7 +10,7 @@ class Dump final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandSetInterval(const bess::pb::DumpArg &arg);
+  CommandResponse CommandSetInterval(const bess::pb::DumpArg &arg);
 
   static const Commands cmds;
 

--- a/core/modules/ether_encap.cc
+++ b/core/modules/ether_encap.cc
@@ -9,7 +9,7 @@ enum {
   ATTR_R_ETHER_TYPE,
 };
 
-pb_error_t EtherEncap::Init(
+CommandResponse EtherEncap::Init(
     const bess::pb::EtherEncapArg &arg[[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 
@@ -17,7 +17,7 @@ pb_error_t EtherEncap::Init(
   AddMetadataAttr("ether_dst", ETHER_ADDR_LEN, AccessMode::kRead);
   AddMetadataAttr("ether_type", 2, AccessMode::kRead);
 
-  return pb_errno(0);
+  return CommandSuccess();
 };
 
 void EtherEncap::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/ether_encap.h
+++ b/core/modules/ether_encap.h
@@ -6,7 +6,7 @@
 
 class EtherEncap final : public Module {
  public:
-  pb_error_t Init(const bess::pb::EtherEncapArg &arg);
+  CommandResponse Init(const bess::pb::EtherEncapArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch);
 };

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -45,15 +45,15 @@ pb_error_t ExactMatch::AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
     return pb_error(EINVAL, "idx %d: must specify 'offset' or 'attr'", idx);
   }
 
-  int force_be = (f->attr_id < 0);
+  bool force_be = (f->attr_id < 0);
 
   if (field.mask() == 0) {
     // by default all bits are considered
-    f->mask = (f->size == 8) ? 0xffffffffffffffffull
-                             : (1ull << (f->size * 8)) - 1;
+    f->mask =
+        (f->size == 8) ? 0xffffffffffffffffull : (1ull << (f->size * 8)) - 1;
   } else {
-    if (uint64_to_bin((uint8_t *)&f->mask, f->size, field.mask(),
-                      bess::utils::is_be_system() | force_be)) {
+    if (bess::utils::uint64_to_bin(&f->mask, field.mask(), f->size,
+                                   bess::utils::is_be_system() || force_be)) {
       return pb_error(EINVAL, "idx %d: not a correct %d-byte mask", idx,
                       f->size);
     }

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -109,18 +109,18 @@ class ExactMatch final : public Module {
   std::string GetDesc() const override;
 
   pb_error_t Init(const bess::pb::ExactMatchArg &arg);
-  pb_cmd_response_t CommandAdd(const bess::pb::ExactMatchCommandAddArg &arg);
-  pb_cmd_response_t CommandDelete(
+  CommandResponse CommandAdd(const bess::pb::ExactMatchCommandAddArg &arg);
+  CommandResponse CommandDelete(
       const bess::pb::ExactMatchCommandDeleteArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
-  pb_cmd_response_t CommandSetDefaultGate(
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandSetDefaultGate(
       const bess::pb::ExactMatchCommandSetDefaultGateArg &arg);
 
  private:
   pb_error_t AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
                          struct EmField *f, int idx);
-  pb_error_t GatherKey(const RepeatedPtrField<std::string> &fields,
-                       em_hkey_t *key);
+  CommandResponse GatherKey(const RepeatedPtrField<std::string> &fields,
+                            em_hkey_t *key);
 
   gate_idx_t default_gate_;
 

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -108,7 +108,7 @@ class ExactMatch final : public Module {
 
   std::string GetDesc() const override;
 
-  pb_error_t Init(const bess::pb::ExactMatchArg &arg);
+  CommandResponse Init(const bess::pb::ExactMatchArg &arg);
   CommandResponse CommandAdd(const bess::pb::ExactMatchCommandAddArg &arg);
   CommandResponse CommandDelete(
       const bess::pb::ExactMatchCommandDeleteArg &arg);
@@ -117,8 +117,8 @@ class ExactMatch final : public Module {
       const bess::pb::ExactMatchCommandSetDefaultGateArg &arg);
 
  private:
-  pb_error_t AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
-                         struct EmField *f, int idx);
+  CommandResponse AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
+                              struct EmField *f, int idx);
   CommandResponse GatherKey(const RepeatedPtrField<std::string> &fields,
                             em_hkey_t *key);
 

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -149,37 +149,37 @@ void FlowGen::PopulateInitialFlows() {
   }
 }
 
-pb_error_t FlowGen::ProcessArguments(const bess::pb::FlowGenArg &arg) {
+CommandResponse FlowGen::ProcessArguments(const bess::pb::FlowGenArg &arg) {
   if (arg.template_().length() == 0) {
-    return pb_error(EINVAL, "must specify 'template'");
+    return CommandFailure(EINVAL, "must specify 'template'");
   }
 
   if (arg.template_().length() > MAX_TEMPLATE_SIZE) {
-    return pb_error(EINVAL, "'template' is too big");
+    return CommandFailure(EINVAL, "'template' is too big");
   }
 
   template_size_ = arg.template_().length();
 
   memset(templ_, 0, MAX_TEMPLATE_SIZE);
   bess::utils::Copy(templ_, arg.template_().c_str(), template_size_);
-  pb_error_t err = UpdateBaseAddresses();
-  if (err.code() != 0) {
+  CommandResponse err = UpdateBaseAddresses();
+  if (err.error().code() != 0) {
     return err;
   }
 
   total_pps_ = arg.pps();
   if (std::isnan(total_pps_) || total_pps_ < 0.0) {
-    return pb_error(EINVAL, "invalid 'pps'");
+    return CommandFailure(EINVAL, "invalid 'pps'");
   }
 
   flow_rate_ = arg.flow_rate();
   if (std::isnan(flow_rate_) || flow_rate_ < 0.0) {
-    return pb_error(EINVAL, "invalid 'flow_rate'");
+    return CommandFailure(EINVAL, "invalid 'flow_rate'");
   }
 
   flow_duration_ = arg.flow_duration();
   if (std::isnan(flow_duration_) || flow_duration_ < 0.0) {
-    return pb_error(EINVAL, "invalid 'flow_duration'");
+    return CommandFailure(EINVAL, "invalid 'flow_duration'");
   }
 
   if (arg.arrival() == "uniform") {
@@ -187,8 +187,8 @@ pb_error_t FlowGen::ProcessArguments(const bess::pb::FlowGenArg &arg) {
   } else if (arg.arrival() == "exponential") {
     arrival_ = Arrival::kExponential;
   } else {
-    return pb_error(EINVAL,
-                    "'arrival' must be either 'uniform' or 'exponential'");
+    return CommandFailure(
+        EINVAL, "'arrival' must be either 'uniform' or 'exponential'");
   }
 
   if (arg.duration() == "uniform") {
@@ -196,7 +196,8 @@ pb_error_t FlowGen::ProcessArguments(const bess::pb::FlowGenArg &arg) {
   } else if (arg.duration() == "pareto") {
     duration_ = Duration::kPareto;
   } else {
-    return pb_error(EINVAL, "'duration' must be either 'uniform' or 'pareto'");
+    return CommandFailure(EINVAL,
+                          "'duration' must be either 'uniform' or 'pareto'");
   }
 
   if (arg.quick_rampup()) {
@@ -207,7 +208,7 @@ pb_error_t FlowGen::ProcessArguments(const bess::pb::FlowGenArg &arg) {
   ip_dst_range_ = arg.ip_dst_range();
 
   if (arg.port_src_range() > 65535 || arg.port_dst_range() > 65535) {
-    return pb_error(EINVAL, "portrang must be e <= 65535");
+    return CommandFailure(EINVAL, "portrang must be e <= 65535");
   }
 
   port_src_range_ = (uint16_t)arg.port_src_range();
@@ -220,7 +221,7 @@ pb_error_t FlowGen::ProcessArguments(const bess::pb::FlowGenArg &arg) {
     port_src_range_ = 20000;
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void FlowGen::UpdateDerivedParameters() {
@@ -328,9 +329,9 @@ CommandResponse FlowGen::CommandSetBurst(
   return CommandSuccess();
 }
 
-pb_error_t FlowGen::Init(const bess::pb::FlowGenArg &arg) {
+CommandResponse FlowGen::Init(const bess::pb::FlowGenArg &arg) {
   task_id_t tid;
-  pb_error_t err;
+  CommandResponse err;
 
   rng_.SetSeed(0xBAADF00DDEADBEEFul);
 
@@ -346,16 +347,16 @@ pb_error_t FlowGen::Init(const bess::pb::FlowGenArg &arg) {
   /* register task */
   tid = RegisterTask(nullptr);
   if (tid == INVALID_TASK_ID) {
-    return pb_error(ENOMEM, "task creation failed");
+    return CommandFailure(ENOMEM, "task creation failed");
   }
 
   templ_ = new char[MAX_TEMPLATE_SIZE];
   if (templ_ == nullptr) {
-    return pb_error(ENOMEM, "unable to allocate template");
+    return CommandFailure(ENOMEM, "unable to allocate template");
   }
 
   err = ProcessArguments(arg);
-  if (err.code() != 0) {
+  if (err.error().code() != 0) {
     return err;
   }
 
@@ -364,7 +365,7 @@ pb_error_t FlowGen::Init(const bess::pb::FlowGenArg &arg) {
   /* add a seed flow (and background flows if necessary) */
   PopulateInitialFlows();
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void FlowGen::DeInit() {
@@ -376,10 +377,10 @@ void FlowGen::DeInit() {
   delete[] templ_;
 }
 
-pb_error_t FlowGen::UpdateBaseAddresses() {
+CommandResponse FlowGen::UpdateBaseAddresses() {
   char *p = reinterpret_cast<char *>(templ_);
   if (!p) {
-    return pb_error(EINVAL, "must specify 'template'");
+    return CommandFailure(EINVAL, "must specify 'template'");
   }
 
   Ipv4Header *ipheader = reinterpret_cast<Ipv4Header *>(p + sizeof(EthHeader));
@@ -390,7 +391,7 @@ pb_error_t FlowGen::UpdateBaseAddresses() {
   ip_dst_base_ = ntohl(ipheader->dst);
   port_src_base_ = ntohs(tcpheader->src_port);
   port_dst_base_ = ntohs(tcpheader->dst_port);
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 bess::Packet *FlowGen::FillPacket(struct flow *f) {

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -58,7 +58,7 @@ class FlowGen final : public Module {
         burst_() {}
 
   static const Commands cmds;
-  pb_error_t Init(const bess::pb::FlowGenArg &arg);
+  CommandResponse Init(const bess::pb::FlowGenArg &arg);
   CommandResponse CommandUpdate(const bess::pb::FlowGenArg &arg);
   CommandResponse CommandSetBurst(
       const bess::pb::FlowGenCommandSetBurstArg &arg);
@@ -78,11 +78,11 @@ class FlowGen final : public Module {
   void MeasureParetoMean();
   void PopulateInitialFlows();
 
-  pb_error_t UpdateBaseAddresses();
+  CommandResponse UpdateBaseAddresses();
   bess::Packet *FillPacket(struct flow *f);
   void GeneratePackets(bess::PacketBatch *batch);
 
-  pb_error_t ProcessArguments(const bess::pb::FlowGenArg &arg);
+  CommandResponse ProcessArguments(const bess::pb::FlowGenArg &arg);
 
   // the number of concurrent flows
   int active_flows_;

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -59,8 +59,8 @@ class FlowGen final : public Module {
 
   static const Commands cmds;
   pb_error_t Init(const bess::pb::FlowGenArg &arg);
-  pb_cmd_response_t CommandUpdate(const bess::pb::FlowGenArg &arg);
-  pb_cmd_response_t CommandSetBurst(
+  CommandResponse CommandUpdate(const bess::pb::FlowGenArg &arg);
+  CommandResponse CommandSetBurst(
       const bess::pb::FlowGenCommandSetBurstArg &arg);
 
   void DeInit() override;

--- a/core/modules/generic_decap.cc
+++ b/core/modules/generic_decap.cc
@@ -1,14 +1,14 @@
 #include "generic_decap.h"
 
-pb_error_t GenericDecap::Init(const bess::pb::GenericDecapArg &arg) {
+CommandResponse GenericDecap::Init(const bess::pb::GenericDecapArg &arg) {
   if (arg.bytes() == 0) {
-    return pb_errno(0);
+    return CommandSuccess();
   }
   decap_size_ = arg.bytes();
   if (decap_size_ <= 0 || decap_size_ > 1024) {
-    return pb_error(EINVAL, "invalid decap size");
+    return CommandFailure(EINVAL, "invalid decap size");
   }
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void GenericDecap::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/generic_decap.h
+++ b/core/modules/generic_decap.h
@@ -8,7 +8,7 @@ class GenericDecap final : public Module {
  public:
   GenericDecap() : Module(), decap_size_() {}
 
-  pb_error_t Init(const bess::pb::GenericDecapArg &arg);
+  CommandResponse Init(const bess::pb::GenericDecapArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/generic_encap.cc
+++ b/core/modules/generic_encap.cc
@@ -65,7 +65,7 @@ pb_error_t GenericEncap::Init(const bess::pb::GenericEncapArg &arg) {
     f->pos = size_acc;
 
     err = AddFieldOne(field, f, i);
-    if (err.err() != 0) {
+    if (err.code() != 0) {
       return err;
     }
 

--- a/core/modules/generic_encap.cc
+++ b/core/modules/generic_encap.cc
@@ -1,5 +1,7 @@
 #include "generic_encap.h"
 
+#include "../utils/endian.h"
+
 static_assert(MAX_FIELD_SIZE <= sizeof(uint64_t),
               "field cannot be larger than 8 bytes");
 
@@ -26,8 +28,7 @@ pb_error_t GenericEncap::AddFieldOne(
   } else if (field.insertion_case() ==
              bess::pb::GenericEncapArg_Field::kValue) {
     f->attr_id = -1;
-    uint64_t value = field.value();
-    if (uint64_to_bin((uint8_t *)&f->value, f->size, value, 1)) {
+    if (bess::utils::uint64_to_bin(&f->value, field.value(), f->size, 1)) {
       return pb_error(EINVAL,
                       "idx %d: "
                       "not a correct %d-byte value",

--- a/core/modules/generic_encap.cc
+++ b/core/modules/generic_encap.cc
@@ -11,11 +11,12 @@ static_assert(MAX_FIELD_SIZE <= sizeof(uint64_t),
 #error this code assumes little endian architecture (x86)
 #endif
 
-pb_error_t GenericEncap::AddFieldOne(
+CommandResponse GenericEncap::AddFieldOne(
     const bess::pb::GenericEncapArg_Field &field, struct Field *f, int idx) {
   f->size = field.size();
   if (f->size < 1 || f->size > MAX_FIELD_SIZE) {
-    return pb_error(EINVAL, "idx %d: 'size' must be 1-%d", idx, MAX_FIELD_SIZE);
+    return CommandFailure(EINVAL, "idx %d: 'size' must be 1-%d", idx,
+                          MAX_FIELD_SIZE);
   }
 
   if (field.insertion_case() == bess::pb::GenericEncapArg_Field::kAttribute) {
@@ -23,22 +24,24 @@ pb_error_t GenericEncap::AddFieldOne(
     f->attr_id = AddMetadataAttr(attr, f->size,
                                  bess::metadata::Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
-      return pb_error(-f->attr_id, "idx %d: add_metadata_attr() failed", idx);
+      return CommandFailure(-f->attr_id, "idx %d: add_metadata_attr() failed",
+                            idx);
     }
   } else if (field.insertion_case() ==
              bess::pb::GenericEncapArg_Field::kValue) {
     f->attr_id = -1;
-    if (bess::utils::uint64_to_bin(&f->value, field.value(), f->size, 1)) {
-      return pb_error(EINVAL,
-                      "idx %d: "
-                      "not a correct %d-byte value",
-                      idx, f->size);
+    if (!bess::utils::uint64_to_bin(&f->value, field.value(), f->size, 1)) {
+      return CommandFailure(EINVAL,
+                            "idx %d: "
+                            "not a correct %d-byte value",
+                            idx, f->size);
     }
   } else {
-    return pb_error(EINVAL, "idx %d: must specify 'value' or 'attribute'", idx);
+    return CommandFailure(EINVAL, "idx %d: must specify 'value' or 'attribute'",
+                          idx);
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 /* Takes a list of fields. Each field is either:
@@ -54,18 +57,18 @@ pb_error_t GenericEncap::AddFieldOne(
  * where the 2-byte <xx> <xx> comes from the value of metadata attribute 'foo'
  * for each packet.
  */
-pb_error_t GenericEncap::Init(const bess::pb::GenericEncapArg &arg) {
+CommandResponse GenericEncap::Init(const bess::pb::GenericEncapArg &arg) {
   int size_acc = 0;
 
   for (int i = 0; i < arg.fields_size(); i++) {
     const auto &field = arg.fields(i);
-    pb_error_t err;
+    CommandResponse err;
     struct Field *f = &fields_[i];
 
     f->pos = size_acc;
 
     err = AddFieldOne(field, f, i);
-    if (err.code() != 0) {
+    if (err.error().code() != 0) {
       return err;
     }
 
@@ -75,7 +78,7 @@ pb_error_t GenericEncap::Init(const bess::pb::GenericEncapArg &arg) {
   encap_size_ = size_acc;
   num_fields_ = arg.fields_size();
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void GenericEncap::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/generic_encap.h
+++ b/core/modules/generic_encap.h
@@ -18,13 +18,13 @@ class GenericEncap final : public Module {
  public:
   GenericEncap() : Module(), encap_size_(), num_fields_(), fields_() {}
 
-  pb_error_t Init(const bess::pb::GenericEncapArg &arg);
+  CommandResponse Init(const bess::pb::GenericEncapArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch);
 
  private:
-  pb_error_t AddFieldOne(const bess::pb::GenericEncapArg_Field &field,
-                         struct Field *f, int idx);
+  CommandResponse AddFieldOne(const bess::pb::GenericEncapArg_Field &field,
+                              struct Field *f, int idx);
 
   int encap_size_;
 

--- a/core/modules/hash_lb.cc
+++ b/core/modules/hash_lb.cc
@@ -40,9 +40,8 @@ const Commands HashLB::cmds = {{"set_mode", "HashLBCommandSetModeArg",
                                {"set_gates", "HashLBCommandSetGatesArg",
                                 MODULE_CMD_FUNC(&HashLB::CommandSetGates), 0}};
 
-pb_cmd_response_t HashLB::CommandSetMode(
+CommandResponse HashLB::CommandSetMode(
     const bess::pb::HashLBCommandSetModeArg &arg) {
-  pb_cmd_response_t response;
   if (arg.mode() == "l2") {
     mode_ = LB_L2;
   } else if (arg.mode() == "l3") {
@@ -50,35 +49,27 @@ pb_cmd_response_t HashLB::CommandSetMode(
   } else if (arg.mode() == "l4") {
     mode_ = LB_L4;
   } else {
-    set_cmd_response_error(&response,
-                           pb_error(EINVAL, "available LB modes: l2, l3, l4"));
+    return CommandFailure(EINVAL, "available LB modes: l2, l3, l4");
   }
-  return response;
+
+  return CommandSuccess();
 }
 
-pb_cmd_response_t HashLB::CommandSetGates(
+CommandResponse HashLB::CommandSetGates(
     const bess::pb::HashLBCommandSetGatesArg &arg) {
-  pb_cmd_response_t response;
-
   if (arg.gates_size() > MAX_HLB_GATES) {
-    set_cmd_response_error(
-        &response, pb_error(EINVAL, "no more than %d gates", MAX_HLB_GATES));
-    return response;
+    return CommandFailure(EINVAL, "no more than %d gates", MAX_HLB_GATES);
   }
 
   for (int i = 0; i < arg.gates_size(); i++) {
     gates_[i] = arg.gates(i);
     if (!is_valid_gate(gates_[i])) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "invalid gate %d", gates_[i]));
-      return response;
+      return CommandFailure(EINVAL, "invalid gate %d", gates_[i]);
     }
   }
 
   num_gates_ = arg.gates_size();
-
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 pb_error_t HashLB::Init(const bess::pb::HashLBArg &arg) {

--- a/core/modules/hash_lb.cc
+++ b/core/modules/hash_lb.cc
@@ -72,17 +72,17 @@ CommandResponse HashLB::CommandSetGates(
   return CommandSuccess();
 }
 
-pb_error_t HashLB::Init(const bess::pb::HashLBArg &arg) {
+CommandResponse HashLB::Init(const bess::pb::HashLBArg &arg) {
   mode_ = DEFAULT_MODE;
 
   if (arg.gates_size() > MAX_HLB_GATES) {
-    return pb_error(EINVAL, "no more than %d gates", MAX_HLB_GATES);
+    return CommandFailure(EINVAL, "no more than %d gates", MAX_HLB_GATES);
   }
 
   for (int i = 0; i < arg.gates_size(); i++) {
     gates_[i] = arg.gates(i);
     if (!is_valid_gate(gates_[i])) {
-      return pb_error(EINVAL, "invalid gate %d", gates_[i]);
+      return CommandFailure(EINVAL, "invalid gate %d", gates_[i]);
     }
   }
 
@@ -95,10 +95,10 @@ pb_error_t HashLB::Init(const bess::pb::HashLBArg &arg) {
   } else if (arg.mode() == "l4") {
     mode_ = LB_L4;
   } else {
-    return pb_error(EINVAL, "available LB modes: l2, l3, l4");
+    return CommandFailure(EINVAL, "available LB modes: l2, l3, l4");
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void HashLB::LbL2(bess::PacketBatch *batch, gate_idx_t *out_gates) {

--- a/core/modules/hash_lb.h
+++ b/core/modules/hash_lb.h
@@ -25,9 +25,8 @@ class HashLB final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandSetMode(
-      const bess::pb::HashLBCommandSetModeArg &arg);
-  pb_cmd_response_t CommandSetGates(
+  CommandResponse CommandSetMode(const bess::pb::HashLBCommandSetModeArg &arg);
+  CommandResponse CommandSetGates(
       const bess::pb::HashLBCommandSetGatesArg &arg);
 
  private:

--- a/core/modules/hash_lb.h
+++ b/core/modules/hash_lb.h
@@ -21,7 +21,7 @@ class HashLB final : public Module {
 
   HashLB() : Module(), gates_(), num_gates_(), mode_() {}
 
-  pb_error_t Init(const bess::pb::HashLBArg &arg);
+  CommandResponse Init(const bess::pb::HashLBArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -15,7 +15,7 @@ enum {
   ATTR_W_ETHER_TYPE,
 };
 
-pb_error_t IPEncap::Init(const bess::pb::IPEncapArg &arg[[maybe_unused]]) {
+CommandResponse IPEncap::Init(const bess::pb::IPEncapArg &arg[[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 
   AddMetadataAttr("ip_src", 4, AccessMode::kRead);
@@ -24,7 +24,7 @@ pb_error_t IPEncap::Init(const bess::pb::IPEncapArg &arg[[maybe_unused]]) {
   AddMetadataAttr("ip_nexthop", 4, AccessMode::kWrite);
   AddMetadataAttr("ether_type", 2, AccessMode::kWrite);
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void IPEncap::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -6,7 +6,7 @@
 
 class IPEncap final : public Module {
  public:
-  pb_error_t Init(const bess::pb::IPEncapArg &arg);
+  CommandResponse Init(const bess::pb::IPEncapArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 };

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -21,7 +21,7 @@ const Commands IPLookup::cmds = {
     {"add", "IPLookupCommandAddArg", MODULE_CMD_FUNC(&IPLookup::CommandAdd), 0},
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&IPLookup::CommandClear), 0}};
 
-pb_error_t IPLookup::Init(const bess::pb::IPLookupArg &arg) {
+CommandResponse IPLookup::Init(const bess::pb::IPLookupArg &arg) {
   struct rte_lpm_config conf = {
       .max_rules = arg.max_rules() ? arg.max_rules() : 1024,
       .number_tbl8s = arg.max_tbl8s() ? arg.max_tbl8s() : 128,
@@ -33,10 +33,10 @@ pb_error_t IPLookup::Init(const bess::pb::IPLookupArg &arg) {
   lpm_ = rte_lpm_create(name().c_str(), /* socket_id = */ 0, &conf);
 
   if (!lpm_) {
-    return pb_error(rte_errno, "DPDK error: %s", rte_strerror(rte_errno));
+    return CommandFailure(rte_errno, "DPDK error: %s", rte_strerror(rte_errno));
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void IPLookup::DeInit() {

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -12,7 +12,7 @@ class IPLookup final : public Module {
 
   IPLookup() : Module(), lpm_(), default_gate_() {}
 
-  pb_error_t Init(const bess::pb::IPLookupArg &arg);
+  CommandResponse Init(const bess::pb::IPLookupArg &arg);
 
   void DeInit() override;
 

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -18,8 +18,8 @@ class IPLookup final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::IPLookupCommandAddArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::IPLookupCommandAddArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   struct rte_lpm *lpm_;

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -575,19 +575,14 @@ void L2Forward::ProcessBatch(bess::PacketBatch *batch) {
   RunSplit(out_gates, batch);
 }
 
-pb_cmd_response_t L2Forward::CommandAdd(
+CommandResponse L2Forward::CommandAdd(
     const bess::pb::L2ForwardCommandAddArg &arg) {
-  pb_cmd_response_t response;
-
   for (int i = 0; i < arg.entries_size(); i++) {
     const auto &entry = arg.entries(i);
 
     if (!entry.addr().length()) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL,
-                                      "add list item map must contain addr"
-                                      " as a string"));
-      return response;
+      return CommandFailure(EINVAL,
+                            "add list item map must contain addr as a string");
     }
 
     const char *str_addr = entry.addr().c_str();
@@ -595,148 +590,104 @@ pb_cmd_response_t L2Forward::CommandAdd(
     char addr[6];
 
     if (parse_mac_addr(str_addr, addr) != 0) {
-      set_cmd_response_error(
-          &response,
-          pb_error(EINVAL, "%s is not a proper mac address", str_addr));
-      return response;
+      return CommandFailure(EINVAL, "%s is not a proper mac address", str_addr);
     }
 
     int r = l2_add_entry(&l2_table_, l2_addr_to_u64(addr), gate);
 
     if (r == -EEXIST) {
-      set_cmd_response_error(
-          &response,
-          pb_error(EEXIST, "MAC address '%s' already exist", str_addr));
-      return response;
+      return CommandFailure(EEXIST, "MAC address '%s' already exist", str_addr);
     } else if (r == -ENOMEM) {
-      set_cmd_response_error(&response, pb_error(ENOMEM, "Not enough space"));
-      return response;
+      return CommandFailure(ENOMEM, "Not enough space");
     } else if (r != 0) {
-      set_cmd_response_error(&response, pb_errno(-r));
-      return response;
+      return CommandFailure(-r);
     }
   }
 
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t L2Forward::CommandDelete(
+CommandResponse L2Forward::CommandDelete(
     const bess::pb::L2ForwardCommandDeleteArg &arg) {
-  pb_cmd_response_t response;
-
   for (int i = 0; i < arg.addrs_size(); i++) {
     const auto &_addr = arg.addrs(i);
 
     if (!_addr.length()) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "lookup must be list of string"));
-      return response;
+      return CommandFailure(EINVAL, "lookup must be list of string");
     }
 
     const char *str_addr = _addr.c_str();
     char addr[6];
 
     if (parse_mac_addr(str_addr, addr) != 0) {
-      set_cmd_response_error(
-          &response,
-          pb_error(EINVAL, "%s is not a proper mac address", str_addr));
-      return response;
+      return CommandFailure(EINVAL, "%s is not a proper mac address", str_addr);
     }
 
     int r = l2_del_entry(&l2_table_, l2_addr_to_u64(addr));
 
     if (r == -ENOENT) {
-      set_cmd_response_error(
-          &response,
-          pb_error(ENOENT, "MAC address '%s' does not exist", str_addr));
-      return response;
+      return CommandFailure(ENOENT, "MAC address '%s' does not exist",
+                            str_addr);
     } else if (r != 0) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "Unknown Error: %d\n", r));
-      return response;
+      return CommandFailure(EINVAL, "Unknown Error: %d\n", r);
     }
   }
 
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t L2Forward::CommandSetDefaultGate(
+CommandResponse L2Forward::CommandSetDefaultGate(
     const bess::pb::L2ForwardCommandSetDefaultGateArg &arg) {
-  pb_cmd_response_t response;
-
   default_gate_ = arg.gate();
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t L2Forward::CommandLookup(
+CommandResponse L2Forward::CommandLookup(
     const bess::pb::L2ForwardCommandLookupArg &arg) {
-  int i;
-  pb_cmd_response_t response;
   bess::pb::L2ForwardCommandLookupResponse ret;
-  for (i = 0; i < arg.addrs_size(); i++) {
+  for (int i = 0; i < arg.addrs_size(); i++) {
     const auto &_addr = arg.addrs(i);
 
     if (!_addr.length()) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "lookup must be list of string"));
-      return response;
+      return CommandFailure(EINVAL, "lookup must be list of string");
     }
 
     const char *str_addr = _addr.c_str();
     char addr[6];
 
     if (parse_mac_addr(str_addr, addr) != 0) {
-      set_cmd_response_error(
-          &response,
-          pb_error(EINVAL, "%s is not a proper mac address", str_addr));
-      return response;
+      return CommandFailure(EINVAL, "%s is not a proper mac address", str_addr);
     }
 
     gate_idx_t gate;
     int r = l2_find(&l2_table_, l2_addr_to_u64(addr), &gate);
 
     if (r == -ENOENT) {
-      set_cmd_response_error(
-          &response,
-          pb_error(ENOENT, "MAC address '%s' does not exist", str_addr));
-      return response;
+      return CommandFailure(ENOENT, "MAC address '%s' does not exist",
+                            str_addr);
     } else if (r != 0) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "Unknown Error: %d\n", r));
-      return response;
+      return CommandFailure(EINVAL, "Unknown Error: %d\n", r);
     }
     ret.add_gates(gate);
   }
 
-  response.mutable_error()->set_err(0);
-  response.mutable_other()->PackFrom(ret);
-  return response;
+  return CommandSuccess(ret);
 }
 
-pb_cmd_response_t L2Forward::CommandPopulate(
+CommandResponse L2Forward::CommandPopulate(
     const bess::pb::L2ForwardCommandPopulateArg &arg) {
-  pb_cmd_response_t response;
   const char *base;
   char base_str[6] = {0};
   uint64_t base_u64;
 
   if (!arg.base().length()) {
-    set_cmd_response_error(
-        &response,
-        pb_error(EINVAL, "base must exist in gen, and must be string"));
-    return response;
+    return CommandFailure(EINVAL, "base must exist in gen, and must be string");
   }
 
   // parse base addr
   base = arg.base().c_str();
   if (parse_mac_addr(base, base_str) != 0) {
-    set_cmd_response_error(
-        &response,
-        pb_error(EINVAL, "%s is not a proper mac address", base_str));
-    return response;
+    return CommandFailure(EINVAL, "%s is not a proper mac address", base_str);
   }
 
   base_u64 = l2_addr_to_u64(base_str);
@@ -753,8 +704,7 @@ pb_cmd_response_t L2Forward::CommandPopulate(
     base_u64++;
   }
 
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 ADD_MODULE(L2Forward, "l2_forward",

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -527,7 +527,7 @@ const Commands L2Forward::cmds = {
      MODULE_CMD_FUNC(&L2Forward::CommandPopulate), 0},
 };
 
-pb_error_t L2Forward::Init(const bess::pb::L2ForwardArg &arg) {
+CommandResponse L2Forward::Init(const bess::pb::L2ForwardArg &arg) {
   int ret = 0;
   int size = arg.size();
   int bucket = arg.bucket();
@@ -544,13 +544,13 @@ pb_error_t L2Forward::Init(const bess::pb::L2ForwardArg &arg) {
   ret = l2_init(&l2_table_, size, bucket);
 
   if (ret != 0) {
-    return pb_error(-ret,
-                    "initialization failed with argument "
-                    "size: '%d' bucket: '%d'",
-                    size, bucket);
+    return CommandFailure(-ret,
+                          "initialization failed with argument "
+                          "size: '%d' bucket: '%d'",
+                          size, bucket);
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void L2Forward::DeInit() {

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -35,7 +35,7 @@ class L2Forward final : public Module {
 
   L2Forward() : Module(), l2_table_(), default_gate_() {}
 
-  pb_error_t Init(const bess::pb::L2ForwardArg &arg);
+  CommandResponse Init(const bess::pb::L2ForwardArg &arg);
 
   void DeInit() override;
 

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -41,14 +41,12 @@ class L2Forward final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::L2ForwardCommandAddArg &arg);
-  pb_cmd_response_t CommandDelete(
-      const bess::pb::L2ForwardCommandDeleteArg &arg);
-  pb_cmd_response_t CommandSetDefaultGate(
+  CommandResponse CommandAdd(const bess::pb::L2ForwardCommandAddArg &arg);
+  CommandResponse CommandDelete(const bess::pb::L2ForwardCommandDeleteArg &arg);
+  CommandResponse CommandSetDefaultGate(
       const bess::pb::L2ForwardCommandSetDefaultGateArg &arg);
-  pb_cmd_response_t CommandLookup(
-      const bess::pb::L2ForwardCommandLookupArg &arg);
-  pb_cmd_response_t CommandPopulate(
+  CommandResponse CommandLookup(const bess::pb::L2ForwardCommandLookupArg &arg);
+  CommandResponse CommandPopulate(
       const bess::pb::L2ForwardCommandPopulateArg &arg);
 
  private:

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -30,7 +30,7 @@ const Commands Measure::cmds = {
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&Measure::CommandClear), 0},
 };
 
-pb_error_t Measure::Init(const bess::pb::MeasureArg &arg) {
+CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
   // seconds from nanoseconds
   warmup_ns_ = arg.warmup() * 1000000000ull;
 
@@ -49,7 +49,7 @@ pb_error_t Measure::Init(const bess::pb::MeasureArg &arg) {
 
   start_ns_ = tsc_to_ns(rdtsc());
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void Measure::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -91,12 +91,10 @@ void Measure::ProcessBatch(bess::PacketBatch *batch) {
   RunNextModule(batch);
 }
 
-pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
+CommandResponse Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
   uint64_t pkt_total = pkt_cnt_;
   uint64_t byte_total = bytes_cnt_;
   uint64_t bits = (byte_total + pkt_total * 24) * 8;
-
-  pb_cmd_response_t response;
 
   bess::pb::MeasureCommandGetSummaryResponse r;
 
@@ -115,16 +113,13 @@ pb_cmd_response_t Measure::CommandGetSummary(const bess::pb::EmptyArg &) {
   r.set_jitter_50_ns(jitter_hist_.percentile(50));
   r.set_jitter_99_ns(jitter_hist_.percentile(99));
 
-  response.mutable_error()->set_err(0);
-  response.mutable_other()->PackFrom(r);
-
-  return response;
+  return CommandSuccess(r);
 }
 
-pb_cmd_response_t Measure::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse Measure::CommandClear(const bess::pb::EmptyArg &) {
   rtt_hist_.reset();
   jitter_hist_.reset();
-  return pb_cmd_response_t();
+  return CommandResponse();
 }
 
 ADD_MODULE(Measure, "measure",

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -22,7 +22,7 @@ class Measure final : public Module {
         bytes_cnt_(),
         total_latency_() {}
 
-  pb_error_t Init(const bess::pb::MeasureArg &arg);
+  CommandResponse Init(const bess::pb::MeasureArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -26,8 +26,8 @@ class Measure final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandGetSummary(const bess::pb::EmptyArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandGetSummary(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
   static const Commands cmds;
 

--- a/core/modules/mttest.cc
+++ b/core/modules/mttest.cc
@@ -39,17 +39,17 @@ pb_error_t MetadataTest::Init(const bess::pb::MetadataTestArg &arg) {
   pb_error_t err;
 
   err = AddAttributes(arg.read(), Attribute::AccessMode::kRead);
-  if (err.err() != 0) {
+  if (err.code() != 0) {
     return err;
   }
 
   err = AddAttributes(arg.write(), Attribute::AccessMode::kWrite);
-  if (err.err() != 0) {
+  if (err.code() != 0) {
     return err;
   }
 
   err = AddAttributes(arg.update(), Attribute::AccessMode::kUpdate);
-  if (err.err() != 0) {
+  if (err.code() != 0) {
     return err;
   }
 

--- a/core/modules/mttest.cc
+++ b/core/modules/mttest.cc
@@ -2,7 +2,7 @@
 
 #include <glog/logging.h>
 
-pb_error_t MetadataTest::AddAttributes(
+CommandResponse MetadataTest::AddAttributes(
     const google::protobuf::Map<std::string, int64_t> &attributes,
     Attribute::AccessMode mode) {
   for (const auto &kv : attributes) {
@@ -13,7 +13,7 @@ pb_error_t MetadataTest::AddAttributes(
 
     ret = AddMetadataAttr(attr_name, attr_size, mode);
     if (ret < 0)
-      return pb_error(-ret, "invalid metadata declaration");
+      return CommandFailure(-ret, "invalid metadata declaration");
 
     /* check /var/log/syslog for log messages */
     switch (mode) {
@@ -32,28 +32,28 @@ pb_error_t MetadataTest::AddAttributes(
     }
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
-pb_error_t MetadataTest::Init(const bess::pb::MetadataTestArg &arg) {
-  pb_error_t err;
+CommandResponse MetadataTest::Init(const bess::pb::MetadataTestArg &arg) {
+  CommandResponse err;
 
   err = AddAttributes(arg.read(), Attribute::AccessMode::kRead);
-  if (err.code() != 0) {
+  if (err.error().code() != 0) {
     return err;
   }
 
   err = AddAttributes(arg.write(), Attribute::AccessMode::kWrite);
-  if (err.code() != 0) {
+  if (err.error().code() != 0) {
     return err;
   }
 
   err = AddAttributes(arg.update(), Attribute::AccessMode::kUpdate);
-  if (err.code() != 0) {
+  if (err.error().code() != 0) {
     return err;
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void MetadataTest::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/mttest.h
+++ b/core/modules/mttest.h
@@ -11,12 +11,12 @@ class MetadataTest final : public Module {
   static const gate_idx_t kNumIGates = MAX_GATES;
   static const gate_idx_t kNumOGates = MAX_GATES;
 
-  pb_error_t Init(const bess::pb::MetadataTestArg &arg);
+  CommandResponse Init(const bess::pb::MetadataTestArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch);
 
  private:
-  pb_error_t AddAttributes(
+  CommandResponse AddAttributes(
       const google::protobuf::Map<std::string, int64_t> &attrs,
       Attribute::AccessMode mode);
 };

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -38,16 +38,16 @@ pb_error_t NAT::Init(const bess::pb::NATArg &arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t NAT::CommandAdd(const bess::pb::NATArg &arg) {
+CommandResponse NAT::CommandAdd(const bess::pb::NATArg &arg) {
   InitRules(arg);
-  return pb_cmd_response_t();
+  return CommandResponse();
 }
 
-pb_cmd_response_t NAT::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse NAT::CommandClear(const bess::pb::EmptyArg &) {
   rules_.clear();
   flow_hash_.Clear();
 
-  return pb_cmd_response_t();
+  return CommandResponse();
 }
 
 // Extract a Flow object from IP header ip and L4 header l4
@@ -163,15 +163,13 @@ static inline void stamp_flow(struct Ipv4Header *ip, void *l4,
 
 // Rewrite IP header and L4 header src info using flow
 static inline void stamp_flow_src(struct Ipv4Header *ip, void *l4,
-                                  const Flow &flow)
-{
+                                  const Flow &flow) {
   stamp_flow<true>(ip, l4, flow);
 }
 
 // Rewrite IP header and L4 header dst info using flow
 static inline void stamp_flow_dst(struct Ipv4Header *ip, void *l4,
-                                  const Flow &flow)
-{
+                                  const Flow &flow) {
   stamp_flow<false>(ip, l4, flow);
 }
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -33,9 +33,9 @@ std::string Flow::ToString() const {
                              dst_ip, dst_port);
 }
 
-pb_error_t NAT::Init(const bess::pb::NATArg &arg) {
+CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
   InitRules(arg);
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 CommandResponse NAT::CommandAdd(const bess::pb::NATArg &arg) {

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -185,8 +185,8 @@ class NAT final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::NATArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::NATArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   void InitRules(const bess::pb::NATArg &arg) {

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -181,7 +181,7 @@ class NAT final : public Module {
   static const gate_idx_t kNumIGates = 2;
   static const gate_idx_t kNumOGates = 2;
 
-  pb_error_t Init(const bess::pb::NATArg &arg);
+  CommandResponse Init(const bess::pb::NATArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/noop.cc
+++ b/core/modules/noop.cc
@@ -1,13 +1,13 @@
 #include "noop.h"
 
-pb_error_t NoOP::Init(const bess::pb::EmptyArg &) {
+CommandResponse NoOP::Init(const bess::pb::EmptyArg &) {
   task_id_t tid;
 
   tid = RegisterTask(nullptr);
   if (tid == INVALID_TASK_ID)
-    return pb_error(ENOMEM, "Task creation failed");
+    return CommandFailure(ENOMEM, "Task creation failed");
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 struct task_result NoOP::RunTask(void *) {

--- a/core/modules/noop.h
+++ b/core/modules/noop.h
@@ -6,7 +6,7 @@
 
 class NoOP final : public Module {
  public:
-  pb_error_t Init(const bess::pb::EmptyArg &arg);
+  CommandResponse Init(const bess::pb::EmptyArg &arg);
 
   struct task_result RunTask(void *arg) override;
 

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -117,20 +117,17 @@ struct task_result PortInc::RunTask(void *arg) {
   return ret;
 }
 
-pb_error_t PortInc::SetBurst(uint64_t burst) {
-  if (burst > bess::PacketBatch::kMaxBurst) {
-    return pb_error(EINVAL, "burst size must be [0,%zu]",
-                    bess::PacketBatch::kMaxBurst);
-  }
-  burst_ = burst;
-  return pb_errno(0);
-}
-
-pb_cmd_response_t PortInc::CommandSetBurst(
+CommandResponse PortInc::CommandSetBurst(
     const bess::pb::PortIncCommandSetBurstArg &arg) {
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, SetBurst(arg.burst()));
-  return response;
+  uint64_t burst = arg.burst();
+
+  if (burst > bess::PacketBatch::kMaxBurst) {
+    return CommandFailure(EINVAL, "burst size must be [0,%zu]",
+                          bess::PacketBatch::kMaxBurst);
+  }
+
+  burst_ = burst;
+  return CommandSuccess();
 }
 
 ADD_MODULE(PortInc, "port_inc", "receives packets from a port")

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -6,23 +6,23 @@ const Commands PortInc::cmds = {
      MODULE_CMD_FUNC(&PortInc::CommandSetBurst), 1},
 };
 
-pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
+CommandResponse PortInc::Init(const bess::pb::PortIncArg &arg) {
   const char *port_name;
   queue_t num_inc_q;
   int ret;
-  pb_error_t err;
+  CommandResponse err;
   placement_constraint placement;
 
   burst_ = bess::PacketBatch::kMaxBurst;
 
   if (!arg.port().length()) {
-    return pb_error(EINVAL, "'port' must be given as a string");
+    return CommandFailure(EINVAL, "'port' must be given as a string");
   }
   port_name = arg.port().c_str();
 
   const auto &it = PortBuilder::all_ports().find(port_name);
   if (it == PortBuilder::all_ports().end()) {
-    return pb_error(ENODEV, "Port %s not found", port_name);
+    return CommandFailure(ENODEV, "Port %s not found", port_name);
   }
 
   port_ = it->second;
@@ -30,7 +30,7 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
 
   num_inc_q = port_->num_queues[PACKET_DIR_INC];
   if (num_inc_q == 0) {
-    return pb_error(ENODEV, "Port %s has no incoming queue", port_name);
+    return CommandFailure(ENODEV, "Port %s has no incoming queue", port_name);
   }
 
   placement = port_->GetNodePlacementConstraint();
@@ -40,7 +40,7 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
     task_id_t tid = RegisterTask((void *)(uintptr_t)qid);
 
     if (tid == INVALID_TASK_ID) {
-      return pb_error(ENOMEM, "Task creation failed");
+      return CommandFailure(ENOMEM, "Task creation failed");
     }
   }
 
@@ -51,10 +51,10 @@ pb_error_t PortInc::Init(const bess::pb::PortIncArg &arg) {
   ret = port_->AcquireQueues(reinterpret_cast<const module *>(this),
                              PACKET_DIR_INC, nullptr, 0);
   if (ret < 0) {
-    return pb_errno(-ret);
+    return CommandFailure(-ret);
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void PortInc::DeInit() {

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -13,7 +13,7 @@ class PortInc final : public Module {
 
   PortInc() : Module(), port_(), prefetch_(), burst_() {}
 
-  pb_error_t Init(const bess::pb::PortIncArg &arg);
+  CommandResponse Init(const bess::pb::PortIncArg &arg);
 
   void DeInit() override;
 

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -21,12 +21,10 @@ class PortInc final : public Module {
 
   std::string GetDesc() const override;
 
-  pb_cmd_response_t CommandSetBurst(
+  CommandResponse CommandSetBurst(
       const bess::pb::PortIncCommandSetBurstArg &arg);
 
  private:
-  pb_error_t SetBurst(uint64_t burst);
-
   Port *port_;
   int prefetch_;
   int burst_;

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -1,24 +1,24 @@
 #include "port_out.h"
 #include "../utils/format.h"
 
-pb_error_t PortOut::Init(const bess::pb::PortOutArg &arg) {
+CommandResponse PortOut::Init(const bess::pb::PortOutArg &arg) {
   const char *port_name;
   int ret;
 
   if (!arg.port().length()) {
-    return pb_error(EINVAL, "'port' must be given as a string");
+    return CommandFailure(EINVAL, "'port' must be given as a string");
   }
 
   port_name = arg.port().c_str();
 
   const auto &it = PortBuilder::all_ports().find(port_name);
   if (it == PortBuilder::all_ports().end()) {
-    return pb_error(ENODEV, "Port %s not found", port_name);
+    return CommandFailure(ENODEV, "Port %s not found", port_name);
   }
   port_ = it->second;
 
   if (port_->num_queues[PACKET_DIR_OUT] == 0) {
-    return pb_error(ENODEV, "Port %s has no outgoing queue", port_name);
+    return CommandFailure(ENODEV, "Port %s has no outgoing queue", port_name);
   }
 
   ret = port_->AcquireQueues(reinterpret_cast<const module *>(this),
@@ -27,10 +27,10 @@ pb_error_t PortOut::Init(const bess::pb::PortOutArg &arg) {
   node_constraints_ = port_->GetNodePlacementConstraint();
 
   if (ret < 0) {
-    return pb_errno(-ret);
+    return CommandFailure(-ret);
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void PortOut::DeInit() {

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -11,7 +11,7 @@ class PortOut final : public Module {
 
   PortOut() : Module(), port_() {}
 
-  pb_error_t Init(const bess::pb::PortOutArg &arg);
+  CommandResponse Init(const bess::pb::PortOutArg &arg);
 
   void DeInit() override;
 

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -22,13 +22,11 @@ class Queue final : public Module {
 
   std::string GetDesc() const override;
 
-  pb_cmd_response_t CommandSetBurst(
-      const bess::pb::QueueCommandSetBurstArg &arg);
-  pb_cmd_response_t CommandSetSize(const bess::pb::QueueCommandSetSizeArg &arg);
+  CommandResponse CommandSetBurst(const bess::pb::QueueCommandSetBurstArg &arg);
+  CommandResponse CommandSetSize(const bess::pb::QueueCommandSetSizeArg &arg);
 
  private:
   int Resize(int slots);
-  pb_error_t SetBurst(uint64_t burst);
   pb_error_t SetSize(uint64_t size);
 
   struct llring *queue_;

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -13,7 +13,7 @@ class Queue final : public Module {
     propagate_workers_ = false;
   }
 
-  pb_error_t Init(const bess::pb::QueueArg &arg);
+  CommandResponse Init(const bess::pb::QueueArg &arg);
 
   void DeInit() override;
 
@@ -27,7 +27,7 @@ class Queue final : public Module {
 
  private:
   int Resize(int slots);
-  pb_error_t SetSize(uint64_t size);
+  CommandResponse SetSize(uint64_t size);
 
   struct llring *queue_;
   bool prefetch_;

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -103,20 +103,15 @@ struct task_result QueueInc::RunTask(void *arg) {
   return ret;
 }
 
-pb_error_t QueueInc::SetBurst(uint64_t burst) {
-  if (burst > bess::PacketBatch::kMaxBurst) {
-    return pb_error(EINVAL, "burst size must be [0,%zu]",
-                    bess::PacketBatch::kMaxBurst);
-  }
-  burst_ = burst;
-  return pb_errno(0);
-}
-
-pb_cmd_response_t QueueInc::CommandSetBurst(
+CommandResponse QueueInc::CommandSetBurst(
     const bess::pb::QueueIncCommandSetBurstArg &arg) {
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, SetBurst(arg.burst()));
-  return response;
+  if (arg.burst() > bess::PacketBatch::kMaxBurst) {
+    return CommandFailure(EINVAL, "burst size must be [0,%zu]",
+                          bess::PacketBatch::kMaxBurst);
+  } else {
+    burst_ = arg.burst();
+    return CommandSuccess();
+  }
 }
 
 ADD_MODULE(QueueInc, "queue_inc",

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -7,20 +7,20 @@ const Commands QueueInc::cmds = {{"set_burst", "QueueIncCommandSetBurstArg",
                                   MODULE_CMD_FUNC(&QueueInc::CommandSetBurst),
                                   1}};
 
-pb_error_t QueueInc::Init(const bess::pb::QueueIncArg &arg) {
+CommandResponse QueueInc::Init(const bess::pb::QueueIncArg &arg) {
   const char *port_name;
   task_id_t tid;
-  pb_error_t err;
+  CommandResponse err;
   burst_ = bess::PacketBatch::kMaxBurst;
   if (!arg.port().length()) {
-    return pb_error(EINVAL, "Field 'port' must be specified");
+    return CommandFailure(EINVAL, "Field 'port' must be specified");
   }
   port_name = arg.port().c_str();
   qid_ = arg.qid();
 
   const auto &it = PortBuilder::all_ports().find(port_name);
   if (it == PortBuilder::all_ports().end()) {
-    return pb_error(ENODEV, "Port %s not found", port_name);
+    return CommandFailure(ENODEV, "Port %s not found", port_name);
   }
   port_ = it->second;
   burst_ = bess::PacketBatch::kMaxBurst;
@@ -31,15 +31,15 @@ pb_error_t QueueInc::Init(const bess::pb::QueueIncArg &arg) {
   node_constraints_ = port_->GetNodePlacementConstraint();
   tid = RegisterTask((void *)(uintptr_t)qid_);
   if (tid == INVALID_TASK_ID)
-    return pb_error(ENOMEM, "Task creation failed");
+    return CommandFailure(ENOMEM, "Task creation failed");
 
   int ret = port_->AcquireQueues(reinterpret_cast<const module *>(this),
                                  PACKET_DIR_INC, &qid_, 1);
   if (ret < 0) {
-    return pb_errno(-ret);
+    return CommandFailure(-ret);
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void QueueInc::DeInit() {

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -13,7 +13,7 @@ class QueueInc final : public Module {
 
   QueueInc() : Module(), port_(), qid_(), prefetch_(), burst_() {}
 
-  pb_error_t Init(const bess::pb::QueueIncArg &arg);
+  CommandResponse Init(const bess::pb::QueueIncArg &arg);
   void DeInit() override;
 
   struct task_result RunTask(void *arg) override;

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -20,7 +20,7 @@ class QueueInc final : public Module {
 
   std::string GetDesc() const override;
 
-  pb_cmd_response_t CommandSetBurst(
+  CommandResponse CommandSetBurst(
       const bess::pb::QueueIncCommandSetBurstArg &arg);
 
  private:
@@ -28,7 +28,6 @@ class QueueInc final : public Module {
   queue_t qid_;
   int prefetch_;
   int burst_;
-  pb_error_t SetBurst(uint64_t burst);
 };
 
 #endif  // BESS_MODULES_QUEUEINC_H_

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -3,12 +3,12 @@
 #include "../port.h"
 #include "../utils/format.h"
 
-pb_error_t QueueOut::Init(const bess::pb::QueueOutArg &arg) {
+CommandResponse QueueOut::Init(const bess::pb::QueueOutArg &arg) {
   const char *port_name;
   int ret;
 
   if (!arg.port().length()) {
-    return pb_error(EINVAL, "Field 'port' must be specified");
+    return CommandFailure(EINVAL, "Field 'port' must be specified");
   }
 
   port_name = arg.port().c_str();
@@ -16,7 +16,7 @@ pb_error_t QueueOut::Init(const bess::pb::QueueOutArg &arg) {
 
   const auto &it = PortBuilder::all_ports().find(port_name);
   if (it == PortBuilder::all_ports().end()) {
-    return pb_error(ENODEV, "Port %s not found", port_name);
+    return CommandFailure(ENODEV, "Port %s not found", port_name);
   }
   port_ = it->second;
 
@@ -25,10 +25,10 @@ pb_error_t QueueOut::Init(const bess::pb::QueueOutArg &arg) {
   ret = port_->AcquireQueues(reinterpret_cast<const module *>(this),
                              PACKET_DIR_OUT, &qid_, 1);
   if (ret < 0) {
-    return pb_errno(-ret);
+    return CommandFailure(-ret);
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void QueueOut::DeInit() {

--- a/core/modules/queue_out.h
+++ b/core/modules/queue_out.h
@@ -11,7 +11,7 @@ class QueueOut final : public Module {
 
   QueueOut() : Module(), port_(), qid_() {}
 
-  pb_error_t Init(const bess::pb::QueueOutArg &arg);
+  CommandResponse Init(const bess::pb::QueueOutArg &arg);
 
   void DeInit() override;
 

--- a/core/modules/random_drop.cc
+++ b/core/modules/random_drop.cc
@@ -1,14 +1,14 @@
 #include "random_drop.h"
-#include <time.h>
 #include <string>
+#include <time.h>
 
-pb_error_t RandomDrop::Init(const bess::pb::RandomDropArg &arg) {
+CommandResponse RandomDrop::Init(const bess::pb::RandomDropArg &arg) {
   double drop_rate = arg.drop_rate();
   if (drop_rate < 0 || drop_rate > 1) {
-    return pb_error(EINVAL, "drop rate needs to be between [0, 1]");
+    return CommandFailure(EINVAL, "drop rate needs to be between [0, 1]");
   }
   threshold_ = drop_rate * kRange;
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void RandomDrop::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/random_drop.h
+++ b/core/modules/random_drop.h
@@ -5,17 +5,16 @@
 #include "../module_msg.pb.h"
 #include "../utils/random.h"
 
-
 // RandomDrop drops packets with a specified probability [0, 1].
 class RandomDrop final : public Module {
  public:
   static const uint32_t kRange = 1000000;  // for granularity
-  pb_error_t Init(const bess::pb::RandomDropArg &arg);
+  CommandResponse Init(const bess::pb::RandomDropArg &arg);
   void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
-  Random rng_; // Random number generator
-  uint threshold_; // Drop threshold for random number generated
+  Random rng_;      // Random number generator
+  uint threshold_;  // Drop threshold for random number generated
 };
 
 #endif  // BESS_MODULES_RANDOM_DROP_H_

--- a/core/modules/random_update.cc
+++ b/core/modules/random_update.cc
@@ -9,9 +9,8 @@ const Commands RandomUpdate::cmds = {
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&RandomUpdate::CommandClear), 0},
 };
 
-pb_error_t RandomUpdate::Init(const bess::pb::RandomUpdateArg &arg) {
-  CommandResponse response = CommandAdd(arg);
-  return response.error();
+CommandResponse RandomUpdate::Init(const bess::pb::RandomUpdateArg &arg) {
+  return CommandAdd(arg);
 }
 
 CommandResponse RandomUpdate::CommandAdd(const bess::pb::RandomUpdateArg &arg) {

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -17,8 +17,8 @@ class RandomUpdate final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::RandomUpdateArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::RandomUpdateArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   int num_vars_;

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -13,7 +13,7 @@ class RandomUpdate final : public Module {
 
   RandomUpdate() : Module(), num_vars_(), vars_(), rng_() {}
 
-  pb_error_t Init(const bess::pb::RandomUpdateArg &arg);
+  CommandResponse Init(const bess::pb::RandomUpdateArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -21,14 +21,10 @@ pb_error_t Replicate::Init(const bess::pb::ReplicateArg &arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t Replicate::CommandSetGates(
+CommandResponse Replicate::CommandSetGates(
     const bess::pb::ReplicateCommandSetGatesArg &arg) {
-  pb_cmd_response_t response;
-
   if (arg.gates_size() > kMaxGates) {
-    set_cmd_response_error(
-        &response, pb_error(EINVAL, "no more than %d gates", kMaxGates));
-    return response;
+    return CommandFailure(EINVAL, "no more than %d gates", kMaxGates);
   }
 
   for (int i = 0; i < arg.gates_size(); i++) {
@@ -36,8 +32,7 @@ pb_cmd_response_t Replicate::CommandSetGates(
   }
 
   ngates_ = arg.gates_size();
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 void Replicate::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -5,11 +5,11 @@ const Commands Replicate::cmds = {
      MODULE_CMD_FUNC(&Replicate::CommandSetGates), 0},
 };
 
-pb_error_t Replicate::Init(const bess::pb::ReplicateArg &arg) {
-  pb_error_t err;
+CommandResponse Replicate::Init(const bess::pb::ReplicateArg &arg) {
+  CommandResponse err;
 
   if (arg.gates_size() > kMaxGates) {
-    return pb_error(EINVAL, "no more than %d gates", kMaxGates);
+    return CommandFailure(EINVAL, "no more than %d gates", kMaxGates);
   }
 
   for (int i = 0; i < arg.gates_size(); i++) {
@@ -18,7 +18,7 @@ pb_error_t Replicate::Init(const bess::pb::ReplicateArg &arg) {
   }
   ngates_ = arg.gates_size();
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 CommandResponse Replicate::CommandSetGates(

--- a/core/modules/replicate.h
+++ b/core/modules/replicate.h
@@ -13,7 +13,7 @@ class Replicate final : public Module {
 
   Replicate() : Module(), gates_(), ngates_() {}
 
-  pb_error_t Init(const bess::pb::ReplicateArg &arg);
+  CommandResponse Init(const bess::pb::ReplicateArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/replicate.h
+++ b/core/modules/replicate.h
@@ -20,7 +20,7 @@ class Replicate final : public Module {
   /*!
    * Sets the number of output gates.
    */
-  pb_cmd_response_t CommandSetGates(
+  CommandResponse CommandSetGates(
       const bess::pb::ReplicateCommandSetGatesArg &arg);
 
  private:

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -11,34 +11,27 @@ const Commands Rewrite::cmds = {
 
 pb_error_t Rewrite::Init(const bess::pb::RewriteArg &arg) {
   if (arg.templates_size() > 0) {
-    pb_cmd_response_t response = CommandAdd(arg);
+    CommandResponse response = CommandAdd(arg);
     return response.error();
   } else {
     return pb_errno(0);
   }
 }
 
-pb_cmd_response_t Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {
-  pb_cmd_response_t response;
-
+CommandResponse Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {
   size_t curr = num_templates_;
 
   if (curr + arg.templates_size() > bess::PacketBatch::kMaxBurst) {
-    set_cmd_response_error(&response, pb_error(EINVAL,
-                                               "max %zu packet templates "
-                                               "can be used %zu %d",
-                                               bess::PacketBatch::kMaxBurst,
-                                               curr, arg.templates_size()));
-    return response;
+    return CommandFailure(EINVAL, "max %zu packet templates can be used %zu %d",
+                          bess::PacketBatch::kMaxBurst, curr,
+                          arg.templates_size());
   }
 
   for (int i = 0; i < arg.templates_size(); i++) {
     const auto &templ = arg.templates(i);
 
     if (templ.length() > kMaxTemplateSize) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "template is too big"));
-      return response;
+      return CommandFailure(EINVAL, "template is too big");
     }
 
     memset(templates_[curr + i], 0, kMaxTemplateSize);
@@ -48,8 +41,7 @@ pb_cmd_response_t Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {
 
   num_templates_ = curr + arg.templates_size();
   if (num_templates_ == 0) {
-    set_cmd_response_error(&response, pb_errno(0));
-    return response;
+    return CommandSuccess();
   }
 
   for (size_t i = num_templates_; i < kNumSlots; i++) {
@@ -58,18 +50,13 @@ pb_cmd_response_t Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {
     template_size_[i] = template_size_[j];
   }
 
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t Rewrite::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse Rewrite::CommandClear(const bess::pb::EmptyArg &) {
   next_turn_ = 0;
   num_templates_ = 0;
-
-  pb_cmd_response_t response;
-
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 inline void Rewrite::DoRewriteSingle(bess::PacketBatch *batch) {

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -9,13 +9,8 @@ const Commands Rewrite::cmds = {
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&Rewrite::CommandClear), 0},
 };
 
-pb_error_t Rewrite::Init(const bess::pb::RewriteArg &arg) {
-  if (arg.templates_size() > 0) {
-    CommandResponse response = CommandAdd(arg);
-    return response.error();
-  } else {
-    return pb_errno(0);
-  }
+CommandResponse Rewrite::Init(const bess::pb::RewriteArg &arg) {
+  return CommandAdd(arg);
 }
 
 CommandResponse Rewrite::CommandAdd(const bess::pb::RewriteArg &arg) {

--- a/core/modules/rewrite.h
+++ b/core/modules/rewrite.h
@@ -18,7 +18,7 @@ class Rewrite final : public Module {
         template_size_(),
         templates_() {}
 
-  pb_error_t Init(const bess::pb::RewriteArg &arg);
+  CommandResponse Init(const bess::pb::RewriteArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/rewrite.h
+++ b/core/modules/rewrite.h
@@ -22,8 +22,8 @@ class Rewrite final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::RewriteArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::RewriteArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   inline void DoRewrite(bess::PacketBatch *batch);

--- a/core/modules/round_robin.cc
+++ b/core/modules/round_robin.cc
@@ -7,18 +7,18 @@ const Commands RoundRobin::cmds = {
      MODULE_CMD_FUNC(&RoundRobin::CommandSetGates), 0},
 };
 
-pb_error_t RoundRobin::Init(const bess::pb::RoundRobinArg &arg) {
-  pb_error_t err;
+CommandResponse RoundRobin::Init(const bess::pb::RoundRobinArg &arg) {
+  CommandResponse err;
 
   if (arg.gates_size() > MAX_RR_GATES) {
-    return pb_error(EINVAL, "no more than %d gates", MAX_RR_GATES);
+    return CommandFailure(EINVAL, "no more than %d gates", MAX_RR_GATES);
   }
 
   for (int i = 0; i < arg.gates_size(); i++) {
     int elem = arg.gates(i);
     gates_[i] = elem;
     if (!is_valid_gate(gates_[i])) {
-      return pb_error(EINVAL, "invalid gate %d", gates_[i]);
+      return CommandFailure(EINVAL, "invalid gate %d", gates_[i]);
     }
   }
   ngates_ = arg.gates_size();
@@ -29,11 +29,12 @@ pb_error_t RoundRobin::Init(const bess::pb::RoundRobinArg &arg) {
     } else if (arg.mode() == "batch") {
       per_packet_ = 0;
     } else {
-      return pb_error(EINVAL, "argument must be either 'packet' or 'batch'");
+      return CommandFailure(EINVAL,
+                            "argument must be either 'packet' or 'batch'");
     }
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 CommandResponse RoundRobin::CommandSetMode(

--- a/core/modules/round_robin.cc
+++ b/core/modules/round_robin.cc
@@ -36,47 +36,35 @@ pb_error_t RoundRobin::Init(const bess::pb::RoundRobinArg &arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t RoundRobin::CommandSetMode(
+CommandResponse RoundRobin::CommandSetMode(
     const bess::pb::RoundRobinCommandSetModeArg &arg) {
-  pb_cmd_response_t response;
-
   if (arg.mode() == "packet") {
     per_packet_ = 1;
   } else if (arg.mode() == "batch") {
     per_packet_ = 0;
   } else {
-    set_cmd_response_error(
-        &response,
-        pb_error(EINVAL, "argument must be either 'packet' or 'batch'"));
-    return response;
+    return CommandFailure(EINVAL,
+                          "argument must be either 'packet' or 'batch'");
   }
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t RoundRobin::CommandSetGates(
+CommandResponse RoundRobin::CommandSetGates(
     const bess::pb::RoundRobinCommandSetGatesArg &arg) {
-  pb_cmd_response_t response;
-
   if (arg.gates_size() > MAX_RR_GATES) {
-    set_cmd_response_error(
-        &response, pb_error(EINVAL, "no more than %d gates", MAX_RR_GATES));
-    return response;
+    return CommandFailure(EINVAL, "no more than %d gates", MAX_RR_GATES);
   }
 
   for (int i = 0; i < arg.gates_size(); i++) {
     int elem = arg.gates(i);
     gates_[i] = elem;
     if (!is_valid_gate(gates_[i])) {
-      set_cmd_response_error(&response,
-                             pb_error(EINVAL, "invalid gate %d", gates_[i]));
-      return response;
+      return CommandFailure(EINVAL, "invalid gate %d", gates_[i]);
     }
   }
 
   ngates_ = arg.gates_size();
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 void RoundRobin::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/round_robin.h
+++ b/core/modules/round_robin.h
@@ -47,12 +47,12 @@ class RoundRobin final : public Module {
   /*!
    * Switches the RoundRobin module between "batch" vs "packet" scheduling.
    */
-  pb_cmd_response_t CommandSetMode(
+  CommandResponse CommandSetMode(
       const bess::pb::RoundRobinCommandSetModeArg &arg);
   /*!
    * Sets the number of output gates.
    */
-  pb_cmd_response_t CommandSetGates(
+  CommandResponse CommandSetGates(
       const bess::pb::RoundRobinCommandSetGatesArg &arg);
 
  private:

--- a/core/modules/round_robin.h
+++ b/core/modules/round_robin.h
@@ -40,7 +40,7 @@ class RoundRobin final : public Module {
   RoundRobin()
       : Module(), gates_(), ngates_(), current_gate_(), per_packet_() {}
 
-  pb_error_t Init(const bess::pb::RoundRobinArg &arg);
+  CommandResponse Init(const bess::pb::RoundRobinArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -62,8 +62,8 @@ pb_error_t SetMetadata::AddAttrOne(
   // stored in memory). value_bin is a short stream of bytes, which means that
   // its data will never be reordered.
   if (attr.value_case() == bess::pb::SetMetadataArg_Attribute::kValueInt) {
-    if (uint64_to_bin((uint8_t *)&value, size, attr.value_int(),
-                      bess::utils::is_be_system())) {
+    if (bess::utils::uint64_to_bin(&value, attr.value_int(), size,
+                                   bess::utils::is_be_system())) {
       return pb_error(EINVAL,
                       "'value_int' field has not a "
                       "correct %zu-byte value",

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -109,7 +109,7 @@ pb_error_t SetMetadata::Init(const bess::pb::SetMetadataArg &arg) {
     pb_error_t err;
 
     err = AddAttrOne(attr);
-    if (err.err() != 0) {
+    if (err.code() != 0) {
       return err;
     }
   }

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -35,7 +35,7 @@ static void CopyFromValue(bess::PacketBatch *batch, const struct Attr *attr,
   }
 }
 
-pb_error_t SetMetadata::AddAttrOne(
+CommandResponse SetMetadata::AddAttrOne(
     const bess::pb::SetMetadataArg_Attribute &attr) {
   std::string name;
   size_t size = 0;
@@ -45,14 +45,14 @@ pb_error_t SetMetadata::AddAttrOne(
   int ret;
 
   if (!attr.name().length()) {
-    return pb_error(EINVAL, "'name' field is missing");
+    return CommandFailure(EINVAL, "'name' field is missing");
   }
   name = attr.name();
   size = attr.size();
 
   if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize) {
-    return pb_error(EINVAL, "'size' must be 1-%zu",
-                    bess::metadata::kMetadataAttrMaxSize);
+    return CommandFailure(EINVAL, "'size' must be 1-%zu",
+                          bess::metadata::kMetadataAttrMaxSize);
   }
 
   // All metadata values are stored in a reserved area of packet data.
@@ -62,33 +62,33 @@ pb_error_t SetMetadata::AddAttrOne(
   // stored in memory). value_bin is a short stream of bytes, which means that
   // its data will never be reordered.
   if (attr.value_case() == bess::pb::SetMetadataArg_Attribute::kValueInt) {
-    if (bess::utils::uint64_to_bin(&value, attr.value_int(), size,
-                                   bess::utils::is_be_system())) {
-      return pb_error(EINVAL,
-                      "'value_int' field has not a "
-                      "correct %zu-byte value",
-                      size);
+    if (!bess::utils::uint64_to_bin(&value, attr.value_int(), size,
+                                    bess::utils::is_be_system())) {
+      return CommandFailure(EINVAL,
+                            "'value_int' field has not a "
+                            "correct %zu-byte value",
+                            size);
     }
   } else if (attr.value_case() ==
              bess::pb::SetMetadataArg_Attribute::kValueBin) {
     if (attr.value_bin().length() != size) {
-      return pb_error(EINVAL,
-                      "'value_bin' field has not a "
-                      "correct %zu-byte value",
-                      size);
+      return CommandFailure(EINVAL,
+                            "'value_bin' field has not a "
+                            "correct %zu-byte value",
+                            size);
     }
     bess::utils::Copy(&value, attr.value_bin().data(), size);
   } else {
     offset = attr.offset();
     if (offset < 0 || offset + size >= SNBUF_DATA) {
-      return pb_error(EINVAL, "invalid packet offset");
+      return CommandFailure(EINVAL, "invalid packet offset");
     }
   }
 
   ret = AddMetadataAttr(name, size,
                         bess::metadata::Attribute::AccessMode::kWrite);
   if (ret < 0)
-    return pb_error(-ret, "add_metadata_attr() failed");
+    return CommandFailure(-ret, "add_metadata_attr() failed");
 
   attrs_.emplace_back();
   attrs_.back().name = name;
@@ -96,25 +96,25 @@ pb_error_t SetMetadata::AddAttrOne(
   attrs_.back().offset = offset;
   attrs_.back().value = value;
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
-pb_error_t SetMetadata::Init(const bess::pb::SetMetadataArg &arg) {
+CommandResponse SetMetadata::Init(const bess::pb::SetMetadataArg &arg) {
   if (!arg.attrs_size()) {
-    return pb_error(EINVAL, "'attrs' must be specified");
+    return CommandFailure(EINVAL, "'attrs' must be specified");
   }
 
   for (int i = 0; i < arg.attrs_size(); i++) {
     const auto &attr = arg.attrs(i);
-    pb_error_t err;
+    CommandResponse err;
 
     err = AddAttrOne(attr);
-    if (err.code() != 0) {
+    if (err.error().code() != 0) {
       return err;
     }
   }
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void SetMetadata::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/set_metadata.h
+++ b/core/modules/set_metadata.h
@@ -18,12 +18,12 @@ class SetMetadata final : public Module {
  public:
   SetMetadata() : Module(), attrs_() {}
 
-  pb_error_t Init(const bess::pb::SetMetadataArg &arg);
+  CommandResponse Init(const bess::pb::SetMetadataArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch);
 
  private:
-  pb_error_t AddAttrOne(const bess::pb::SetMetadataArg_Attribute &attr);
+  CommandResponse AddAttrOne(const bess::pb::SetMetadataArg_Attribute &attr);
 
   std::vector<struct Attr> attrs_;
 };

--- a/core/modules/source.cc
+++ b/core/modules/source.cc
@@ -29,34 +29,25 @@ pb_error_t Source::Init(const bess::pb::SourceArg &arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t Source::CommandSetBurst(
+CommandResponse Source::CommandSetBurst(
     const bess::pb::SourceCommandSetBurstArg &arg) {
-  pb_cmd_response_t response;
-
   if (arg.burst() > bess::PacketBatch::kMaxBurst) {
-    set_cmd_response_error(&response,
-                           pb_error(EINVAL, "burst size must be [0,%zu]",
-                                    bess::PacketBatch::kMaxBurst));
-    return response;
+    return CommandFailure(EINVAL, "burst size must be [0,%zu]",
+                          bess::PacketBatch::kMaxBurst);
   }
   burst_ = arg.burst();
 
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t Source::CommandSetPktSize(
+CommandResponse Source::CommandSetPktSize(
     const bess::pb::SourceCommandSetPktSizeArg &arg) {
-  pb_cmd_response_t response;
-
   uint64_t val = arg.pkt_size();
   if (val == 0 || val > SNBUF_DATA) {
-    set_cmd_response_error(&response, pb_error(EINVAL, "Invalid packet size"));
-    return response;
+    return CommandFailure(EINVAL, "Invalid packet size");
   }
   pkt_size_ = val;
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 struct task_result Source::RunTask(void *) {

--- a/core/modules/source.cc
+++ b/core/modules/source.cc
@@ -7,26 +7,26 @@ const Commands Source::cmds = {
      MODULE_CMD_FUNC(&Source::CommandSetBurst), 1},
 };
 
-pb_error_t Source::Init(const bess::pb::SourceArg &arg) {
-  pb_error_t err;
+CommandResponse Source::Init(const bess::pb::SourceArg &arg) {
+  CommandResponse err;
 
   task_id_t tid = RegisterTask(nullptr);
   if (tid == INVALID_TASK_ID)
-    return pb_error(ENOMEM, "Task creation failed");
+    return CommandFailure(ENOMEM, "Task creation failed");
 
   pkt_size_ = 60;
   burst_ = bess::PacketBatch::kMaxBurst;
 
   if (arg.pkt_size() > 0) {
     if (arg.pkt_size() > SNBUF_DATA) {
-      return pb_error(EINVAL, "Invalid packet size");
+      return CommandFailure(EINVAL, "Invalid packet size");
     }
     pkt_size_ = arg.pkt_size();
   }
 
   burst_ = bess::PacketBatch::kMaxBurst;
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 CommandResponse Source::CommandSetBurst(

--- a/core/modules/source.h
+++ b/core/modules/source.h
@@ -16,9 +16,9 @@ class Source final : public Module {
 
   struct task_result RunTask(void *arg) override;
 
-  pb_cmd_response_t CommandSetBurst(
+  CommandResponse CommandSetBurst(
       const bess::pb::SourceCommandSetBurstArg &arg);
-  pb_cmd_response_t CommandSetPktSize(
+  CommandResponse CommandSetPktSize(
       const bess::pb::SourceCommandSetPktSizeArg &arg);
 
  private:

--- a/core/modules/source.h
+++ b/core/modules/source.h
@@ -12,7 +12,7 @@ class Source final : public Module {
 
   Source() : Module(), pkt_size_(), burst_() {}
 
-  pb_error_t Init(const bess::pb::SourceArg &arg);
+  CommandResponse Init(const bess::pb::SourceArg &arg);
 
   struct task_result RunTask(void *arg) override;
 

--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -14,29 +14,28 @@ static inline int is_valid_gate(gate_idx_t gate) {
   return (gate < MAX_GATES || gate == DROP_GATE);
 }
 
-pb_error_t Split::Init(const bess::pb::SplitArg &arg) {
+CommandResponse Split::Init(const bess::pb::SplitArg &arg) {
   size_ = arg.size();
   if (size_ < 1 || size_ > MAX_SIZE) {
-    return pb_error(EINVAL, "'size' must be 1-%d", MAX_SIZE);
+    return CommandFailure(EINVAL, "'size' must be 1-%d", MAX_SIZE);
   }
 
-  mask_ = (size_ == 8) ? 0xffffffffffffffffull
-                       : (1ull << (size_ * 8)) - 1;
+  mask_ = (size_ == 8) ? 0xffffffffffffffffull : (1ull << (size_ * 8)) - 1;
 
   if (arg.type_case() == bess::pb::SplitArg::kAttribute) {
     attr_id_ = AddMetadataAttr(arg.attribute().c_str(), size_,
                                bess::metadata::Attribute::AccessMode::kRead);
     if (attr_id_ < 0) {
-      return pb_error(-attr_id_, "add_metadata_attr() failed");
+      return CommandFailure(-attr_id_, "add_metadata_attr() failed");
     }
   } else {
     attr_id_ = -1;
     offset_ = arg.offset();
     if (offset_ < 0 || offset_ > 1024) {
-      return pb_error(EINVAL, "invalid 'offset'");
+      return CommandFailure(EINVAL, "invalid 'offset'");
     }
   }
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void Split::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/split.h
+++ b/core/modules/split.h
@@ -10,7 +10,7 @@ class Split final : public Module {
 
   Split() : Module(), mask_(), attr_id_(), offset_(), size_() {}
 
-  pb_error_t Init(const bess::pb::SplitArg &arg);
+  CommandResponse Init(const bess::pb::SplitArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch);
 

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -36,14 +36,14 @@ static inline void timestamp_packet(bess::Packet *pkt, size_t offset,
   *ts = time;
 }
 
-pb_error_t Timestamp::Init(const bess::pb::TimestampArg &arg) {
+CommandResponse Timestamp::Init(const bess::pb::TimestampArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
     offset_ = sizeof(struct EthHeader) + sizeof(struct Ipv4Header) +
               sizeof(struct UdpHeader);
   }
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void Timestamp::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -9,7 +9,7 @@ class Timestamp final : public Module {
   using MarkerType = uint32_t;
   static const MarkerType kMarker = 0x54C5BE55;
 
-  pb_error_t Init(const bess::pb::TimestampArg &arg);
+  CommandResponse Init(const bess::pb::TimestampArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -63,8 +63,8 @@ pb_cmd_response_t Update::CommandAdd(const bess::pb::UpdateArg &arg) {
       return response;
     }
 
-    if (uint64_to_bin((uint8_t *)&value, size, field.value(),
-                      bess::utils::is_be_system())) {
+    if (bess::utils::uint64_to_bin(&value, field.value(), size,
+                                   bess::utils::is_be_system())) {
       set_cmd_response_error(&response, pb_error(EINVAL,
                                                  "'value' field has not a "
                                                  "correct %d-byte value",

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -7,9 +7,8 @@ const Commands Update::cmds = {
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&Update::CommandClear), 0},
 };
 
-pb_error_t Update::Init(const bess::pb::UpdateArg &arg) {
-  CommandResponse response = CommandAdd(arg);
-  return response.error();
+CommandResponse Update::Init(const bess::pb::UpdateArg &arg) {
+  return CommandAdd(arg);
 }
 
 void Update::ProcessBatch(bess::PacketBatch *batch) {
@@ -57,8 +56,8 @@ CommandResponse Update::CommandAdd(const bess::pb::UpdateArg &arg) {
       return CommandFailure(EINVAL, "'size' must be 1-8");
     }
 
-    if (bess::utils::uint64_to_bin(&value, field.value(), size,
-                                   bess::utils::is_be_system())) {
+    if (!bess::utils::uint64_to_bin(&value, field.value(), size,
+                                    bess::utils::is_be_system())) {
       return CommandFailure(
           EINVAL, "'value' field has not a correct %d-byte value", size);
     }

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -8,7 +8,7 @@ const Commands Update::cmds = {
 };
 
 pb_error_t Update::Init(const bess::pb::UpdateArg &arg) {
-  pb_cmd_response_t response = CommandAdd(arg);
+  CommandResponse response = CommandAdd(arg);
   return response.error();
 }
 
@@ -34,17 +34,12 @@ void Update::ProcessBatch(bess::PacketBatch *batch) {
   RunNextModule(batch);
 }
 
-pb_cmd_response_t Update::CommandAdd(const bess::pb::UpdateArg &arg) {
-  pb_cmd_response_t response;
-
+CommandResponse Update::CommandAdd(const bess::pb::UpdateArg &arg) {
   int curr = num_fields_;
 
   if (curr + arg.fields_size() > UPDATE_MAX_FIELDS) {
-    set_cmd_response_error(&response, pb_error(EINVAL,
-                                               "max %d variables "
-                                               "can be specified",
-                                               UPDATE_MAX_FIELDS));
-    return response;
+    return CommandFailure(EINVAL, "max %d variables can be specified",
+                          UPDATE_MAX_FIELDS);
   }
 
   for (int i = 0; i < arg.fields_size(); i++) {
@@ -59,30 +54,24 @@ pb_cmd_response_t Update::CommandAdd(const bess::pb::UpdateArg &arg) {
 
     size = field.size();
     if (size < 1 || size > 8) {
-      set_cmd_response_error(&response, pb_error(EINVAL, "'size' must be 1-8"));
-      return response;
+      return CommandFailure(EINVAL, "'size' must be 1-8");
     }
 
     if (bess::utils::uint64_to_bin(&value, field.value(), size,
                                    bess::utils::is_be_system())) {
-      set_cmd_response_error(&response, pb_error(EINVAL,
-                                                 "'value' field has not a "
-                                                 "correct %d-byte value",
-                                                 size));
-      return response;
+      return CommandFailure(
+          EINVAL, "'value' field has not a correct %d-byte value", size);
     }
 
     if (offset < 0) {
-      set_cmd_response_error(&response, pb_error(EINVAL, "too small 'offset'"));
-      return response;
+      return CommandFailure(EINVAL, "too small 'offset'");
     }
 
     offset -= (8 - size);
     mask = (1ull << ((8 - size) * 8)) - 1;
 
     if (offset + 8 > SNBUF_DATA) {
-      set_cmd_response_error(&response, pb_error(EINVAL, "too large 'offset'"));
-      return response;
+      return CommandFailure(EINVAL, "too large 'offset'");
     }
 
     fields_[curr + i].offset = offset;
@@ -91,16 +80,12 @@ pb_cmd_response_t Update::CommandAdd(const bess::pb::UpdateArg &arg) {
   }
 
   num_fields_ = curr + arg.fields_size();
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
-pb_cmd_response_t Update::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse Update::CommandClear(const bess::pb::EmptyArg &) {
   num_fields_ = 0;
-
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 ADD_MODULE(Update, "update", "updates packet data with specified values")

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -16,8 +16,8 @@ class Update final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::UpdateArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::UpdateArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   int num_fields_;

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -12,7 +12,7 @@ class Update final : public Module {
 
   Update() : Module(), num_fields_(), fields_() {}
 
-  pb_error_t Init(const bess::pb::UpdateArg &arg);
+  CommandResponse Init(const bess::pb::UpdateArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -145,15 +145,14 @@ pb_error_t UrlFilter::Init(const bess::pb::UrlFilterArg &arg) {
   return pb_errno(0);
 }
 
-pb_cmd_response_t UrlFilter::CommandAdd(const bess::pb::UrlFilterArg &arg) {
-  pb_cmd_response_t response;
-  set_cmd_response_error(&response, Init(arg));
-  return response;
+CommandResponse UrlFilter::CommandAdd(const bess::pb::UrlFilterArg &arg) {
+  Init(arg);
+  return CommandSuccess();
 }
 
-pb_cmd_response_t UrlFilter::CommandClear(const bess::pb::EmptyArg &) {
+CommandResponse UrlFilter::CommandClear(const bess::pb::EmptyArg &) {
   blacklist_.clear();
-  return pb_cmd_response_t();
+  return CommandResponse();
 }
 
 void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -132,7 +132,7 @@ inline static bess::Packet *GenerateResetPacket(
   return pkt;
 }
 
-pb_error_t UrlFilter::Init(const bess::pb::UrlFilterArg &arg) {
+CommandResponse UrlFilter::Init(const bess::pb::UrlFilterArg &arg) {
   for (const auto &url : arg.blacklist()) {
     if (blacklist_.find(url.host()) == blacklist_.end()) {
       blacklist_.emplace(std::piecewise_construct,
@@ -142,7 +142,7 @@ pb_error_t UrlFilter::Init(const bess::pb::UrlFilterArg &arg) {
     Trie &trie = blacklist_.at(url.host());
     trie.Insert(url.path());
   }
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 CommandResponse UrlFilter::CommandAdd(const bess::pb::UrlFilterArg &arg) {

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -84,7 +84,7 @@ class UrlFilter final : public Module {
   static const gate_idx_t kNumIGates = 2;
   static const gate_idx_t kNumOGates = 2;
 
-  pb_error_t Init(const bess::pb::UrlFilterArg &arg);
+  CommandResponse Init(const bess::pb::UrlFilterArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -88,8 +88,8 @@ class UrlFilter final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::UrlFilterArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandAdd(const bess::pb::UrlFilterArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
   std::unordered_map<std::string, Trie> blacklist_;

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -12,9 +12,8 @@ const Commands VLANPush::cmds = {
     {"set_tci", "VLANPushArg", MODULE_CMD_FUNC(&VLANPush::CommandSetTci), 0},
 };
 
-pb_error_t VLANPush::Init(const bess::pb::VLANPushArg &arg) {
-  CommandResponse response = CommandSetTci(arg);
-  return response.error();
+CommandResponse VLANPush::Init(const bess::pb::VLANPushArg &arg) {
+  return CommandSetTci(arg);
 }
 
 CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -13,20 +13,15 @@ const Commands VLANPush::cmds = {
 };
 
 pb_error_t VLANPush::Init(const bess::pb::VLANPushArg &arg) {
-  pb_cmd_response_t response = CommandSetTci(arg);
+  CommandResponse response = CommandSetTci(arg);
   return response.error();
 }
 
-pb_cmd_response_t VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
-  pb_cmd_response_t response;
-
-  uint16_t tci;
-  tci = arg.tci();
-
+CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
+  uint16_t tci = arg.tci();
   vlan_tag_ = htonl((0x8100 << 16) | tci);
   qinq_tag_ = htonl((0x88a8 << 16) | tci);
-  set_cmd_response_error(&response, pb_errno(0));
-  return response;
+  return CommandSuccess();
 }
 
 /* the behavior is undefined if a packet is already double tagged */

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -10,7 +10,7 @@ class VLANPush final : public Module {
 
   VLANPush() : Module(), vlan_tag_(), qinq_tag_() {}
 
-  pb_error_t Init(const bess::pb::VLANPushArg &arg);
+  CommandResponse Init(const bess::pb::VLANPushArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -16,7 +16,7 @@ class VLANPush final : public Module {
 
   std::string GetDesc() const override;
 
-  pb_cmd_response_t CommandSetTci(const bess::pb::VLANPushArg &arg);
+  CommandResponse CommandSetTci(const bess::pb::VLANPushArg &arg);
 
  private:
   /* network order */

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -14,7 +14,7 @@ enum {
   ATTR_W_TUN_ID,
 };
 
-pb_error_t VXLANDecap::Init(
+CommandResponse VXLANDecap::Init(
     const bess::pb::VXLANDecapArg &arg[[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 
@@ -22,7 +22,7 @@ pb_error_t VXLANDecap::Init(
   AddMetadataAttr("tun_ip_dst", 4, AccessMode::kWrite);
   AddMetadataAttr("tun_id", 4, AccessMode::kWrite);
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/vxlan_decap.h
+++ b/core/modules/vxlan_decap.h
@@ -6,7 +6,7 @@
 
 class VXLANDecap final : public Module {
  public:
-  pb_error_t Init(const bess::pb::VXLANDecapArg &arg);
+  CommandResponse Init(const bess::pb::VXLANDecapArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch);
 };

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -18,13 +18,13 @@ enum {
   ATTR_W_IP_PROTO,
 };
 
-pb_error_t VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
+CommandResponse VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
   auto dstport = arg.dstport();
   if (dstport == 0) {
     dstport_ = rte_cpu_to_be_16(4789);
   } else {
     if (dstport >= 65536)
-      return pb_error(EINVAL, "invalid 'dstport' field");
+      return CommandFailure(EINVAL, "invalid 'dstport' field");
     dstport_ = rte_cpu_to_be_16(dstport);
   }
 
@@ -37,7 +37,7 @@ pb_error_t VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
   AddMetadataAttr("ip_dst", 4, AccessMode::kWrite);
   AddMetadataAttr("ip_proto", 1, AccessMode::kWrite);
 
-  return pb_errno(0);
+  return CommandSuccess();
 }
 
 void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -10,7 +10,7 @@ class VXLANEncap final : public Module {
  public:
   VXLANEncap() : Module(), dstport_() {}
 
-  pb_error_t Init(const bess::pb::VXLANEncapArg &arg);
+  CommandResponse Init(const bess::pb::VXLANEncapArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -113,13 +113,14 @@ class WildcardMatch final : public Module {
 
   std::string GetDesc() const override;
 
-  pb_cmd_response_t CommandAdd(const bess::pb::WildcardMatchCommandAddArg &arg);
-  pb_cmd_response_t CommandDelete(
+  CommandResponse CommandAdd(const bess::pb::WildcardMatchCommandAddArg &arg);
+  CommandResponse CommandDelete(
       const bess::pb::WildcardMatchCommandDeleteArg &arg);
-  pb_cmd_response_t CommandClear(const bess::pb::EmptyArg &arg);
-  pb_cmd_response_t CommandSetDefaultGate(
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandSetDefaultGate(
       const bess::pb::WildcardMatchCommandSetDefaultGateArg &arg);
-  pb_cmd_response_t CommandGetRules(const bess::pb::EmptyArg &);
+  CommandResponse CommandGetRules(const bess::pb::EmptyArg &);
+
  private:
   struct WmTuple {
     CuckooMap<wm_hkey_t, struct WmData, wm_hash, wm_eq> ht;
@@ -132,7 +133,7 @@ class WildcardMatch final : public Module {
                          struct WmField *f);
 
   template <typename T>
-  pb_error_t ExtractKeyMask(const T &arg, wm_hkey_t *key, wm_hkey_t *mask);
+  CommandResponse ExtractKeyMask(const T &arg, wm_hkey_t *key, wm_hkey_t *mask);
 
   int FindTuple(wm_hkey_t *mask);
   int AddTuple(wm_hkey_t *mask);

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -107,7 +107,7 @@ class WildcardMatch final : public Module {
   WildcardMatch()
       : Module(), default_gate_(), total_key_size_(), fields_(), tuples_() {}
 
-  pb_error_t Init(const bess::pb::WildcardMatchArg &arg);
+  CommandResponse Init(const bess::pb::WildcardMatchArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
@@ -129,8 +129,8 @@ class WildcardMatch final : public Module {
 
   gate_idx_t LookupEntry(const wm_hkey_t &key, gate_idx_t def_gate);
 
-  pb_error_t AddFieldOne(const bess::pb::WildcardMatchField &field,
-                         struct WmField *f);
+  CommandResponse AddFieldOne(const bess::pb::WildcardMatchField &field,
+                              struct WmField *f);
 
   template <typename T>
   CommandResponse ExtractKeyMask(const T &arg, wm_hkey_t *key, wm_hkey_t *mask);

--- a/core/port.cc
+++ b/core/port.cc
@@ -98,7 +98,7 @@ void PortBuilder::InitDrivers() {
 bool PortBuilder::RegisterPortClass(
     std::function<Port *()> port_generator, const std::string &class_name,
     const std::string &name_template, const std::string &help_text,
-    std::function<pb_error_t(Port *, const google::protobuf::Any &)>
+    std::function<CommandResponse(Port *, const google::protobuf::Any &)>
         init_func) {
   all_port_builders_holder().emplace(
       std::piecewise_construct, std::forward_as_tuple(class_name),
@@ -130,12 +130,12 @@ const std::map<std::string, Port *> &PortBuilder::all_ports() {
 
 void Port::CollectStats(bool) {}
 
-pb_error_t Port::InitWithGenericArg(const google::protobuf::Any &arg) {
+CommandResponse Port::InitWithGenericArg(const google::protobuf::Any &arg) {
   return port_builder_->RunInit(this, arg);
 }
 
-pb_error_t Port::Init(const bess::pb::EmptyArg &) {
-  return pb_errno(0);
+CommandResponse Port::Init(const bess::pb::EmptyArg &) {
+  return CommandSuccess();
 }
 
 void Port::DeInit() {}

--- a/core/port.h
+++ b/core/port.h
@@ -40,10 +40,12 @@ typedef enum {
 class Port;
 class PortTest;
 
-using port_init_func_t = pb_func_t<pb_error_t, Port, google::protobuf::Any>;
+using port_init_func_t =
+    pb_func_t<CommandResponse, Port, google::protobuf::Any>;
 
 template <typename T, typename P>
-static inline port_init_func_t PORT_INIT_FUNC(pb_error_t (P::*fn)(const T &)) {
+static inline port_init_func_t PORT_INIT_FUNC(
+    CommandResponse (P::*fn)(const T &)) {
   return [fn](Port *p, const google::protobuf::Any &arg) {
     T arg_;
     arg.UnpackTo(&arg_);
@@ -112,7 +114,7 @@ class PortBuilder {
   const std::string &help_text() const { return help_text_; }
   bool initialized() const { return initialized_; }
 
-  pb_error_t RunInit(Port *p, const google::protobuf::Any &arg) const {
+  CommandResponse RunInit(Port *p, const google::protobuf::Any &arg) const {
     return init_func_(p, arg);
   }
 
@@ -174,7 +176,7 @@ class Port {
 
   virtual ~Port() {}
 
-  pb_error_t Init(const bess::pb::EmptyArg &arg);
+  CommandResponse Init(const bess::pb::EmptyArg &arg);
 
   virtual void DeInit();
 
@@ -211,7 +213,7 @@ class Port {
  public:
   friend class PortBuilder;
 
-  pb_error_t InitWithGenericArg(const google::protobuf::Any &arg);
+  CommandResponse InitWithGenericArg(const google::protobuf::Any &arg);
 
   PortStats GetPortStats();
 

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -13,7 +13,9 @@ class DummyPort : public Port {
 
   virtual void InitDriver() { initialized_ = true; }
 
-  pb_error_t Init(const google::protobuf::Any &) { return pb_errno(42); }
+  CommandResponse Init(const google::protobuf::Any &) {
+    return CommandFailure(42);
+  }
 
   virtual void DeInit() {
     if (deinited_)
@@ -76,8 +78,8 @@ TEST_F(PortTest, CreatePort) {
   bess::pb::EmptyArg arg_;
   google::protobuf::Any arg;
   arg.PackFrom(arg_);
-  pb_error_t err = p->InitWithGenericArg(arg);
-  EXPECT_EQ(42, err.code());
+  CommandResponse err = p->InitWithGenericArg(arg);
+  EXPECT_EQ(42, err.error().code());
 }
 
 // Checks that adding a port puts it into the global port collection.

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -77,7 +77,7 @@ TEST_F(PortTest, CreatePort) {
   google::protobuf::Any arg;
   arg.PackFrom(arg_);
   pb_error_t err = p->InitWithGenericArg(arg);
-  EXPECT_EQ(42, err.err());
+  EXPECT_EQ(42, err.code());
 }
 
 // Checks that adding a port puts it into the global port collection.

--- a/core/utils/endian.cc
+++ b/core/utils/endian.cc
@@ -1,0 +1,52 @@
+#include "endian.h"
+
+namespace bess {
+namespace utils {
+
+bool uint64_to_bin(void *ptr, uint64_t val, size_t size, bool big_endian) {
+  uint8_t *const ptr8 = static_cast<uint8_t *>(ptr);
+
+  if (big_endian) {
+    for (uint8_t *p = ptr8 + size - 1; p >= ptr8; p--) {
+      *p = val & 0xff;
+      val >>= 8;
+    }
+  } else {
+    for (uint8_t *p = ptr8; p < ptr8 + size; p++) {
+      *p = val & 0xff;
+      val >>= 8;
+    }
+  }
+
+  if (val) {
+    return false;  // the value is too large for the size
+  } else {
+    return true;
+  }
+}
+
+bool bin_to_uint64(uint64_t *pval, const void *ptr, size_t size,
+                   bool big_endian) {
+  const uint8_t *const ptr8 = static_cast<const uint8_t *>(ptr);
+
+  if (size > 8 || size < 1) {
+    return false;  // size must be 1-8
+  }
+
+  *pval = 0;
+
+  if (big_endian) {
+    for (const uint8_t *p = ptr8; p < ptr8 + size; p++) {
+      *pval = (*pval << 8) | *p;
+    }
+  } else {
+    for (const uint8_t *p = ptr8 + size - 1; p >= ptr8; p--) {
+      *pval = (*pval << 8) | *p;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace utils
+}  // namespace bess

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -1,7 +1,9 @@
 #ifndef BESS_UTILS_ENDIAN_H_
 #define BESS_UTILS_ENDIAN_H_
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace bess {
 namespace utils {
@@ -54,9 +56,9 @@ class[[gnu::packed]] BigEndian final : public EndianBase<T> {
     return is_be_system() ? v : EndianBase<T>::swap(v);
   }
 
-  bool operator==(const BigEndian &other) const { return value_ == other.value_; }
+  bool operator==(const BigEndian &rhs) const { return value_ == rhs.value_; }
 
-  bool operator!=(const BigEndian &other) const { return value_ != other.value_; }
+  bool operator!=(const BigEndian &rhs) const { return value_ != rhs.value_; }
 
  protected:
   T value_;
@@ -75,6 +77,13 @@ static_assert(std::is_pod<be64_t>::value, "not a POD type");
 static_assert(sizeof(be16_t) == 2, "be16_t is not 2 bytes");
 static_assert(sizeof(be32_t) == 4, "be32_t is not 4 bytes");
 static_assert(sizeof(be64_t) == 8, "be64_t is not 8 bytes");
+
+// Copy data from val to *ptr. Set "big_endian" to store in big endian
+bool uint64_to_bin(void *ptr, uint64_t val, size_t size, bool big_endian);
+
+// Copy data from *ptr to *pval. Set "big_endian" if *ptr has big endian data
+bool bin_to_uint64(uint64_t *pval, const void *ptr, size_t size,
+                   bool big_endian);
 
 }  // namespace utils
 }  // namespace bess

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -33,18 +33,18 @@ class BESS(object):
     # errors from BESS daemon
     class Error(Exception):
 
-        def __init__(self, err, errmsg, details):
-            self.err = err
+        def __init__(self, code, errmsg, details):
+            self.code = code
             self.errmsg = errmsg
             self.details = details
 
         def __str__(self):
-            if self.err in errno.errorcode:
-                err_code = errno.errorcode[self.err]
+            if self.code in errno.errorcode:
+                err_code = errno.errorcode[self.code]
             else:
                 err_code = '<unknown>'
             return 'errno: %d (%s: %s), %s, details: %s' % (
-                self.err, err_code, os.strerror(self.err), self.errmsg,
+                self.code, err_code, os.strerror(self.code), self.errmsg,
                 repr(self.details))
 
     # abnormal RPC failure
@@ -153,15 +153,15 @@ class BESS(object):
             if res:
                 pprint.pprint(res)
 
-        if response.error.err != 0:
-            err = response.error.err
+        if response.error.code != 0:
+            code = response.error.code
             errmsg = response.error.errmsg
             if errmsg == '':
                 errmsg = '(error message is not given)'
             details = response.error.details
             if details == '':
                 details = None
-            raise self.Error(err, errmsg, details)
+            raise self.Error(code, errmsg, details)
 
         return response
 

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -346,7 +346,7 @@ class BESS(object):
         return self._request('DisconnectModules', request)
 
     def run_module_command(self, name, cmd, arg_type, arg):
-        request = bess_msg.ModuleCommandRequest()
+        request = bess_msg.CommandRequest()
         request.name = name
         request.cmd = cmd
 

--- a/libbess-python/bess_test.py
+++ b/libbess-python/bess_test.py
@@ -22,7 +22,7 @@ class TestServiceImpl(service_pb2.BESSControlServicer):
         return response
 
     def ModuleCommand(self, request, context):
-        response = bess_msg.ModuleCommandResponse()
+        response = bess_msg.CommandResponse()
         return response
 
     def ListModules(self, request, context):
@@ -58,33 +58,33 @@ class TestBESS(unittest.TestCase):
         client.connect()
 
         response = client.kill(block=False)
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)
 
     def test_list_modules(self):
         client = bess.BESS()
         client.connect()
 
         response = client.list_modules()
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)
 
     def test_create_port(self):
         client = bess.BESS()
         client.connect()
 
         response = client.create_port('PCAPPort', 'p0', {'dev': 'rnd'})
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)
         self.assertEqual('p0', response.name)
 
         response = client.create_port('PMDPort', 'p0', {
             'loopback': True,
             'port_id': 14325,
             'pci': 'akshdkashf'})
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)
         self.assertEqual('p0', response.name)
 
         response = client.create_port('UnixSocketPort', 'p0',
                                       {'path': '/ajksd/dd'})
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)
         self.assertEqual('p0', response.name)
 
         response = client.create_port('VPort', 'p0', {
@@ -96,7 +96,7 @@ class TestBESS(unittest.TestCase):
             'loopback': False,
             'ip_addrs': ['1.2.3.4', '255.254.253.252']
         })
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)
         self.assertEqual('p0', response.name)
 
     def test_run_module_command(self):
@@ -108,4 +108,4 @@ class TestBESS(unittest.TestCase):
                                              'ExactMatchCommandAddArg',
                                              {'gate': 0,
                                               'fields': ['\x11', '\x22']})
-        self.assertEqual(0, response.error.err)
+        self.assertEqual(0, response.error.code)

--- a/libbess-python/protobuf_to_dict_test.py
+++ b/libbess-python/protobuf_to_dict_test.py
@@ -8,14 +8,13 @@ class TestProtobufConvert(unittest.TestCase):
 
     def test_protobuf_to_dict(self):
         pb = bess_msg.CreatePortResponse()
-        pb.error.err = 1
+        pb.error.code = 1
         pb.error.errmsg = 'bar'
-        pb.error.details = ''
         pb.name = 'foo'
 
         true_result = {
             'error': {
-                'err': 1,
+                'code': 1,
                 'errmsg': 'bar',
             },
             'name': 'foo'
@@ -25,14 +24,13 @@ class TestProtobufConvert(unittest.TestCase):
 
     def test_dict_to_protobuf(self):
         pb = bess_msg.CreatePortResponse()
-        pb.error.err = 1
+        pb.error.code = 1
         pb.error.errmsg = 'bar'
-        pb.error.details = ''
         pb.name = 'foo'
 
         msg_dict = {
             'error': {
-                'err': 1,
+                'code': 1,
                 'errmsg': 'bar',
             },
             'name': 'foo'

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -391,7 +391,7 @@ message ModuleCommandRequest {
 
 message ModuleCommandResponse {
   Error error = 1;
-  google.protobuf.Any other = 2;  /// Command response (see module_msg.proto)
+  google.protobuf.Any data = 2;  /// Command response (see module_msg.proto)
 }
 
 

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -383,15 +383,15 @@ message DisconnectModulesRequest {
   uint64 ogate = 2;  /// Output gate ID of previous module
 }
 
-message ModuleCommandRequest {
-  string name = 1;              /// Name of module to handle this command
+message CommandRequest {
+  string name = 1;              /// Name of module/port/driver
   string cmd = 2;               /// Name of command
-  google.protobuf.Any arg = 3;  /// Command argument (see module_msg.proto)
+  google.protobuf.Any arg = 3;  /// Command argument
 }
 
-message ModuleCommandResponse {
+message CommandResponse {
   Error error = 1;
-  google.protobuf.Any data = 2;  /// Command response (see module_msg.proto)
+  google.protobuf.Any data = 2;  /// Command response (see *_msg.proto)
 }
 
 

--- a/protobuf/error.proto
+++ b/protobuf/error.proto
@@ -5,5 +5,4 @@ package bess.pb;
 message Error {
   int32 err = 1;
   string errmsg = 2;
-  string details = 3;
 }

--- a/protobuf/error.proto
+++ b/protobuf/error.proto
@@ -3,6 +3,6 @@ syntax = "proto3";
 package bess.pb;
 
 message Error {
-  int32 err = 1;
+  int32 code = 1;  // 0 for success, errno (>0) for failure
   string errmsg = 2;
 }

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -249,7 +249,7 @@ service BESSControl {
   ///
   /// NOTE: Some commands cannot be used if there are running workers.
   ///       For those commands you must pause all workers first.
-  rpc ModuleCommand (ModuleCommandRequest) returns (ModuleCommandResponse) {}
+  rpc ModuleCommand (CommandRequest) returns (CommandResponse) {}
 
 
   //  -------------------------------------------------------------------------


### PR DESCRIPTION
> NOTE: This PR may break any custom modules/drivers outside the main repository.

Currently the return type of `Init()` and `CommandFoo()` are inconsistent, and reporting success/failure is verbose and can be done in many different ways. This increases code complexity and dependency on Protobuf. This PR simplifies Init/command handling, with new type `CommandResponse` and helper functions `CommandSuccess()` and `CommandFailure()`. These can be used whether you are writing `Init()` or commands, or whether you are dealing with Port or Module.

## Usage comparison

### Before (existing code)
```
// Init function
pb_error_t MyModule::Init(const bess::pb::DumpArg &arg) {
  // case 1: success in Init()
  return pb_errno(0);

  // case 2: failure in Init()
  return pb_errno(EINVAL);

  // case 3: failure in Init(), with error message
  return pb_error(EINVAL, "Invalid value: %d", val);
}

// Command function
pb_cmd_response_t MyModule::CommandFoo(const bess::pb::SomeType x) {
  // case 4: success in command
  pb_cmd_response_t response;
  set_cmd_response_error(&response, pb_errno(0));
  return response;

  // case 5: success in command, with return data
  pb_cmd_response_t response;
  response.mutable_error()->set_err(0);
  response.mutable_other()->PackFrom(some_return_data);
  return response;

  // case 6: failure in Init()
  pb_cmd_response_t response;
  set_cmd_response_error(&response, pb_errno(EINVAL));
  return response;

  // case 7: failure in Init(), with error message
  pb_cmd_response_t response;
  set_cmd_response_error(&response, 
                         pb_error(EINVAL, "Invalid value %d", val));
  return response;
}
```

### After (with new API)
```
CommandResponse MyModule::Init(const bess::pb::DumpArg &arg) {  // or
CommandResponse MyModule::CommandFoo(const bess::pb::SomeType x) {
  // case 1: success
  return CommandSuccess();

  // case 2: success with return data
  return CommandSuccess(some_return_data);

  // case 3: failure
  return CommandFailure(EINVAL);

  // case 4: failure with error message
  return CommandFailure(EINVAL, "Invalid value: %d", val);
}
```