### PR TITLE
Fix false style error detection

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -34,7 +34,7 @@ get_patch() {
 		fi
 
 		# show colored version to the user
-		echo "$reformatted" | git diff --no-index --color=always $file -
+		echo "$reformatted" | git diff --no-index --no-pager --color=always $file -
 
 		# ... and save non-colored patch for git-apply
 		file_diff=`echo "$reformatted" | diff -u $file - | \

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -37,9 +37,15 @@ get_patch() {
 		echo "$reformatted" | git diff --no-index --color=always $file -
 
 		# ... and save non-colored patch for git-apply
-		patch+=`echo "$reformatted" | diff -u $file - | \
-			sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|"`
-		patch+=$'\n'
+		file_diff=`echo "$reformatted" | diff -u $file - | \
+			   sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|"`
+
+		# diff output does not have a linefeed at the end.
+		# We need one if there are multiple diff outputs.
+		if [[ ! -z $file_diff ]]; then
+			patch+=file_diff
+			patch+=$'\n'
+		fi
 	done
 }
 


### PR DESCRIPTION
When there are multiple files to commit, LF is used as a separator between diff results. It causes the pre-commit hook to (incorrectly) recognize the LF characters that there are something requiring reformatting.