### PR TITLE
port: Virtualize Port and delete dead codes

### DIFF
--- a/core/drivers/vport.h
+++ b/core/drivers/vport.h
@@ -12,8 +12,7 @@ class VPort final : public Port {
   CommandResponse Init(const bess::pb::VPortArg &arg);
   void DeInit() override;
 
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts,
-                          int max_cnt) override;
+  int RecvPackets(queue_t qid, bess::Packet **pkts, int max_cnt) override;
   int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:

--- a/core/drivers/vport_zc.h
+++ b/core/drivers/vport_zc.h
@@ -52,10 +52,10 @@ class ZeroCopyVPort final : public Port {
  public:
   CommandResponse Init(const bess::pb::EmptyArg &arg);
 
-  void DeInit();
+  void DeInit() override;
 
-  int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt);
-  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
+  int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   friend class ZeroCopyVPortTest;

--- a/core/port.cc
+++ b/core/port.cc
@@ -134,20 +134,6 @@ CommandResponse Port::InitWithGenericArg(const google::protobuf::Any &arg) {
   return port_builder_->RunInit(this, arg);
 }
 
-CommandResponse Port::Init(const bess::pb::EmptyArg &) {
-  return CommandSuccess();
-}
-
-void Port::DeInit() {}
-
-int Port::RecvPackets(queue_t, bess::Packet **, int) {
-  return 0;
-}
-
-int Port::SendPackets(queue_t, bess::Packet **, int) {
-  return 0;
-}
-
 Port::PortStats Port::GetPortStats() {
   CollectStats(false);
 

--- a/core/port.h
+++ b/core/port.h
@@ -176,17 +176,15 @@ class Port {
 
   virtual ~Port() {}
 
-  CommandResponse Init(const bess::pb::EmptyArg &arg);
-
-  virtual void DeInit();
+  virtual void DeInit() = 0;
 
   // For one-time initialization of the port's "driver" (optional).
   virtual void InitDriver() {}
 
   virtual void CollectStats(bool reset);
 
-  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt);
-  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt);
+  virtual int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) = 0;
+  virtual int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) = 0;
 
   // For custom incoming / outgoing queue sizes (optional).
   virtual size_t DefaultIncQueueSize() const { return kDefaultIncQueueSize; }

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -11,16 +11,19 @@ class DummyPort : public Port {
  public:
   DummyPort() : Port(), deinited_(nullptr) {}
 
-  virtual void InitDriver() { initialized_ = true; }
+  void InitDriver() override { initialized_ = true; }
 
   CommandResponse Init(const google::protobuf::Any &) {
     return CommandFailure(42);
   }
 
-  virtual void DeInit() {
+  void DeInit() override {
     if (deinited_)
       *deinited_ = true;
   }
+
+  int RecvPackets(queue_t, bess::Packet **, int) override { return 0; }
+  int SendPackets(queue_t, bess::Packet **, int) override { return 0; }
 
   void set_deinited(bool *val) { deinited_ = val; }
 


### PR DESCRIPTION
`Init()`, `DeInit()`, `RecvPackets()`, `SendPackets()` should always be defined
when creating a new driver. To make the process less error-prone, we can enforce
this by making those functions purely virtual.