### PR TITLE
Stabilizes code coverage data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ core/*.gcda
 core/*.gcno
 core/*/*.gcda
 core/*/*.gcno
+*.gcov
 coverage.info
 coverage_html

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 
 env:
   global:
-    - GCOV_PREFIX_STRIP=2
     - ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-3.8/bin/llvm-symbolizer
     - ASAN_OPTIONS=log_path=/tmp/saniziter,log_exe_name=1
     - LSAN_OPTIONS=suppressions=$TRAVIS_BUILD_DIR/core/lsan.suppress
@@ -27,7 +26,7 @@ before_install:
 install:
   - sudo apt-get install -y python
   - pip install grpcio scapy
-  - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y lcov"
+  - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y g++-5" # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"
   - ln -s /build/dpdk-17.02 deps
@@ -43,14 +42,12 @@ before_script:
 script:
   - ./container_build.py bess
   - ./container_build.py kmod_buildtest
-  - (cd core && ./all_test)
-  - ./sanity_check.sh
-  - ./bessctl/bessctl -- daemon start -- run testing/run_module_tests
+  - (cd core && GCOV_PREFIX_STRIP=3 ./all_test) # TcpFlowReconstructTest requires working directory to be `core/`
+  - GCOV_PREFIX_STRIP=2 ./sanity_check.sh
+  - GCOV_PREFIX_STRIP=2 ./bessctl/bessctl -- daemon start -- run testing/run_module_tests
 
 after_success:
-  - "[[ ${DEBUG:-0} == 0 ]] || bash <(curl -s https://codecov.io/bash)"
-  - "lcov --capture --directory . --output-file coverage.info && \
-    genhtml coverage.info --output-directory coverage_html"
+  - "[[ ${DEBUG:-0} == 0 ]] || (cd core && bash <(curl -s https://codecov.io/bash) -x gcov-5)"
 
 after_failure:
   - more /tmp/bessd.*.INFO.* | cat      # dump all bessd log files

--- a/core/Makefile
+++ b/core/Makefile
@@ -131,7 +131,7 @@ all: version.h $(EXEC) modules tests benchmarks
 
 clean:
 	rm -rf $(EXEC) .deps/*.d .deps/*/*.d *_test */*_test *_bench */*_bench \
-		*.a *.pb.* *.o */*.o *.so */*.so *.gcda *.gcno */*.gcda */*.gcno \
+		*.a *.pb.* *.o */*.o *.so */*.so *.gcov *.gcda *.gcno */*.gcda */*.gcno \
 		coverage.info coverage_html
 
 tags:


### PR DESCRIPTION
- If `DEBUG=1`, run unit tests only
- Use gcov-5
- Remove `lcov` on CI since it seems to be useless

This PR should address #434 and #388.