### PR TITLE
Fix `WorkerSplit` and `Bypass` model

### DIFF
--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -11,6 +11,7 @@ class Bypass final : public Module {
   static const gate_idx_t kNumIGates = MAX_GATES;
   static const gate_idx_t kNumOGates = MAX_GATES;
 
+  Bypass() { max_allowed_workers_ = Worker::kMaxWorkers; }
   void ProcessBatch(bess::PacketBatch *batch) override;
 };
 

--- a/core/modules/worker_split.h
+++ b/core/modules/worker_split.h
@@ -7,6 +7,8 @@ class WorkerSplit final : public Module {
  public:
   static const gate_idx_t kNumOGates = Worker::kMaxWorkers;
 
+  WorkerSplit() { max_allowed_workers_ = kNumOGates; }
+
   void ProcessBatch(bess::PacketBatch *batch) override;
 };
 

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -20,7 +20,8 @@ TESTS='exactmatch.bess
   update.bess
   vlantest.bess
   wildcardmatch.bess
-  nat.bess'
+  nat.bess
+  worker_split.bess'
 
 function fail
 {


### PR DESCRIPTION
Both modules are thread safe and `worker_split.bess` uses them as such.