### PR TITLE
bessctl: scan all workers in resume checks

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -534,6 +534,9 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     for (; i <= wid_filter; i++) {
+      if (workers[i] == nullptr) {
+        continue;
+      }
       bess::TrafficClass* root = workers[i]->scheduler()->root();
       if (!root) {
         continue;
@@ -584,7 +587,10 @@ class BESSControlImpl final : public BESSControl::Service {
     LOG(INFO) << "Checking scheduling constraints";
     // Check constraints around chains run by each worker. This checks that
     // global constraints are met.
-    for (int i = 0; i < num_workers; i++) {
+    for (int i = 0; i < Worker::kMaxWorkers; i++) {
+      if (workers[i] == nullptr) {
+        continue;
+      }
       int socket = 1ull << workers[i]->socket();
       int core = workers[i]->core();
       bess::TrafficClass* root = workers[i]->scheduler()->root();

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -521,14 +521,15 @@ class BESSControlImpl final : public BESSControl::Service {
     int i;
 
     wid_filter = request->wid();
-    if (wid_filter >= num_workers) {
-      return return_with_error(
-          response, EINVAL, "'wid' must be between 0 and %d", num_workers - 1);
+    if (wid_filter >= Worker::kMaxWorkers) {
+      return return_with_error(response, EINVAL,
+                               "'wid' must be between 0 and %d",
+                               Worker::kMaxWorkers - 1);
     }
 
     if (wid_filter < 0) {
       i = 0;
-      wid_filter = num_workers - 1;
+      wid_filter = Worker::kMaxWorkers - 1;
     } else {
       i = wid_filter;
     }

--- a/core/module.cc
+++ b/core/module.cc
@@ -677,7 +677,10 @@ void propagate_active_worker() {
     Module *m = pair.second;
     m->ResetActiveWorkerSet();
   }
-  for (int i = 0; i < num_workers; i++) {
+  for (int i = 0; i < Worker::kMaxWorkers; i++) {
+    if (workers[i] == nullptr) {
+      continue;
+    }
     int socket = 1ull << workers[i]->socket();
     int core = workers[i]->core();
     bess::TrafficClass *root = workers[i]->scheduler()->root();


### PR DESCRIPTION
Currently, propagate_active_workers() and
CheckSchedulingConstraints() don't handle the cases when workers are
created in any order other than 0, 1, 2, 3, ...

Running the following script produces the crash below.

```
bess.pause_all()
bess.add_worker(wid=1, core=0)
bess.add_worker(wid=2, core=1)
bess.add_worker(wid=3, core=2)
bess.resume_all()
```

log:
```
*** Error: Unhandled exception in the configuration script (most recent call last)
  File "foo.bess", line 5, in <module>
    bess.resume_all()
  File "/home/melvin/bess/bessctl/../libbess-python/bess.py", line 226, in resume_all
    return self.check_resume_all()
  File "/home/melvin/bess/bessctl/../libbess-python/bess.py", line 220, in check_resume_all
    ret = self.check_constraints()
  File "/home/melvin/bess/bessctl/../libbess-python/bess.py", line 191, in check_constraints
    response = self.check_scheduling_constraints()
  File "/home/melvin/bess/bessctl/../libbess-python/bess.py", line 231, in check_scheduling_constraints
    return self._request('CheckSchedulingConstraints')
  File "/home/melvin/bess/bessctl/../libbess-python/bess.py", line 148, in _request
    raise self.RPCError(str(e))
*** Error: RPC failed to localhost:10514 - <_Rendezvous of RPC that terminated with (StatusCode.UNAVAILABLE, {"created":"@1493924686.381156070","description":"EOF","file":"src/core/lib/iomgr/tcp_posix.c","file_line":235,"grpc_status":14})>
From /tmp/bessd_crash.log (Thu May  4 12:04:46 2017):
A critical error has occured. Aborting...
Signal: 11 (Segmentation fault), si_code: 1 (SEGV_MAPERR: address not mapped to object)
pid: 11334, tid: 11347, address: 0x20, IP: 0x62f7ab
Backtrace (recent calls first) ---
(0): /home/melvin/bess/core/bessd(_Z23propagate_active_workerv+0x1ab) [0x62f7ab]
    propagate_active_worker() at /home/melvin/bess/core/module.cc:683
         680:   for (int i = 0; i < num_workers; i++) {
         681:     int socket = 1ull << workers[i]->socket();
         682:     int core = workers[i]->core();
      -> 683:     bess::TrafficClass *root = workers[i]->scheduler()->root();
         684:     if (root) {
         685:       root->Traverse([i, socket, core](bess::TCChildArgs *args) {
         686:         bess::TrafficClass *c = args->child();
(1): /home/melvin/bess/core/bessd(_ZN15BESSControlImpl26CheckSchedulingConstraintsEPN4grpc13ServerContextEPKN4bess2pb12EmptyRequestEPNS4_34CheckSchedulingConstraintsResponseE+0x3e) [0x645d0e]
    BESSControlImpl::CheckSchedulingConstraints(grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*) at /home/melvin/bess/core/bessctl.cc:583
      -> 583:     propagate_active_worker();
(2): /home/melvin/bess/core/bessd(_ZNSt17_Function_handlerIFN4grpc6StatusEPN4bess2pb11BESSControl7ServiceEPNS0_13ServerContextEPKNS3_12EmptyRequestEPNS3_34CheckSchedulingConstraintsResponseEESt7_Mem_fnIMS5_FS1_S8_SB_SD_EEE9_M_invokeERKSt9_Any_dataOS6_OS8_OSB_OSD_+0x47) [0x6a9307]
    grpc::Status std::_Mem_fn_base<grpc::Status (bess::pb::BESSControl::Service::*)(grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*), true>::operator()<grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*, void>(bess::pb::BESSControl::Service*, grpc::ServerContext*&&, bess::pb::EmptyRequest const*&&, bess::pb::CheckSchedulingConstraintsResponse*&&) const at /usr/include/c++/5/functional:600
      -> 600:   { return (__object->*_M_pmf)(std::forward<_Args>(__args)...); }
     (inlined by) std::_Function_handler<grpc::Status (bess::pb::BESSControl::Service*, grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*), std::_Mem_fn<grpc::Status (bess::pb::BESSControl::Service::*)(grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*)> >::_M_invoke(std::_Any_data const&, bess::pb::BESSControl::Service*&&, grpc::ServerContext*&&, bess::pb::EmptyRequest const*&&, bess::pb::CheckSchedulingConstraintsResponse*&&) at /usr/include/c++/5/functional:1857
      -> 1857:      std::forward<_ArgTypes>(__args)...);
(3): /home/melvin/bess/core/bessd(_ZN4grpc16RpcMethodHandlerIN4bess2pb11BESSControl7ServiceENS2_12EmptyRequestENS2_34CheckSchedulingConstraintsResponseEE10RunHandlerERKNS_13MethodHandler16HandlerParameterE+0xae) [0x6c379e]
    std::function<grpc::Status (bess::pb::BESSControl::Service*, grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*)>::operator()(bess::pb::BESSControl::Service*, grpc::ServerContext*, bess::pb::EmptyRequest const*, bess::pb::CheckSchedulingConstraintsResponse*) const at /usr/include/c++/5/functional:2267
      -> 2267:       return _M_invoker(_M_functor, std::forward<_ArgTypes>(__args)...);
     (inlined by) grpc::RpcMethodHandler<bess::pb::BESSControl::Service, bess::pb::EmptyRequest, bess::pb::CheckSchedulingConstraintsResponse>::RunHandler(grpc::MethodHandler::HandlerParameter const&) at /usr/local/include/grpc++/impl/codegen/method_handler_impl.h:59
      -> 59:       status = func_(service_, param.server_context, &req, &rsp);
(4): /home/melvin/bess/core/bessd(_ZN4grpc6Server24SyncRequestThreadManager6DoWorkEPvb+0x898) [0x9c6b38]
    grpc::Server::SyncRequestThreadManager::DoWork(void*, bool) at ??:?
(5): /home/melvin/bess/core/bessd(_ZN4grpc13ThreadManager12MainWorkLoopEv+0xc6) [0x9c8e66]
    grpc::ThreadManager::MainWorkLoop() at ??:?
(6): /home/melvin/bess/core/bessd(_ZN4grpc13ThreadManager12WorkerThread3RunEv+0xb) [0x9c8ecb]
    grpc::ThreadManager::WorkerThread::Run() at ??:?
(7): /home/melvin/bess/core/bessd() [0xc2640f]
    execute_native_thread_routine at thread.o:?
(8): /lib/x86_64-linux-gnu/libpthread.so.0(+0x76b9) [0x7f5b44f216b9]
    start_thread at ??:?
(9): /lib/x86_64-linux-gnu/libc.so.6(clone+0x6c) [0x7f5b44c5782c]
    clone at /build/glibc-9tT8Do/glibc-2.23/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:109
        (file/line not available)
```