### PR TITLE
tc: Add test for RemoveChild()

### DIFF
--- a/core/.clang-format
+++ b/core/.clang-format
@@ -69,4 +69,3 @@ Standard:        Auto
 TabWidth:        2
 UseTab:          Never
 ...
-


### PR DESCRIPTION
This PR adds tests for `RemoveChild()` in `traffic_class`, as a part of the ongoing effort to improve code coverage.