### PR TITLE
Revamp endianness and protocol code

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -249,7 +249,7 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
     num_out_q = 1;
   }
 
-  bess::utils::EthHeader::Address mac_addr;
+  bess::utils::Ethernet::Address mac_addr;
 
   if (mac_addr_str.length() > 0) {
     if (!mac_addr.FromString(mac_addr_str)) {
@@ -927,7 +927,7 @@ class BESSControlImpl final : public BESSControl::Service {
       port->set_name(p->name());
       port->set_driver(p->port_builder()->class_name());
 
-      bess::utils::EthHeader::Address mac_addr;
+      bess::utils::Ethernet::Address mac_addr;
       bess::utils::Copy(mac_addr.bytes, p->mac_addr, ETH_ALEN);
       port->set_mac_addr(mac_addr.ToString());
     }
@@ -967,7 +967,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
     response->set_name(port->name());
 
-    bess::utils::EthHeader::Address mac_addr;
+    bess::utils::Ethernet::Address mac_addr;
     bess::utils::Copy(mac_addr.bytes, port->mac_addr, ETH_ALEN);
     response->set_mac_addr(mac_addr.ToString());
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -50,7 +50,7 @@ void PMDPort::InitDriver() {
     struct rte_eth_dev_info dev_info;
     std::string pci_info;
     int numa_node = -1;
-    bess::utils::EthHeader::Address lladdr;
+    bess::utils::Ethernet::Address lladdr;
 
     rte_eth_dev_info_get(i, &dev_info);
 

--- a/core/module.h
+++ b/core/module.h
@@ -570,30 +570,6 @@ inline void set_attr(Module *m, int attr_id, bess::Packet *pkt, T val) {
  */
 void propagate_active_worker();
 
-// Define some common versions of the above functions
-#define INSTANTIATE_MT_FOR_TYPE(type)                                        \
-  template type *_ptr_attr_with_offset(bess::metadata::mt_offset_t offset,   \
-                                       bess::Packet *pkt);                   \
-  template type _get_attr_with_offset(bess::metadata::mt_offset_t offset,    \
-                                      bess::Packet *pkt);                    \
-  template void _set_attr_with_offset(bess::metadata::mt_offset_t offset,    \
-                                      bess::Packet *pkt, type val);          \
-  template type *ptr_attr_with_offset(bess::metadata::mt_offset_t offset,    \
-                                      bess::Packet *pkt);                    \
-  template type get_attr_with_offset(bess::metadata::mt_offset_t offset,     \
-                                     bess::Packet *pkt);                     \
-  template void set_attr_with_offset(bess::metadata::mt_offset_t offset,     \
-                                     bess::Packet *pkt, type val);           \
-  template type *ptr_attr<type>(Module * m, int attr_id, bess::Packet *pkt); \
-  template type get_attr<type>(Module * m, int attr_id, bess::Packet *pkt);  \
-  template void set_attr<>(Module * m, int attr_id, bess::Packet *pkt,       \
-                           type val);
-
-INSTANTIATE_MT_FOR_TYPE(uint8_t)
-INSTANTIATE_MT_FOR_TYPE(uint16_t)
-INSTANTIATE_MT_FOR_TYPE(uint32_t)
-INSTANTIATE_MT_FOR_TYPE(uint64_t)
-
 #define DEF_MODULE(_MOD, _NAME_TEMPLATE, _HELP)                          \
   class _MOD##_class {                                                   \
    public:                                                               \

--- a/core/module.h
+++ b/core/module.h
@@ -505,15 +505,15 @@ static inline int is_active_gate(const std::vector<T *> &gates,
 // Unsafe, but faster version. for offset use Attribute_offset().
 template <typename T>
 inline T *_ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
-                                bess::Packet *pkt) {
+                                const bess::Packet *pkt) {
   promise(offset >= 0);
-  uintptr_t addr = reinterpret_cast<uintptr_t>(pkt->metadata()) + offset;
+  uintptr_t addr = pkt->metadata<uintptr_t>() + offset;
   return reinterpret_cast<T *>(addr);
 }
 
 template <typename T>
 inline T _get_attr_with_offset(bess::metadata::mt_offset_t offset,
-                               bess::Packet *pkt) {
+                               const bess::Packet *pkt) {
   return *_ptr_attr_with_offset<T>(offset, pkt);
 }
 
@@ -534,7 +534,7 @@ inline T *ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
 
 template <typename T>
 inline T get_attr_with_offset(bess::metadata::mt_offset_t offset,
-                              bess::Packet *pkt) {
+                              const bess::Packet *pkt) {
   return bess::metadata::IsValidOffset(offset)
              ? _get_attr_with_offset<T>(offset, pkt)
              : T();
@@ -556,7 +556,7 @@ inline T *ptr_attr(Module *m, int attr_id, bess::Packet *pkt) {
 }
 
 template <typename T>
-inline T get_attr(Module *m, int attr_id, bess::Packet *pkt) {
+inline T get_attr(Module *m, int attr_id, const bess::Packet *pkt) {
   return get_attr_with_offset<T>(m->attr_offset(attr_id), pkt);
 }
 

--- a/core/module.h
+++ b/core/module.h
@@ -504,28 +504,28 @@ static inline int is_active_gate(const std::vector<T *> &gates,
 
 // Unsafe, but faster version. for offset use Attribute_offset().
 template <typename T>
-inline T *_ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
-                                const bess::Packet *pkt) {
+static inline T *_ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
+                                       const bess::Packet *pkt) {
   promise(offset >= 0);
   uintptr_t addr = pkt->metadata<uintptr_t>() + offset;
   return reinterpret_cast<T *>(addr);
 }
 
 template <typename T>
-inline T _get_attr_with_offset(bess::metadata::mt_offset_t offset,
-                               const bess::Packet *pkt) {
+static inline T _get_attr_with_offset(bess::metadata::mt_offset_t offset,
+                                      const bess::Packet *pkt) {
   return *_ptr_attr_with_offset<T>(offset, pkt);
 }
 
 template <typename T>
-inline void _set_attr_with_offset(bess::metadata::mt_offset_t offset,
-                                  bess::Packet *pkt, T val) {
+static inline void _set_attr_with_offset(bess::metadata::mt_offset_t offset,
+                                         bess::Packet *pkt, T val) {
   *(_ptr_attr_with_offset<T>(offset, pkt)) = val;
 }
 
 // Safe version.
 template <typename T>
-inline T *ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
+static T *ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
                                bess::Packet *pkt) {
   return bess::metadata::IsValidOffset(offset)
              ? _ptr_attr_with_offset<T>(offset, pkt)
@@ -533,7 +533,7 @@ inline T *ptr_attr_with_offset(bess::metadata::mt_offset_t offset,
 }
 
 template <typename T>
-inline T get_attr_with_offset(bess::metadata::mt_offset_t offset,
+static T get_attr_with_offset(bess::metadata::mt_offset_t offset,
                               const bess::Packet *pkt) {
   return bess::metadata::IsValidOffset(offset)
              ? _get_attr_with_offset<T>(offset, pkt)
@@ -541,8 +541,8 @@ inline T get_attr_with_offset(bess::metadata::mt_offset_t offset,
 }
 
 template <typename T>
-inline void set_attr_with_offset(bess::metadata::mt_offset_t offset,
-                                 bess::Packet *pkt, T val) {
+static inline void set_attr_with_offset(bess::metadata::mt_offset_t offset,
+                                        bess::Packet *pkt, T val) {
   if (bess::metadata::IsValidOffset(offset)) {
     _set_attr_with_offset<T>(offset, pkt, val);
   }
@@ -551,17 +551,17 @@ inline void set_attr_with_offset(bess::metadata::mt_offset_t offset,
 // Slowest but easiest.
 // TODO(melvin): These ought to be members of Module
 template <typename T>
-inline T *ptr_attr(Module *m, int attr_id, bess::Packet *pkt) {
+static inline T *ptr_attr(Module *m, int attr_id, bess::Packet *pkt) {
   return ptr_attr_with_offset<T>(m->attr_offset(attr_id), pkt);
 }
 
 template <typename T>
-inline T get_attr(Module *m, int attr_id, const bess::Packet *pkt) {
+static inline T get_attr(Module *m, int attr_id, const bess::Packet *pkt) {
   return get_attr_with_offset<T>(m->attr_offset(attr_id), pkt);
 }
 
 template <typename T>
-inline void set_attr(Module *m, int attr_id, bess::Packet *pkt, T val) {
+static inline void set_attr(Module *m, int attr_id, bess::Packet *pkt, T val) {
   set_attr_with_offset(m->attr_offset(attr_id), pkt, val);
 }
 

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -33,7 +33,7 @@ CommandResponse ACL::CommandClear(const bess::pb::EmptyArg &) {
 
 void ACL::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
 
   gate_idx_t out_gates[bess::PacketBatch::kMaxBurst];
@@ -44,7 +44,7 @@ void ACL::ProcessBatch(bess::PacketBatch *batch) {
     bess::Packet *pkt = batch->pkts()[i];
 
     EthHeader *eth = pkt->head_data<EthHeader *>();
-    Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
     UdpHeader *udp = reinterpret_cast<UdpHeader *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -32,7 +32,7 @@ CommandResponse ACL::CommandClear(const bess::pb::EmptyArg &) {
 }
 
 void ACL::ProcessBatch(bess::PacketBatch *batch) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
 
@@ -43,7 +43,7 @@ void ACL::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    EthHeader *eth = pkt->head_data<EthHeader *>();
+    Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
     UdpHeader *udp = reinterpret_cast<UdpHeader *>(

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -11,8 +11,8 @@ const Commands ACL::cmds = {
 CommandResponse ACL::Init(const bess::pb::ACLArg &arg) {
   for (const auto &rule : arg.rules()) {
     ACLRule new_rule = {
-        .src_ip = CIDRNetwork(rule.src_ip()),
-        .dst_ip = CIDRNetwork(rule.dst_ip()),
+        .src_ip = Ipv4Prefix(rule.src_ip()),
+        .dst_ip = Ipv4Prefix(rule.dst_ip()),
         .src_port = be16_t(static_cast<uint16_t>(rule.src_port())),
         .dst_port = be16_t(static_cast<uint16_t>(rule.dst_port())),
         .drop = rule.drop()};

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -34,7 +34,7 @@ CommandResponse ACL::CommandClear(const bess::pb::EmptyArg &) {
 void ACL::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
-  using bess::utils::UdpHeader;
+  using bess::utils::Udp;
 
   gate_idx_t out_gates[bess::PacketBatch::kMaxBurst];
   gate_idx_t incoming_gate = get_igate();
@@ -46,7 +46,7 @@ void ACL::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
-    UdpHeader *udp = reinterpret_cast<UdpHeader *>(
+    Udp *udp = reinterpret_cast<Udp *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);
 
     out_gates[i] = DROP_GATE;  // By default, drop unmatched packets

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -46,8 +46,8 @@ void ACL::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
-    Udp *udp = reinterpret_cast<Udp *>(
-        reinterpret_cast<uint8_t *>(ip) + ip_bytes);
+    Udp *udp =
+        reinterpret_cast<Udp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
 
     out_gates[i] = DROP_GATE;  // By default, drop unmatched packets
 

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -15,8 +15,8 @@ CommandResponse ACL::Init(const bess::pb::ACLArg &arg) {
     ACLRule new_rule = {
         .src_ip = CIDRNetwork(rule.src_ip()),
         .dst_ip = CIDRNetwork(rule.dst_ip()),
-        .src_port = htons(static_cast<uint16_t>(rule.src_port())),
-        .dst_port = htons(static_cast<uint16_t>(rule.dst_port())),
+        .src_port = be16_t(static_cast<uint16_t>(rule.src_port())),
+        .dst_port = be16_t(static_cast<uint16_t>(rule.dst_port())),
         .established = rule.established(),
         .drop = rule.drop()};
     rules_.push_back(new_rule);
@@ -48,10 +48,10 @@ void ACL::ProcessBatch(bess::PacketBatch *batch) {
     struct udp_hdr *udp = reinterpret_cast<struct udp_hdr *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);
 
-    IPAddress src_ip = ip->src_addr;
-    IPAddress dst_ip = ip->dst_addr;
-    uint16_t src_port = udp->src_port;
-    uint16_t dst_port = udp->dst_port;
+    be32_t src_ip(be32_t::swap(ip->src_addr));
+    be32_t dst_ip(be32_t::swap(ip->dst_addr));
+    be16_t src_port(be32_t::swap(udp->src_port));
+    be16_t dst_port(be32_t::swap(udp->dst_port));
 
     out_gates[i] = DROP_GATE;  // By default, drop unmatched packets
 

--- a/core/modules/acl.h
+++ b/core/modules/acl.h
@@ -9,7 +9,7 @@
 
 using bess::utils::be16_t;
 using bess::utils::be32_t;
-using bess::utils::CIDRNetwork;
+using bess::utils::Ipv4Prefix;
 
 class ACL final : public Module {
  public:
@@ -20,8 +20,8 @@ class ACL final : public Module {
              (dst_port == be16_t(0) || dst_port == dport);
     }
 
-    CIDRNetwork src_ip;
-    CIDRNetwork dst_ip;
+    Ipv4Prefix src_ip;
+    Ipv4Prefix dst_ip;
     be16_t src_port;
     be16_t dst_port;
     bool drop;

--- a/core/modules/acl.h
+++ b/core/modules/acl.h
@@ -7,23 +7,23 @@
 #include "../module_msg.pb.h"
 #include "../utils/ip.h"
 
-using bess::utils::IPAddress;
+using bess::utils::be16_t;
+using bess::utils::be32_t;
 using bess::utils::CIDRNetwork;
 
 class ACL final : public Module {
  public:
   struct ACLRule {
-    bool Match(IPAddress sip, IPAddress dip, uint16_t sport,
-               uint16_t dport) const {
+    bool Match(be32_t sip, be32_t dip, be16_t sport, be16_t dport) const {
       return src_ip.Match(sip) && dst_ip.Match(dip) &&
-             (src_port == 0 || src_port == sport) &&
-             (dst_port == 0 || dst_port == dport);
+             (src_port == be16_t(0) || src_port == sport) &&
+             (dst_port == be16_t(0) || dst_port == dport);
     }
 
     CIDRNetwork src_ip;
     CIDRNetwork dst_ip;
-    uint16_t src_port;
-    uint16_t dst_port;
+    be16_t src_port;
+    be16_t dst_port;
     bool established;
     bool drop;
   };

--- a/core/modules/acl.h
+++ b/core/modules/acl.h
@@ -24,7 +24,6 @@ class ACL final : public Module {
     CIDRNetwork dst_ip;
     be16_t src_port;
     be16_t dst_port;
-    bool established;
     bool drop;
   };
 

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -255,11 +255,11 @@ uint32_t DRR::GetNextPackets(bess::PacketBatch* batch, Flow* f, int* err) {
 
 DRR::FlowId DRR::GetId(bess::Packet* pkt) {
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
 
   EthHeader* eth = pkt->head_data<EthHeader*>();
-  Ipv4Header* ip = reinterpret_cast<Ipv4Header*>(eth + 1);
+  Ipv4* ip = reinterpret_cast<Ipv4*>(eth + 1);
   size_t ip_bytes = ip->header_length << 2;
   UdpHeader* udp = reinterpret_cast<UdpHeader*>(
       reinterpret_cast<uint8_t*>(ip) + ip_bytes);  // Assumes a l-4 header

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -256,12 +256,12 @@ uint32_t DRR::GetNextPackets(bess::PacketBatch* batch, Flow* f, int* err) {
 DRR::FlowId DRR::GetId(bess::Packet* pkt) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
-  using bess::utils::UdpHeader;
+  using bess::utils::Udp;
 
   Ethernet* eth = pkt->head_data<Ethernet*>();
   Ipv4* ip = reinterpret_cast<Ipv4*>(eth + 1);
   size_t ip_bytes = ip->header_length << 2;
-  UdpHeader* udp = reinterpret_cast<UdpHeader*>(
+  Udp* udp = reinterpret_cast<Udp*>(
       reinterpret_cast<uint8_t*>(ip) + ip_bytes);  // Assumes a l-4 header
   // TODO(joshua): handle packet fragmentation
   FlowId id = {ip->src.value(), ip->dst.value(), udp->src_port.value(),

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -261,8 +261,8 @@ DRR::FlowId DRR::GetId(bess::Packet* pkt) {
   Ethernet* eth = pkt->head_data<Ethernet*>();
   Ipv4* ip = reinterpret_cast<Ipv4*>(eth + 1);
   size_t ip_bytes = ip->header_length << 2;
-  Udp* udp = reinterpret_cast<Udp*>(
-      reinterpret_cast<uint8_t*>(ip) + ip_bytes);  // Assumes a l-4 header
+  Udp* udp = reinterpret_cast<Udp*>(reinterpret_cast<uint8_t*>(ip) +
+                                    ip_bytes);  // Assumes a l-4 header
   // TODO(joshua): handle packet fragmentation
   FlowId id = {ip->src.value(), ip->dst.value(), udp->src_port.value(),
                udp->dst_port.value(), ip->protocol};

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -254,11 +254,11 @@ uint32_t DRR::GetNextPackets(bess::PacketBatch* batch, Flow* f, int* err) {
 }
 
 DRR::FlowId DRR::GetId(bess::Packet* pkt) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
 
-  EthHeader* eth = pkt->head_data<EthHeader*>();
+  Ethernet* eth = pkt->head_data<Ethernet*>();
   Ipv4* ip = reinterpret_cast<Ipv4*>(eth + 1);
   size_t ip_bytes = ip->header_length << 2;
   UdpHeader* udp = reinterpret_cast<UdpHeader*>(

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -12,7 +12,7 @@
 #include "../utils/cuckoo_map.h"
 #include "../utils/ip.h"
 
-using bess::utils::CIDRNetwork;
+using bess::utils::Ipv4Prefix;
 using bess::utils::CuckooMap;
 
 /*

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -12,7 +12,6 @@
 #include "../utils/cuckoo_map.h"
 #include "../utils/ip.h"
 
-using bess::utils::IPAddress;
 using bess::utils::CIDRNetwork;
 using bess::utils::CuckooMap;
 

--- a/core/modules/dump.cc
+++ b/core/modules/dump.cc
@@ -26,7 +26,8 @@ void Dump::ProcessBatch(bess::PacketBatch *batch) {
     printf("----------------------------------------\n");
     printf("%s: packet dump\n", name().c_str());
     std::cout << pkt->Dump();
-    rte_hexdump(stdout, "Metadata buffer", pkt->metadata(), SNBUF_METADATA);
+    rte_hexdump(stdout, "Metadata buffer", pkt->metadata<const char *>(),
+                SNBUF_METADATA);
     next_ns_ = ctx.current_ns() + min_interval_ns_;
   }
 

--- a/core/modules/ether_encap.cc
+++ b/core/modules/ether_encap.cc
@@ -2,7 +2,7 @@
 
 #include "../utils/ether.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 
 enum {
   ATTR_R_ETHER_SRC,
@@ -14,8 +14,8 @@ CommandResponse EtherEncap::Init(
     const bess::pb::EtherEncapArg &arg[[maybe_unused]]) {
   using AccessMode = bess::metadata::Attribute::AccessMode;
 
-  AddMetadataAttr("ether_src", sizeof(EthHeader::Address), AccessMode::kRead);
-  AddMetadataAttr("ether_dst", sizeof(EthHeader::Address), AccessMode::kRead);
+  AddMetadataAttr("ether_src", sizeof(Ethernet::Address), AccessMode::kRead);
+  AddMetadataAttr("ether_dst", sizeof(Ethernet::Address), AccessMode::kRead);
   AddMetadataAttr("ether_type", 2, AccessMode::kRead);
 
   return CommandSuccess();
@@ -27,15 +27,15 @@ void EtherEncap::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    EthHeader::Address ether_src;
-    EthHeader::Address ether_dst;
+    Ethernet::Address ether_src;
+    Ethernet::Address ether_dst;
     bess::utils::be16_t ether_type;
 
-    ether_src = get_attr<EthHeader::Address>(this, ATTR_R_ETHER_SRC, pkt);
-    ether_dst = get_attr<EthHeader::Address>(this, ATTR_R_ETHER_DST, pkt);
+    ether_src = get_attr<Ethernet::Address>(this, ATTR_R_ETHER_SRC, pkt);
+    ether_dst = get_attr<Ethernet::Address>(this, ATTR_R_ETHER_DST, pkt);
     ether_type = get_attr<bess::utils::be16_t>(this, ATTR_R_ETHER_TYPE, pkt);
 
-    EthHeader *eth = static_cast<EthHeader *>(pkt->prepend(sizeof(*eth)));
+    Ethernet *eth = static_cast<Ethernet *>(pkt->prepend(sizeof(*eth)));
 
     // not enough headroom?
     if (unlikely(!eth)) {

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -1,6 +1,5 @@
 #include "flowgen.h"
 
-#include <arpa/inet.h>
 #include <cmath>
 #include <functional>
 

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -13,7 +13,7 @@
 
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
-using bess::utils::TcpHeader;
+using bess::utils::Tcp;
 using bess::utils::be16_t;
 using bess::utils::be32_t;
 
@@ -385,8 +385,8 @@ CommandResponse FlowGen::UpdateBaseAddresses() {
   }
 
   Ipv4 *ipheader = reinterpret_cast<Ipv4 *>(p + sizeof(Ethernet));
-  TcpHeader *tcpheader =
-      reinterpret_cast<TcpHeader *>(p + sizeof(Ethernet) + sizeof(Ipv4));
+  Tcp *tcpheader =
+      reinterpret_cast<Tcp *>(p + sizeof(Ethernet) + sizeof(Ipv4));
 
   ip_src_base_ = ipheader->src.value();
   ip_dst_base_ = ipheader->dst.value();
@@ -408,7 +408,7 @@ bess::Packet *FlowGen::FillPacket(struct flow *f) {
 
   Ethernet *eth = reinterpret_cast<Ethernet *>(p);
   Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
-  TcpHeader *tcp = reinterpret_cast<TcpHeader *>(ip + 1);
+  Tcp *tcp = reinterpret_cast<Tcp *>(ip + 1);
 
   // SYN or FIN?
   if (f->first_pkt || f->packets_left <= 1) {

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -385,8 +385,7 @@ CommandResponse FlowGen::UpdateBaseAddresses() {
   }
 
   Ipv4 *ipheader = reinterpret_cast<Ipv4 *>(p + sizeof(Ethernet));
-  Tcp *tcpheader =
-      reinterpret_cast<Tcp *>(p + sizeof(Ethernet) + sizeof(Ipv4));
+  Tcp *tcpheader = reinterpret_cast<Tcp *>(p + sizeof(Ethernet) + sizeof(Ipv4));
 
   ip_src_base_ = ipheader->src.value();
   ip_dst_base_ = ipheader->dst.value();

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -11,7 +11,7 @@
 #include "../utils/tcp.h"
 #include "../utils/time.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using bess::utils::TcpHeader;
 using bess::utils::be16_t;
@@ -384,9 +384,9 @@ CommandResponse FlowGen::UpdateBaseAddresses() {
     return CommandFailure(EINVAL, "must specify 'template'");
   }
 
-  Ipv4 *ipheader = reinterpret_cast<Ipv4 *>(p + sizeof(EthHeader));
+  Ipv4 *ipheader = reinterpret_cast<Ipv4 *>(p + sizeof(Ethernet));
   TcpHeader *tcpheader =
-      reinterpret_cast<TcpHeader *>(p + sizeof(EthHeader) + sizeof(Ipv4));
+      reinterpret_cast<TcpHeader *>(p + sizeof(Ethernet) + sizeof(Ipv4));
 
   ip_src_base_ = ipheader->src.value();
   ip_dst_base_ = ipheader->dst.value();
@@ -406,7 +406,7 @@ bess::Packet *FlowGen::FillPacket(struct flow *f) {
 
   char *p = pkt->buffer<char *>() + SNBUF_HEADROOM;
 
-  EthHeader *eth = reinterpret_cast<EthHeader *>(p);
+  Ethernet *eth = reinterpret_cast<Ethernet *>(p);
   Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
   TcpHeader *tcp = reinterpret_cast<TcpHeader *>(ip + 1);
 

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -12,7 +12,7 @@
 #include "../utils/time.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
+using bess::utils::Ipv4;
 using bess::utils::TcpHeader;
 using bess::utils::be16_t;
 using bess::utils::be32_t;
@@ -384,9 +384,9 @@ CommandResponse FlowGen::UpdateBaseAddresses() {
     return CommandFailure(EINVAL, "must specify 'template'");
   }
 
-  Ipv4Header *ipheader = reinterpret_cast<Ipv4Header *>(p + sizeof(EthHeader));
+  Ipv4 *ipheader = reinterpret_cast<Ipv4 *>(p + sizeof(EthHeader));
   TcpHeader *tcpheader =
-      reinterpret_cast<TcpHeader *>(p + sizeof(EthHeader) + sizeof(Ipv4Header));
+      reinterpret_cast<TcpHeader *>(p + sizeof(EthHeader) + sizeof(Ipv4));
 
   ip_src_base_ = ipheader->src.value();
   ip_dst_base_ = ipheader->dst.value();
@@ -407,7 +407,7 @@ bess::Packet *FlowGen::FillPacket(struct flow *f) {
   char *p = pkt->buffer<char *>() + SNBUF_HEADROOM;
 
   EthHeader *eth = reinterpret_cast<EthHeader *>(p);
-  Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+  Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
   TcpHeader *tcp = reinterpret_cast<TcpHeader *>(ip + 1);
 
   // SYN or FIN?

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -1,13 +1,14 @@
 #ifndef BESS_MODULES_FLOWGEN_H_
 #define BESS_MODULES_FLOWGEN_H_
 
+#include "../module.h"
+#include "../module_msg.pb.h"
+
 #include <queue>
 #include <stack>
 
-#include "../module.h"
-#include "../module_msg.pb.h"
-#include "../utils/random.h"
 #include "../utils/endian.h"
+#include "../utils/random.h"
 
 typedef std::pair<uint64_t, struct flow *> Event;
 typedef std::priority_queue<Event, std::vector<Event>, std::greater<Event>>

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -7,6 +7,7 @@
 #include "../module.h"
 #include "../module_msg.pb.h"
 #include "../utils/random.h"
+#include "../utils/endian.h"
 
 typedef std::pair<uint64_t, struct flow *> Event;
 typedef std::priority_queue<Event, std::vector<Event>, std::greater<Event>>
@@ -15,10 +16,10 @@ typedef std::priority_queue<Event, std::vector<Event>, std::greater<Event>>
 struct flow {
   int packets_left;
   bool first_pkt;
+
   uint32_t next_seq_no;
-  /* Note that these are in NETWORK ORDER */
-  uint32_t src_ip, dst_ip;
-  uint16_t src_port, dst_port;
+  bess::utils::be32_t src_ip, dst_ip;
+  bess::utils::be16_t src_port, dst_port;
 };
 
 class FlowGen final : public Module {

--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -6,13 +6,13 @@
 
 void IPChecksum::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
 
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
     EthHeader *eth = batch->pkts()[i]->head_data<EthHeader *>();
-    Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     ip->checksum = CalculateIpv4NoOptChecksum(*ip);
   }
 

--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -1,20 +1,19 @@
 #include "ip_checksum.h"
 
-#include <rte_ether.h>
-#include <rte_ip.h>
+#include "../utils/checksum.h"
+#include "../utils/ether.h"
+#include "../utils/ip.h"
 
 void IPChecksum::ProcessBatch(bess::PacketBatch *batch) {
+  using bess::utils::EthHeader;
+  using bess::utils::Ipv4Header;
+
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
-    bess::Packet *pkt = batch->pkts()[i];
-
-    struct ether_hdr *eth = pkt->head_data<struct ether_hdr *>();
-    struct ipv4_hdr *ip = reinterpret_cast<struct ipv4_hdr *>(eth + 1);
-
-    ip->hdr_checksum = 0;
-
-    ip->hdr_checksum = rte_ipv4_cksum(ip);
+    EthHeader *eth = batch->pkts()[i]->head_data<EthHeader *>();
+    Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+    ip->checksum = CalculateIpv4NoOptChecksum(*ip);
   }
 
   RunNextModule(batch);

--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -5,13 +5,13 @@
 #include "../utils/ip.h"
 
 void IPChecksum::ProcessBatch(bess::PacketBatch *batch) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
 
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
-    EthHeader *eth = batch->pkts()[i]->head_data<EthHeader *>();
+    Ethernet *eth = batch->pkts()[i]->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     ip->checksum = CalculateIpv4NoOptChecksum(*ip);
   }

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -5,7 +5,7 @@
 #include "../utils/ip.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
+using bess::utils::Ipv4;
 using bess::utils::be16_t;
 using bess::utils::be32_t;
 
@@ -39,11 +39,11 @@ void IPEncap::ProcessBatch(bess::PacketBatch *batch) {
     be32_t ip_dst = get_attr<be32_t>(this, ATTR_R_IP_DST, pkt);
     uint8_t ip_proto = get_attr<uint8_t>(this, ATTR_R_IP_PROTO, pkt);
 
-    Ipv4Header *iph;
+    Ipv4 *iph;
 
     uint16_t total_len = pkt->total_len() + sizeof(*iph);
 
-    iph = static_cast<Ipv4Header *>(pkt->prepend(sizeof(*iph)));
+    iph = static_cast<Ipv4 *>(pkt->prepend(sizeof(*iph)));
 
     if (unlikely(!iph)) {
       continue;
@@ -53,7 +53,7 @@ void IPEncap::ProcessBatch(bess::PacketBatch *batch) {
     iph->header_length = sizeof(*iph) / 4;
     iph->type_of_service = 0;
     iph->length = be16_t(total_len);
-    iph->fragment_offset = be16_t(Ipv4Header::Flag::kDF);
+    iph->fragment_offset = be16_t(Ipv4::Flag::kDF);
     iph->ttl = 64;
     iph->protocol = ip_proto;
     iph->src = ip_src;

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -3,9 +3,12 @@
 #include "../utils/checksum.h"
 #include "../utils/ether.h"
 #include "../utils/ip.h"
+#include "../utils/endian.h"
 
 using bess::utils::EthHeader;
 using bess::utils::Ipv4Header;
+using bess::utils::be16_t;
+using bess::utils::be32_t;
 
 enum {
   ATTR_R_IP_SRC,
@@ -50,12 +53,12 @@ void IPEncap::ProcessBatch(bess::PacketBatch *batch) {
     iph->version = 0x4;
     iph->header_length = sizeof(*iph) / 4;
     iph->type_of_service = 0;
-    iph->length = __builtin_bswap16(total_len);
-    iph->fragment_offset = __builtin_bswap16(Ipv4Header::Flag::kDF);
+    iph->length = be16_t(total_len);
+    iph->fragment_offset = be16_t(Ipv4Header::Flag::kDF);
     iph->ttl = 64;
     iph->protocol = ip_proto;
-    iph->src = ip_src;
-    iph->dst = ip_dst;
+    iph->src = be32_t(ip_src);
+    iph->dst = be32_t(ip_dst);
 
     iph->checksum = bess::utils::CalculateIpv4NoOptChecksum(*iph);
 

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -1,7 +1,6 @@
 #include "ip_encap.h"
 
 #include "../utils/checksum.h"
-#include "../utils/endian.h"
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -4,7 +4,7 @@
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using bess::utils::be16_t;
 using bess::utils::be32_t;
@@ -63,7 +63,7 @@ void IPEncap::ProcessBatch(bess::PacketBatch *batch) {
 
     set_attr<be32_t>(this, ATTR_W_IP_NEXTHOP, pkt, ip_dst);
     set_attr<be16_t>(this, ATTR_W_ETHER_TYPE, pkt,
-                     be16_t(EthHeader::Type::kIpv4));
+                     be16_t(Ethernet::Type::kIpv4));
   }
 
   RunNextModule(batch);

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -43,7 +43,7 @@ void IPLookup::DeInit() {
 
 void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
 
   gate_idx_t out_gates[bess::PacketBatch::kMaxBurst];
   gate_idx_t default_gate = default_gate_;
@@ -58,7 +58,7 @@ void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
   /* 4 at a time */
   for (i = 0; i + 3 < cnt; i += 4) {
     EthHeader *eth;
-    Ipv4Header *ip;
+    Ipv4 *ip;
 
     uint32_t a0, a1, a2, a3;
     uint32_t next_hops[4];
@@ -66,19 +66,19 @@ void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
     __m128i ip_addr;
 
     eth = batch->pkts()[i]->head_data<EthHeader *>();
-    ip = (Ipv4Header *)(eth + 1);
+    ip = (Ipv4 *)(eth + 1);
     a0 = ip->dst.raw_value();
 
     eth = batch->pkts()[i + 1]->head_data<EthHeader *>();
-    ip = (Ipv4Header *)(eth + 1);
+    ip = (Ipv4 *)(eth + 1);
     a1 = ip->dst.raw_value();
 
     eth = batch->pkts()[i + 2]->head_data<EthHeader *>();
-    ip = (Ipv4Header *)(eth + 1);
+    ip = (Ipv4 *)(eth + 1);
     a2 = ip->dst.raw_value();
 
     eth = batch->pkts()[i + 3]->head_data<EthHeader *>();
-    ip = (Ipv4Header *)(eth + 1);
+    ip = (Ipv4 *)(eth + 1);
     a3 = ip->dst.raw_value();
 
     ip_addr = _mm_set_epi32(a3, a2, a1, a0);
@@ -96,13 +96,13 @@ void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
   /* process the rest one by one */
   for (; i < cnt; i++) {
     EthHeader *eth;
-    Ipv4Header *ip;
+    Ipv4 *ip;
 
     uint32_t next_hop;
     int ret;
 
     eth = batch->pkts()[i]->head_data<EthHeader *>();
-    ip = (Ipv4Header *)(eth + 1);
+    ip = (Ipv4 *)(eth + 1);
 
     ret = rte_lpm_lookup(lpm_, ip->dst.raw_value(), &next_hop);
 

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -42,7 +42,7 @@ void IPLookup::DeInit() {
 }
 
 void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
 
   gate_idx_t out_gates[bess::PacketBatch::kMaxBurst];
@@ -57,7 +57,7 @@ void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
 
   /* 4 at a time */
   for (i = 0; i + 3 < cnt; i += 4) {
-    EthHeader *eth;
+    Ethernet *eth;
     Ipv4 *ip;
 
     uint32_t a0, a1, a2, a3;
@@ -65,19 +65,19 @@ void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
 
     __m128i ip_addr;
 
-    eth = batch->pkts()[i]->head_data<EthHeader *>();
+    eth = batch->pkts()[i]->head_data<Ethernet *>();
     ip = (Ipv4 *)(eth + 1);
     a0 = ip->dst.raw_value();
 
-    eth = batch->pkts()[i + 1]->head_data<EthHeader *>();
+    eth = batch->pkts()[i + 1]->head_data<Ethernet *>();
     ip = (Ipv4 *)(eth + 1);
     a1 = ip->dst.raw_value();
 
-    eth = batch->pkts()[i + 2]->head_data<EthHeader *>();
+    eth = batch->pkts()[i + 2]->head_data<Ethernet *>();
     ip = (Ipv4 *)(eth + 1);
     a2 = ip->dst.raw_value();
 
-    eth = batch->pkts()[i + 3]->head_data<EthHeader *>();
+    eth = batch->pkts()[i + 3]->head_data<Ethernet *>();
     ip = (Ipv4 *)(eth + 1);
     a3 = ip->dst.raw_value();
 
@@ -95,13 +95,13 @@ void IPLookup::ProcessBatch(bess::PacketBatch *batch) {
 
   /* process the rest one by one */
   for (; i < cnt; i++) {
-    EthHeader *eth;
+    Ethernet *eth;
     Ipv4 *ip;
 
     uint32_t next_hop;
     int ret;
 
-    eth = batch->pkts()[i]->head_data<EthHeader *>();
+    eth = batch->pkts()[i]->head_data<Ethernet *>();
     ip = (Ipv4 *)(eth + 1);
 
     ret = rte_lpm_lookup(lpm_, ip->dst.raw_value(), &next_hop);

--- a/core/modules/ipswap.cc
+++ b/core/modules/ipswap.cc
@@ -7,7 +7,7 @@
 void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
-  using bess::utils::UdpHeader;
+  using bess::utils::Udp;
 
   int cnt = batch->cnt();
 
@@ -17,7 +17,7 @@ void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length & 0xf) << 2;
-    UdpHeader *udp = reinterpret_cast<UdpHeader *>(
+    Udp *udp = reinterpret_cast<Udp *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);
 
     // std::swap cannot be used for packed fields

--- a/core/modules/ipswap.cc
+++ b/core/modules/ipswap.cc
@@ -6,7 +6,7 @@
 
 void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
 
   int cnt = batch->cnt();
@@ -15,7 +15,7 @@ void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
     bess::Packet *pkt = batch->pkts()[i];
 
     EthHeader *eth = pkt->head_data<EthHeader *>();
-    Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length & 0xf) << 2;
     UdpHeader *udp = reinterpret_cast<UdpHeader *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);
@@ -27,14 +27,14 @@ void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
 
     bess::utils::be16_t tmp_port;
     switch (ip->protocol) {
-      case Ipv4Header::Proto::kTcp:
-      case Ipv4Header::Proto::kUdp:
+      case Ipv4::Proto::kTcp:
+      case Ipv4::Proto::kUdp:
         // TCP and UDP share the same layout for ports
         tmp_port = udp->src_port;
         udp->src_port = udp->dst_port;
         udp->dst_port = tmp_port;
         break;
-      case Ipv4Header::Proto::kIcmp:
+      case Ipv4::Proto::kIcmp:
         break;
       default:
         VLOG(1) << "Unknown protocol: " << ip->protocol;

--- a/core/modules/ipswap.cc
+++ b/core/modules/ipswap.cc
@@ -27,14 +27,14 @@ void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
 
     bess::utils::be16_t tmp_port;
     switch (ip->protocol) {
-      case 0x06:  // TCP
-      case 0x11:  // UDP
+      case Ipv4Header::Proto::kTcp:
+      case Ipv4Header::Proto::kUdp:
         // TCP and UDP share the same layout for ports
         tmp_port = udp->src_port;
         udp->src_port = udp->dst_port;
         udp->dst_port = tmp_port;
         break;
-      case 0x01:  // ICMP
+      case Ipv4Header::Proto::kIcmp:
         break;
       default:
         VLOG(1) << "Unknown protocol: " << ip->protocol;

--- a/core/modules/ipswap.cc
+++ b/core/modules/ipswap.cc
@@ -17,8 +17,8 @@ void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length & 0xf) << 2;
-    Udp *udp = reinterpret_cast<Udp *>(
-        reinterpret_cast<uint8_t *>(ip) + ip_bytes);
+    Udp *udp =
+        reinterpret_cast<Udp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
 
     // std::swap cannot be used for packed fields
     bess::utils::be32_t tmp_ip = ip->src;

--- a/core/modules/ipswap.cc
+++ b/core/modules/ipswap.cc
@@ -5,7 +5,7 @@
 #include "utils/udp.h"
 
 void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
 
@@ -14,7 +14,7 @@ void IPSwap::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    EthHeader *eth = pkt->head_data<EthHeader *>();
+    Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length & 0xf) << 2;
     UdpHeader *udp = reinterpret_cast<UdpHeader *>(

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -1,10 +1,9 @@
 #include "l2_forward.h"
 
-#include <glog/logging.h>
-#include <rte_byteorder.h>
 #include <rte_hash_crc.h>
 
 #include "../mem_alloc.h"
+#include "../utils/endian.h"
 #include "../utils/simd.h"
 
 #define MAX_TABLE_SIZE (1048576 * 64)
@@ -695,11 +694,12 @@ CommandResponse L2Forward::CommandPopulate(
   int cnt = arg.count();
   int gate_cnt = arg.gate_count();
 
-  base_u64 = rte_be_to_cpu_64(base_u64);
+  base_u64 = bess::utils::be64_t::swap(base_u64) >> 16;
   base_u64 = base_u64 >> 16;
 
   for (int i = 0; i < cnt; i++) {
-    l2_add_entry(&l2_table_, rte_cpu_to_be_64(base_u64 << 16), i % gate_cnt);
+    l2_add_entry(&l2_table_, bess::utils::be64_t::swap(base_u64 << 16),
+                 i % gate_cnt);
 
     base_u64++;
   }

--- a/core/modules/macswap.cc
+++ b/core/modules/macswap.cc
@@ -1,18 +1,19 @@
 #include "macswap.h"
 
-#include <rte_ether.h>
+#include "../utils/ether.h"
 
 void MACSwap::ProcessBatch(bess::PacketBatch *batch) {
+  using bess::utils::EthHeader;
+
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
-    char *head = batch->pkts()[i]->head_data<char *>();
-    struct ether_hdr *eth = (struct ether_hdr *)head;
-    struct ether_addr tmp;
+    EthHeader *eth = batch->pkts()[i]->head_data<EthHeader *>();
+    EthHeader::Address tmp;
 
-    tmp = eth->d_addr;
-    eth->d_addr = eth->s_addr;
-    eth->s_addr = tmp;
+    tmp = eth->dst_addr;
+    eth->dst_addr = eth->src_addr;
+    eth->src_addr = tmp;
   }
 
   RunNextModule(batch);

--- a/core/modules/macswap.cc
+++ b/core/modules/macswap.cc
@@ -3,13 +3,13 @@
 #include "../utils/ether.h"
 
 void MACSwap::ProcessBatch(bess::PacketBatch *batch) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
 
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
-    EthHeader *eth = batch->pkts()[i]->head_data<EthHeader *>();
-    EthHeader::Address tmp;
+    Ethernet *eth = batch->pkts()[i]->head_data<Ethernet *>();
+    Ethernet::Address tmp;
 
     tmp = eth->dst_addr;
     eth->dst_addr = eth->src_addr;

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -10,7 +10,7 @@
 
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
-using bess::utils::UdpHeader;
+using bess::utils::Udp;
 
 static bool IsTimestamped(bess::Packet *pkt, size_t offset, uint64_t *time) {
   auto *marker = pkt->head_data<Timestamp::MarkerType *>(offset);
@@ -38,7 +38,7 @@ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
     offset_ = arg.offset();
   } else {
     offset_ = sizeof(struct Ethernet) + sizeof(struct Ipv4) +
-              sizeof(struct UdpHeader);
+              sizeof(struct Udp);
   }
 
   if (arg.jitter_sample_prob()) {

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -37,8 +37,8 @@ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(struct Ethernet) + sizeof(struct Ipv4) +
-              sizeof(struct Udp);
+    offset_ =
+        sizeof(struct Ethernet) + sizeof(struct Ipv4) + sizeof(struct Udp);
   }
 
   if (arg.jitter_sample_prob()) {

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -8,7 +8,7 @@
 #include "../utils/udp.h"
 #include "timestamp.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using bess::utils::UdpHeader;
 
@@ -37,7 +37,7 @@ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(struct EthHeader) + sizeof(struct Ipv4) +
+    offset_ = sizeof(struct Ethernet) + sizeof(struct Ipv4) +
               sizeof(struct UdpHeader);
   }
 

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -37,8 +37,7 @@ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ =
-        sizeof(struct Ethernet) + sizeof(struct Ipv4) + sizeof(struct Udp);
+    offset_ = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(Udp);
   }
 
   if (arg.jitter_sample_prob()) {

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -9,7 +9,7 @@
 #include "timestamp.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
+using bess::utils::Ipv4;
 using bess::utils::UdpHeader;
 
 static bool IsTimestamped(bess::Packet *pkt, size_t offset, uint64_t *time) {
@@ -37,7 +37,7 @@ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(struct EthHeader) + sizeof(struct Ipv4Header) +
+    offset_ = sizeof(struct EthHeader) + sizeof(struct Ipv4) +
               sizeof(struct UdpHeader);
   }
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -1,7 +1,5 @@
 #include "nat.h"
 
-#include <rte_ip.h>
-
 #include <algorithm>
 #include <numeric>
 #include <string>

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -212,7 +212,7 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
 
     const auto rule_it =
         std::find_if(rules_.begin(), rules_.end(),
-                     [&ip](const std::pair<CIDRNetwork, AvailablePorts> &rule) {
+                     [&ip](const std::pair<Ipv4Prefix, AvailablePorts> &rule) {
                        return rule.first.Match(ip->src);
                      });
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -16,7 +16,7 @@ using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using IpProto = bess::utils::Ipv4::Proto;
 using bess::utils::Udp;
-using bess::utils::TcpHeader;
+using bess::utils::Tcp;
 using bess::utils::IcmpHeader;
 using bess::utils::CalculateChecksumIncremental16;
 using bess::utils::CalculateChecksumUnfoldedIncremental32;
@@ -96,7 +96,7 @@ template <bool src>
 static inline void stamp_flow(struct Ipv4 *ip, void *l4,
                               const Flow &flow) {
   struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
-  struct TcpHeader *tcp = reinterpret_cast<struct TcpHeader *>(l4);
+  struct Tcp *tcp = reinterpret_cast<struct Tcp *>(l4);
   struct IcmpHeader *icmp = reinterpret_cast<struct IcmpHeader *>(l4);
   uint32_t l3_inc = 0;
   uint32_t l4_inc = 0;

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -17,7 +17,7 @@ using bess::utils::Ipv4;
 using IpProto = bess::utils::Ipv4::Proto;
 using bess::utils::Udp;
 using bess::utils::Tcp;
-using bess::utils::IcmpHeader;
+using bess::utils::Icmp;
 using bess::utils::CalculateChecksumIncremental16;
 using bess::utils::CalculateChecksumUnfoldedIncremental32;
 using bess::utils::CalculateChecksumUnfoldedIncremental16;
@@ -61,7 +61,7 @@ CommandResponse NAT::CommandClear(const bess::pb::EmptyArg &) {
 // Extract a Flow object from IP header ip and L4 header l4
 static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
   struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
-  struct IcmpHeader *icmp = reinterpret_cast<struct IcmpHeader *>(l4);
+  struct Icmp *icmp = reinterpret_cast<struct Icmp *>(l4);
   Flow flow;
 
   flow.proto = ip->protocol;
@@ -93,11 +93,10 @@ static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
 }
 
 template <bool src>
-static inline void stamp_flow(struct Ipv4 *ip, void *l4,
-                              const Flow &flow) {
+static inline void stamp_flow(struct Ipv4 *ip, void *l4, const Flow &flow) {
   struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
   struct Tcp *tcp = reinterpret_cast<struct Tcp *>(l4);
-  struct IcmpHeader *icmp = reinterpret_cast<struct IcmpHeader *>(l4);
+  struct Icmp *icmp = reinterpret_cast<struct Icmp *>(l4);
   uint32_t l3_inc = 0;
   uint32_t l4_inc = 0;
 
@@ -174,14 +173,12 @@ static inline void stamp_flow(struct Ipv4 *ip, void *l4,
 }
 
 // Rewrite IP header and L4 header src info using flow
-static inline void stamp_flow_src(struct Ipv4 *ip, void *l4,
-                                  const Flow &flow) {
+static inline void stamp_flow_src(struct Ipv4 *ip, void *l4, const Flow &flow) {
   stamp_flow<true>(ip, l4, flow);
 }
 
 // Rewrite IP header and L4 header dst info using flow
-static inline void stamp_flow_dst(struct Ipv4 *ip, void *l4,
-                                  const Flow &flow) {
+static inline void stamp_flow_dst(struct Ipv4 *ip, void *l4, const Flow &flow) {
   stamp_flow<false>(ip, l4, flow);
 }
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -12,7 +12,7 @@
 #include "../utils/tcp.h"
 #include "../utils/udp.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using IpProto = bess::utils::Ipv4::Proto;
 using bess::utils::UdpHeader;
@@ -199,7 +199,7 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
+    struct Ethernet *eth = pkt->head_data<struct Ethernet *>();
     struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length) << 2;
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -73,6 +73,7 @@ static inline Flow parse_flow(struct Ipv4Header *ip, void *l4) {
         case 15:
         case 16:
           flow.icmp_ident = icmp->ident;
+          flow.dst_port = be16_t(0);
           break;
         default:
           VLOG(1) << "Unknown icmp_type: " << icmp->type;

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -13,8 +13,8 @@
 #include "../utils/udp.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
-using IpProto = bess::utils::Ipv4Header::Proto;
+using bess::utils::Ipv4;
+using IpProto = bess::utils::Ipv4::Proto;
 using bess::utils::UdpHeader;
 using bess::utils::TcpHeader;
 using bess::utils::IcmpHeader;
@@ -59,7 +59,7 @@ CommandResponse NAT::CommandClear(const bess::pb::EmptyArg &) {
 }
 
 // Extract a Flow object from IP header ip and L4 header l4
-static inline Flow parse_flow(struct Ipv4Header *ip, void *l4) {
+static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
   struct UdpHeader *udp = reinterpret_cast<struct UdpHeader *>(l4);
   struct IcmpHeader *icmp = reinterpret_cast<struct IcmpHeader *>(l4);
   Flow flow;
@@ -93,7 +93,7 @@ static inline Flow parse_flow(struct Ipv4Header *ip, void *l4) {
 }
 
 template <bool src>
-static inline void stamp_flow(struct Ipv4Header *ip, void *l4,
+static inline void stamp_flow(struct Ipv4 *ip, void *l4,
                               const Flow &flow) {
   struct UdpHeader *udp = reinterpret_cast<struct UdpHeader *>(l4);
   struct TcpHeader *tcp = reinterpret_cast<struct TcpHeader *>(l4);
@@ -174,13 +174,13 @@ static inline void stamp_flow(struct Ipv4Header *ip, void *l4,
 }
 
 // Rewrite IP header and L4 header src info using flow
-static inline void stamp_flow_src(struct Ipv4Header *ip, void *l4,
+static inline void stamp_flow_src(struct Ipv4 *ip, void *l4,
                                   const Flow &flow) {
   stamp_flow<true>(ip, l4, flow);
 }
 
 // Rewrite IP header and L4 header dst info using flow
-static inline void stamp_flow_dst(struct Ipv4Header *ip, void *l4,
+static inline void stamp_flow_dst(struct Ipv4 *ip, void *l4,
                                   const Flow &flow) {
   stamp_flow<false>(ip, l4, flow);
 }
@@ -200,7 +200,7 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
     bess::Packet *pkt = batch->pkts()[i];
 
     struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
-    struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
+    struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length) << 2;
 
     void *l4 = reinterpret_cast<uint8_t *>(ip) + ip_bytes;

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -59,9 +59,9 @@ CommandResponse NAT::CommandClear(const bess::pb::EmptyArg &) {
 }
 
 // Extract a Flow object from IP header ip and L4 header l4
-static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
-  struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
-  struct Icmp *icmp = reinterpret_cast<struct Icmp *>(l4);
+static inline Flow parse_flow(Ipv4 *ip, void *l4) {
+  Udp *udp = reinterpret_cast<Udp *>(l4);
+  Icmp *icmp = reinterpret_cast<Icmp *>(l4);
   Flow flow;
 
   flow.proto = ip->protocol;
@@ -93,10 +93,10 @@ static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
 }
 
 template <bool src>
-static inline void stamp_flow(struct Ipv4 *ip, void *l4, const Flow &flow) {
-  struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
-  struct Tcp *tcp = reinterpret_cast<struct Tcp *>(l4);
-  struct Icmp *icmp = reinterpret_cast<struct Icmp *>(l4);
+static inline void stamp_flow(Ipv4 *ip, void *l4, const Flow &flow) {
+  Udp *udp = reinterpret_cast<Udp *>(l4);
+  Tcp *tcp = reinterpret_cast<Tcp *>(l4);
+  Icmp *icmp = reinterpret_cast<Icmp *>(l4);
   uint32_t l3_inc = 0;
   uint32_t l4_inc = 0;
 
@@ -173,12 +173,12 @@ static inline void stamp_flow(struct Ipv4 *ip, void *l4, const Flow &flow) {
 }
 
 // Rewrite IP header and L4 header src info using flow
-static inline void stamp_flow_src(struct Ipv4 *ip, void *l4, const Flow &flow) {
+static inline void stamp_flow_src(Ipv4 *ip, void *l4, const Flow &flow) {
   stamp_flow<true>(ip, l4, flow);
 }
 
 // Rewrite IP header and L4 header dst info using flow
-static inline void stamp_flow_dst(struct Ipv4 *ip, void *l4, const Flow &flow) {
+static inline void stamp_flow_dst(Ipv4 *ip, void *l4, const Flow &flow) {
   stamp_flow<false>(ip, l4, flow);
 }
 
@@ -196,8 +196,8 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    struct Ethernet *eth = pkt->head_data<struct Ethernet *>();
-    struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
+    Ethernet *eth = pkt->head_data<Ethernet *>();
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length) << 2;
 
     void *l4 = reinterpret_cast<uint8_t *>(ip) + ip_bytes;

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -15,7 +15,7 @@
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using IpProto = bess::utils::Ipv4::Proto;
-using bess::utils::UdpHeader;
+using bess::utils::Udp;
 using bess::utils::TcpHeader;
 using bess::utils::IcmpHeader;
 using bess::utils::CalculateChecksumIncremental16;
@@ -60,7 +60,7 @@ CommandResponse NAT::CommandClear(const bess::pb::EmptyArg &) {
 
 // Extract a Flow object from IP header ip and L4 header l4
 static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
-  struct UdpHeader *udp = reinterpret_cast<struct UdpHeader *>(l4);
+  struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
   struct IcmpHeader *icmp = reinterpret_cast<struct IcmpHeader *>(l4);
   Flow flow;
 
@@ -95,7 +95,7 @@ static inline Flow parse_flow(struct Ipv4 *ip, void *l4) {
 template <bool src>
 static inline void stamp_flow(struct Ipv4 *ip, void *l4,
                               const Flow &flow) {
-  struct UdpHeader *udp = reinterpret_cast<struct UdpHeader *>(l4);
+  struct Udp *udp = reinterpret_cast<struct Udp *>(l4);
   struct TcpHeader *tcp = reinterpret_cast<struct TcpHeader *>(l4);
   struct IcmpHeader *icmp = reinterpret_cast<struct IcmpHeader *>(l4);
   uint32_t l3_inc = 0;

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -18,7 +18,7 @@
 
 using bess::utils::be16_t;
 using bess::utils::be32_t;
-using bess::utils::CIDRNetwork;
+using bess::utils::Ipv4Prefix;
 
 const uint16_t MIN_PORT = 1024;
 const uint16_t MAX_PORT = 65535;
@@ -71,7 +71,7 @@ class FlowRecord {
 class AvailablePorts {
  public:
   // Tracks available ports within the given IP prefix.
-  explicit AvailablePorts(const CIDRNetwork &prefix)
+  explicit AvailablePorts(const Ipv4Prefix &prefix)
       : prefix_(prefix),
         records_(),
         free_list_(),
@@ -114,14 +114,14 @@ class AvailablePorts {
   // Returns true if there are no free remaining IP/port pairs.
   bool empty() const { return free_list_.empty(); }
 
-  const CIDRNetwork &prefix() const { return prefix_; }
+  const Ipv4Prefix &prefix() const { return prefix_; }
 
   uint64_t next_expiry() const { return next_expiry_; }
 
   void set_next_expiry(uint64_t next_expiry) { next_expiry_ = next_expiry; }
 
  private:
-  CIDRNetwork prefix_;
+  Ipv4Prefix prefix_;
   std::vector<FlowRecord> records_;
   std::vector<std::pair<be32_t, be16_t>> free_list_;
   uint64_t next_expiry_;
@@ -166,15 +166,15 @@ class NAT final : public Module {
  private:
   void InitRules(const bess::pb::NATArg &arg) {
     for (const auto &rule : arg.rules()) {
-      CIDRNetwork int_net(rule.internal_addr_block());
-      CIDRNetwork ext_net(rule.external_addr_block());
+      Ipv4Prefix int_net(rule.internal_addr_block());
+      Ipv4Prefix ext_net(rule.external_addr_block());
       rules_.emplace_back(std::piecewise_construct,
                           std::forward_as_tuple(int_net),
                           std::forward_as_tuple(ext_net));
     }
   }
 
-  std::vector<std::pair<CIDRNetwork, AvailablePorts>> rules_;
+  std::vector<std::pair<Ipv4Prefix, AvailablePorts>> rules_;
   bess::utils::CuckooMap<Flow, FlowRecord *, FlowHash> flow_hash_;
   Random rng_;
 };

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -1,7 +1,6 @@
 #ifndef BESS_MODULES_NAT_H_
 #define BESS_MODULES_NAT_H_
 
-#include <arpa/inet.h>
 #include <rte_config.h>
 #include <rte_hash_crc.h>
 
@@ -17,7 +16,8 @@
 #include "../utils/ip.h"
 #include "../utils/random.h"
 
-using bess::utils::IPAddress;
+using bess::utils::be16_t;
+using bess::utils::be32_t;
 using bess::utils::CIDRNetwork;
 using bess::utils::HashResult;
 using bess::utils::CuckooMap;
@@ -35,52 +35,38 @@ enum Protocol : uint8_t {
 // 5 tuple for TCP/UDP packets with an additional icmp_ident for ICMP query pkts
 class alignas(16) Flow {
  public:
+  be32_t src_ip;
+  be32_t dst_ip;
   union {
-    struct {
-      IPAddress src_ip;
-      IPAddress dst_ip;
-      union {
-        uint16_t src_port;
-        uint16_t icmp_ident;  // identifier of ICMP query
-      };
-      uint16_t dst_port;
-      uint8_t proto;
-    };
-
-    struct {
-      uint64_t e1;
-      uint64_t e2;
-    };
+    be16_t src_port;
+    be16_t icmp_ident;  // identifier of ICMP query
   };
+  be16_t dst_port;
+  uint32_t proto;  // include 24-bit padding
 
-  Flow() : e1(0), e2(0) {}
+  Flow() {}
 
-  Flow(uint32_t sip, uint32_t dip, uint16_t sp = 0, uint16_t dp = 0,
+  Flow(be32_t sip, be32_t dip, be16_t sp = be16_t(0), be16_t dp = be16_t(0),
        uint8_t protocol = 0)
-      : src_ip(sip), dst_ip(dip) {
-    e2 = 0;
-    src_port = sp;
-    dst_port = dp;
-    proto = protocol;
-  }
+      : src_ip(sip), dst_ip(dip), src_port(sp), dst_port(dp), proto(protocol) {}
 
   // Returns a new instance of reserse flow
   Flow ReverseFlow() const {
     if (proto == ICMP) {
-      return Flow(dst_ip, src_ip, icmp_ident, 0, ICMP);
+      return Flow(dst_ip, src_ip, icmp_ident, be16_t(0), ICMP);
     } else {
       return Flow(dst_ip, src_ip, dst_port, src_port, proto);
     }
   }
 
   bool operator==(const Flow &other) const {
-    return e1 == other.e1 && e2 == other.e2;
+    return memcmp(this, &other, sizeof(*this)) == 0;
   }
 
   std::string ToString() const;
 };
 
-static_assert(sizeof(Flow) == 2 * sizeof(uint64_t), "Flow must be 16 bytes.");
+static_assert(sizeof(Flow) == 16, "Flow must be 16 bytes.");
 
 // Stores flow information
 class FlowRecord {
@@ -88,7 +74,7 @@ class FlowRecord {
   Flow internal_flow;
   Flow external_flow;
   uint64_t time;
-  uint16_t port;
+  be16_t port;
 
   FlowRecord() : internal_flow(), external_flow(), time(), port() {}
 };
@@ -106,13 +92,13 @@ class AvailablePorts {
         next_expiry_(),
         min_(),
         max_() {
-    min_ = ntohl(prefix_.addr & prefix_.mask);
-    max_ = ntohl(prefix_.addr | (~prefix_.mask));
+    min_ = prefix_.addr.value() & prefix_.mask.value();
+    max_ = prefix_.addr.value() | (~prefix_.mask.value());
 
     for (uint32_t ip = min_; ip <= max_; ip++) {
       for (uint32_t port = MIN_PORT; port <= MAX_PORT; port++) {
         records_.emplace_back();
-        free_list_.emplace_back(ip, port);
+        free_list_.emplace_back(be32_t(ip), be16_t((uint16_t)port));
       }
     }
     std::random_shuffle(free_list_.begin(), free_list_.end());
@@ -120,24 +106,23 @@ class AvailablePorts {
 
   // Returns a random free IP/port pair within the network and removes it from
   // the free list.
-  std::tuple<IPAddress, uint16_t, FlowRecord *> RandomFreeIPAndPort() {
-    uint32_t ip;
-    uint16_t port;
+  std::tuple<be32_t, be16_t, FlowRecord *> RandomFreeIPAndPort() {
+    be32_t ip;
+    be16_t port;
 
     std::tie(ip, port) = free_list_.back();
     free_list_.pop_back();
 
-    size_t index = (port - MIN_PORT) + (ip - min_) * (MAX_PORT - MIN_PORT + 1);
+    size_t index = (port.value() - MIN_PORT) +
+                   (ip.value() - min_) * (MAX_PORT - MIN_PORT + 1);
     FlowRecord *record = &records_[index];
 
-    return std::make_tuple(htonl(ip), htons(port), record);
+    return std::make_tuple(ip, port, record);
   }
 
   // Adds the index of given IP/port pair back to the free list.
-  void FreeAllocated(const std::tuple<IPAddress, uint16_t, FlowRecord *> &a) {
-    uint32_t ip = ntohl(std::get<0>(a));
-    uint16_t port = ntohs(std::get<1>(a));
-    free_list_.emplace_back(ip, port);
+  void FreeAllocated(const std::tuple<be32_t, be16_t, FlowRecord *> &a) {
+    free_list_.emplace_back(std::get<0>(a), std::get<1>(a));
   }
 
   // Returns true if there are no free remaining IP/port pairs.
@@ -152,18 +137,22 @@ class AvailablePorts {
  private:
   CIDRNetwork prefix_;
   std::vector<FlowRecord> records_;
-  std::vector<std::pair<uint32_t, uint16_t>> free_list_;
+  std::vector<std::pair<be32_t, be16_t>> free_list_;
   uint64_t next_expiry_;
   uint32_t min_, max_;
 };
 
-class FlowHash {
- public:
-  HashResult operator()(const Flow &key) const {
-    HashResult init_val = 0;
+struct FlowHash {
+  std::size_t operator()(const Flow &f) const {
+    const union {
+      Flow flow;
+      uint64_t u64[2];
+    } &bytes = {.flow = f};
+
+    uint32_t init_val = 0;
 #if __SSE4_2__ && __x86_64
-    init_val = crc32c_sse42_u64(key.e1, init_val);
-    init_val = crc32c_sse42_u64(key.e2, init_val);
+    init_val = crc32c_sse42_u64(bytes.u64[0], init_val);
+    init_val = crc32c_sse42_u64(bytes.u64[1], init_val);
 #else
     init_val = rte_hash_crc(&key.e1, sizeof(key.e1), init_val);
     init_val = rte_hash_crc(&key.e2, sizeof(key.e2), init_val);
@@ -204,4 +193,4 @@ class NAT final : public Module {
   Random rng_;
 };
 
-#endif  // BESS_MODULES_NAT_H_
+#endif  // BESS_MODULES_NAT_H_(

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -154,8 +154,8 @@ struct FlowHash {
     init_val = crc32c_sse42_u64(bytes.u64[0], init_val);
     init_val = crc32c_sse42_u64(bytes.u64[1], init_val);
 #else
-    init_val = rte_hash_crc(&key.e1, sizeof(key.e1), init_val);
-    init_val = rte_hash_crc(&key.e2, sizeof(key.e2), init_val);
+    init_val = rte_hash_crc(&bytes.u64[0], sizeof(uint64_t), init_val);
+    init_val = rte_hash_crc(&bytes.u64[1], sizeof(uint64_t), init_val);
 #endif
     return init_val;
   }

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -19,18 +19,10 @@
 using bess::utils::be16_t;
 using bess::utils::be32_t;
 using bess::utils::CIDRNetwork;
-using bess::utils::HashResult;
-using bess::utils::CuckooMap;
 
 const uint16_t MIN_PORT = 1024;
 const uint16_t MAX_PORT = 65535;
 const uint64_t TIME_OUT_NS = 120ull * 1000 * 1000 * 1000;
-
-enum Protocol : uint8_t {
-  ICMP = 0x01,
-  TCP = 0x06,
-  UDP = 0x11,
-};
 
 // 5 tuple for TCP/UDP packets with an additional icmp_ident for ICMP query pkts
 class alignas(16) Flow {
@@ -51,13 +43,7 @@ class alignas(16) Flow {
       : src_ip(sip), dst_ip(dip), src_port(sp), dst_port(dp), proto(protocol) {}
 
   // Returns a new instance of reserse flow
-  Flow ReverseFlow() const {
-    if (proto == ICMP) {
-      return Flow(dst_ip, src_ip, icmp_ident, be16_t(0), ICMP);
-    } else {
-      return Flow(dst_ip, src_ip, dst_port, src_port, proto);
-    }
-  }
+  Flow ReverseFlow() const;
 
   bool operator==(const Flow &other) const {
     return memcmp(this, &other, sizeof(*this)) == 0;
@@ -189,7 +175,7 @@ class NAT final : public Module {
   }
 
   std::vector<std::pair<CIDRNetwork, AvailablePorts>> rules_;
-  CuckooMap<Flow, FlowRecord *, FlowHash> flow_hash_;
+  bess::utils::CuckooMap<Flow, FlowRecord *, FlowHash> flow_hash_;
   Random rng_;
 };
 

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -3,6 +3,8 @@
 
 #include "../module.h"
 #include "../module_msg.pb.h"
+
+#include "../utils/endian.h"
 #include "../utils/random.h"
 
 #define MAX_VARS 16
@@ -24,10 +26,11 @@ class RandomUpdate final : public Module {
   int num_vars_;
 
   struct {
-    uint32_t mask; /* bits with 1 won't be updated */
+    bess::utils::be32_t mask;  // bits with 1 won't be updated
     uint32_t min;
-    uint32_t range; /* == max - min + 1 */
-    int16_t offset;
+    uint32_t range;  // max - min + 1
+    size_t offset;
+    size_t bit_shift;
   } vars_[MAX_VARS];
 
   Random rng_;

--- a/core/modules/set_metadata.h
+++ b/core/modules/set_metadata.h
@@ -5,7 +5,6 @@
 #include "../module_msg.pb.h"
 
 typedef struct { char bytes[bess::metadata::kMetadataAttrMaxSize]; } value_t;
-INSTANTIATE_MT_FOR_TYPE(value_t)
 
 struct Attr {
   std::string name;

--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -1,12 +1,6 @@
 #include "split.h"
 
-#include <rte_byteorder.h>
-
-#define MAX_SIZE 8
-
-#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
-#error this code assumes little endian architecture (x86)
-#endif
+#include "../utils/endian.h"
 
 // XXX: this is repeated in many modules. get rid of them when converting .h to
 // .hh, etc... it's in defined in some old header
@@ -16,8 +10,8 @@ static inline int is_valid_gate(gate_idx_t gate) {
 
 CommandResponse Split::Init(const bess::pb::SplitArg &arg) {
   size_ = arg.size();
-  if (size_ < 1 || size_ > MAX_SIZE) {
-    return CommandFailure(EINVAL, "'size' must be 1-%d", MAX_SIZE);
+  if (size_ < 1 || size_ > sizeof(uint64_t)) {
+    return CommandFailure(EINVAL, "'size' must be 1-%zu", sizeof(uint64_t));
   }
 
   mask_ = (size_ == 8) ? 0xffffffffffffffffull : (1ull << (size_ * 8)) - 1;
@@ -31,7 +25,7 @@ CommandResponse Split::Init(const bess::pb::SplitArg &arg) {
   } else {
     attr_id_ = -1;
     offset_ = arg.offset();
-    if (offset_ < 0 || offset_ > 1024) {
+    if (offset_ > 1024) {
       return CommandFailure(EINVAL, "invalid 'offset'");
     }
   }
@@ -39,6 +33,8 @@ CommandResponse Split::Init(const bess::pb::SplitArg &arg) {
 }
 
 void Split::ProcessBatch(bess::PacketBatch *batch) {
+  using bess::utils::be64_t;
+
   gate_idx_t ogate[bess::PacketBatch::kMaxBurst];
   int cnt = batch->cnt();
 
@@ -46,9 +42,9 @@ void Split::ProcessBatch(bess::PacketBatch *batch) {
     int attr_id = attr_id_;
 
     for (int i = 0; i < cnt; i++) {
-      bess::Packet *pkt = batch->pkts()[i];
+      const bess::Packet *pkt = batch->pkts()[i];
 
-      uint64_t val = get_attr<uint64_t>(this, attr_id, pkt);
+      uint64_t val = get_attr<be64_t>(this, attr_id, pkt).value();
       val &= mask_;
 
       if (is_valid_gate(val)) {
@@ -58,14 +54,9 @@ void Split::ProcessBatch(bess::PacketBatch *batch) {
       }
     }
   } else {
-    int offset = offset_;
-
     for (int i = 0; i < cnt; i++) {
-      bess::Packet *pkt = batch->pkts()[i];
-      char *head = pkt->head_data<char *>();
-
-      uint64_t val = *reinterpret_cast<uint64_t *>(head + offset);
-      val = rte_be_to_cpu_64(val) & mask_;
+      const bess::Packet *pkt = batch->pkts()[i];
+      uint64_t val = (*(pkt->head_data<be64_t *>(offset_))).value() & mask_;
 
       if (is_valid_gate(val)) {
         ogate[i] = val;

--- a/core/modules/split.h
+++ b/core/modules/split.h
@@ -17,8 +17,8 @@ class Split final : public Module {
  private:
   uint64_t mask_;
   int attr_id_;
-  int offset_;
-  int size_;
+  size_t offset_;
+  size_t size_;
 };
 
 #endif  // BESS_MODULES_SPLIT_H_

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -1,10 +1,5 @@
 #include "timestamp.h"
 
-#include <rte_config.h>
-#include <rte_ether.h>
-#include <rte_ip.h>
-#include <rte_udp.h>
-
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 #include "../utils/time.h"
@@ -40,8 +35,7 @@ CommandResponse Timestamp::Init(const bess::pb::TimestampArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(struct EthHeader) + sizeof(struct Ipv4Header) +
-              sizeof(struct UdpHeader);
+    offset_ = sizeof(EthHeader) + sizeof(Ipv4Header) + sizeof(UdpHeader);
   }
   return CommandSuccess();
 }

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -5,7 +5,7 @@
 #include "../utils/time.h"
 #include "../utils/udp.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using bess::utils::UdpHeader;
 
@@ -35,7 +35,7 @@ CommandResponse Timestamp::Init(const bess::pb::TimestampArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(EthHeader) + sizeof(Ipv4) + sizeof(UdpHeader);
+    offset_ = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(UdpHeader);
   }
   return CommandSuccess();
 }

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -6,7 +6,7 @@
 #include "../utils/udp.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
+using bess::utils::Ipv4;
 using bess::utils::UdpHeader;
 
 static inline void timestamp_packet(bess::Packet *pkt, size_t offset,
@@ -35,7 +35,7 @@ CommandResponse Timestamp::Init(const bess::pb::TimestampArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(EthHeader) + sizeof(Ipv4Header) + sizeof(UdpHeader);
+    offset_ = sizeof(EthHeader) + sizeof(Ipv4) + sizeof(UdpHeader);
   }
   return CommandSuccess();
 }

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -7,7 +7,7 @@
 
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
-using bess::utils::UdpHeader;
+using bess::utils::Udp;
 
 static inline void timestamp_packet(bess::Packet *pkt, size_t offset,
                                     uint64_t time) {
@@ -35,7 +35,7 @@ CommandResponse Timestamp::Init(const bess::pb::TimestampArg &arg) {
   if (arg.offset()) {
     offset_ = arg.offset();
   } else {
-    offset_ = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(UdpHeader);
+    offset_ = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(Udp);
   }
   return CommandSuccess();
 }

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -1,6 +1,6 @@
 #include "update.h"
+
 #include "../utils/endian.h"
-#include <rte_byteorder.h>
 
 const Commands Update::cmds = {
     {"add", "UpdateArg", MODULE_CMD_FUNC(&Update::CommandAdd), 0},
@@ -14,18 +14,18 @@ CommandResponse Update::Init(const bess::pb::UpdateArg &arg) {
 void Update::ProcessBatch(bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
-  for (int i = 0; i < num_fields_; i++) {
+  for (size_t i = 0; i < num_fields_; i++) {
     const auto field = &fields_[i];
 
-    uint64_t mask = field->mask;
-    uint64_t value = field->value;
+    be64_t mask = field->mask;
+    be64_t value = field->value;
     int16_t offset = field->offset;  // could be < 0
 
     for (int j = 0; j < cnt; j++) {
       bess::Packet *snb = batch->pkts()[j];
       char *head = snb->head_data<char *>();
 
-      uint64_t *p = reinterpret_cast<uint64_t *>(head + offset);
+      be64_t *p = reinterpret_cast<be64_t *>(head + offset);
       *p = (*p & mask) | value;
     }
   }
@@ -34,48 +34,37 @@ void Update::ProcessBatch(bess::PacketBatch *batch) {
 }
 
 CommandResponse Update::CommandAdd(const bess::pb::UpdateArg &arg) {
-  int curr = num_fields_;
+  size_t curr = num_fields_;
 
-  if (curr + arg.fields_size() > UPDATE_MAX_FIELDS) {
-    return CommandFailure(EINVAL, "max %d variables can be specified",
-                          UPDATE_MAX_FIELDS);
+  if (curr + arg.fields_size() > kMaxFields) {
+    return CommandFailure(EINVAL, "max %zu variables can be specified",
+                          kMaxFields);
   }
 
   for (int i = 0; i < arg.fields_size(); i++) {
     const auto &field = arg.fields(i);
 
-    uint8_t size;
-    int16_t offset;
-    uint64_t mask;
-    uint64_t value;
-
-    offset = field.offset();
-
-    size = field.size();
+    size_t size = field.size();
     if (size < 1 || size > 8) {
       return CommandFailure(EINVAL, "'size' must be 1-8");
     }
 
-    if (!bess::utils::uint64_to_bin(&value, field.value(), size,
-                                    bess::utils::is_be_system())) {
-      return CommandFailure(
-          EINVAL, "'value' field has not a correct %d-byte value", size);
-    }
-
-    if (offset < 0) {
-      return CommandFailure(EINVAL, "too small 'offset'");
-    }
-
-    offset -= (8 - size);
-    mask = (1ull << ((8 - size) * 8)) - 1;
-
-    if (offset + 8 > SNBUF_DATA) {
+    if (field.offset() + size > SNBUF_DATA) {
       return CommandFailure(EINVAL, "too large 'offset'");
     }
 
-    fields_[curr + i].offset = offset;
+    be64_t value(field.value() << ((8 - size) * 8));
+    be64_t mask((1ull << ((8 - size) * 8)) - 1);
+
+    if ((value & mask).value() != 0) {
+      LOG(INFO) << value << ' ' << mask;
+      return CommandFailure(
+          EINVAL, "'value' field has not a correct %zu-byte value", size);
+    }
+
+    fields_[curr + i].offset = field.offset();
     fields_[curr + i].mask = mask;
-    fields_[curr + i].value = rte_cpu_to_be_64(value);
+    fields_[curr + i].value = value;
   }
 
   num_fields_ = curr + arg.fields_size();

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -4,7 +4,9 @@
 #include "../module.h"
 #include "../module_msg.pb.h"
 
-#define UPDATE_MAX_FIELDS 16
+#include "../utils/endian.h"
+
+using bess::utils::be64_t;
 
 class Update final : public Module {
  public:
@@ -20,13 +22,15 @@ class Update final : public Module {
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
-  int num_fields_;
+  static const size_t kMaxFields = 16;
+
+  size_t num_fields_;
 
   struct {
-    uint64_t mask;  /* bits with 1 won't be updated */
-    uint64_t value; /* in network order */
-    int16_t offset;
-  } fields_[UPDATE_MAX_FIELDS];
+    be64_t mask;  /* bits with 1 won't be updated */
+    be64_t value; /* in network order */
+    size_t offset;
+  } fields_[kMaxFields];
 };
 
 #endif  // BESS_MODULES_UPDATE_H_

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -4,7 +4,7 @@
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 
 void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
@@ -18,7 +18,7 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
+    struct Ethernet *eth = pkt->head_data<struct Ethernet *>();
     struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
 
     if (ip->ttl > 1) {

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -5,7 +5,7 @@
 #include "../utils/ip.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
+using bess::utils::Ipv4;
 
 void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
   bess::PacketBatch out_batch;
@@ -19,7 +19,7 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
     bess::Packet *pkt = batch->pkts()[i];
 
     struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
-    struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
+    struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
 
     if (ip->ttl > 1) {
       // The incremental checksum only cares the difference from old_value to

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -18,8 +18,8 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    struct Ethernet *eth = pkt->head_data<struct Ethernet *>();
-    struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
+    Ethernet *eth = pkt->head_data<Ethernet *>();
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
 
     if (ip->ttl > 1) {
       // The incremental checksum only cares the difference from old_value to

--- a/core/modules/update_ttl.h
+++ b/core/modules/update_ttl.h
@@ -3,7 +3,8 @@
 
 #include "../module.h"
 
-// Updates TTl of packets by decrementing by 1 and dropping packets if their TTl <= 1
+// Updates TTl of packets by decrementing by 1 and dropping packets if their TTl
+// <= 1
 class UpdateTTL final : public Module {
  public:
   void ProcessBatch(bess::PacketBatch *batch) override;

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -11,6 +11,7 @@
 using bess::utils::EthHeader;
 using bess::utils::Ipv4Header;
 using bess::utils::TcpHeader;
+using bess::utils::be16_t;
 
 const uint64_t TIME_OUT_NS = 10ull * 1000 * 1000 * 1000;  // 10 seconds
 
@@ -27,7 +28,7 @@ struct[[gnu::packed]] PacketTemplate {
   PacketTemplate() {
     eth.dst_addr = EthHeader::Address();  // To fill in
     eth.src_addr = EthHeader::Address();  // To fill in
-    eth.ether_type = 0x0800;              // IPv4
+    eth.ether_type = be16_t(0x0800);      // IPv4
     ip.version = 4;
     ip.header_length = 5;
     ip.type_of_service = 0;

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -183,8 +183,8 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
-    struct Ethernet *eth = pkt->head_data<struct Ethernet *>();
-    struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
+    Ethernet *eth = pkt->head_data<Ethernet *>();
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
 
     if (ip->protocol != Ipv4::Proto::kTcp) {
       out_batches[0].add(pkt);
@@ -192,8 +192,8 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
     }
 
     int ip_bytes = ip->header_length << 2;
-    struct Tcp *tcp = reinterpret_cast<struct Tcp *>(
-        reinterpret_cast<uint8_t *>(ip) + ip_bytes);
+    Tcp *tcp =
+        reinterpret_cast<Tcp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
 
     Flow flow;
     flow.src_ip = ip->src;

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -35,7 +35,7 @@ struct[[gnu::packed]] PacketTemplate {
     ip.id = be16_t(0);
     ip.fragment_offset = be16_t(0);
     ip.ttl = 0x40;
-    ip.protocol = 0x06;
+    ip.protocol = Ipv4Header::Proto::kTcp;
     ip.checksum = 0;           // To fill in
     ip.src = be32_t(0);        // To fill in
     ip.dst = be32_t(0);        // To fill in
@@ -186,7 +186,7 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
     struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
     struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
 
-    if (ip->protocol != 0x06) {
+    if (ip->protocol != Ipv4Header::Proto::kTcp) {
       out_batches[0].add(pkt);
       continue;
     }

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -27,7 +27,7 @@ struct[[gnu::packed]] PacketTemplate {
   PacketTemplate() {
     eth.dst_addr = EthHeader::Address();  // To fill in
     eth.src_addr = EthHeader::Address();  // To fill in
-    eth.ether_type = be16_t(0x0800);      // IPv4
+    eth.ether_type = be16_t(EthHeader::Type::kIpv4);
     ip.version = 4;
     ip.header_length = 5;
     ip.type_of_service = 0;

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -8,7 +8,7 @@
 #include "../utils/ip.h"
 
 using bess::utils::EthHeader;
-using bess::utils::Ipv4Header;
+using bess::utils::Ipv4;
 using bess::utils::TcpHeader;
 using bess::utils::be16_t;
 
@@ -21,7 +21,7 @@ const Commands UrlFilter::cmds = {
 // Template for generating TCP packets without data
 struct[[gnu::packed]] PacketTemplate {
   EthHeader eth;
-  Ipv4Header ip;
+  Ipv4 ip;
   TcpHeader tcp;
 
   PacketTemplate() {
@@ -35,7 +35,7 @@ struct[[gnu::packed]] PacketTemplate {
     ip.id = be16_t(0);
     ip.fragment_offset = be16_t(0);
     ip.ttl = 0x40;
-    ip.protocol = Ipv4Header::Proto::kTcp;
+    ip.protocol = Ipv4::Proto::kTcp;
     ip.checksum = 0;           // To fill in
     ip.src = be32_t(0);        // To fill in
     ip.dst = be32_t(0);        // To fill in
@@ -76,7 +76,7 @@ inline static bess::Packet *Generate403Packet(const EthHeader::Address &src_eth,
   bess::utils::Copy(ptr + sizeof(rst_template), HTTP_403_BODY, len, true);
 
   EthHeader *eth = reinterpret_cast<EthHeader *>(ptr);
-  Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+  Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
   // We know there is no IP option
   TcpHeader *tcp = reinterpret_cast<TcpHeader *>(ip + 1);
 
@@ -112,7 +112,7 @@ inline static bess::Packet *GenerateResetPacket(
   bess::utils::Copy(ptr, &rst_template, sizeof(rst_template), true);
 
   EthHeader *eth = reinterpret_cast<EthHeader *>(ptr);
-  Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+  Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
   // We know there is no IP option
   TcpHeader *tcp = reinterpret_cast<TcpHeader *>(ip + 1);
 
@@ -184,9 +184,9 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
     bess::Packet *pkt = batch->pkts()[i];
 
     struct EthHeader *eth = pkt->head_data<struct EthHeader *>();
-    struct Ipv4Header *ip = reinterpret_cast<struct Ipv4Header *>(eth + 1);
+    struct Ipv4 *ip = reinterpret_cast<struct Ipv4 *>(eth + 1);
 
-    if (ip->protocol != Ipv4Header::Proto::kTcp) {
+    if (ip->protocol != Ipv4::Proto::kTcp) {
       out_batches[0].add(pkt);
       continue;
     }

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -45,7 +45,7 @@ struct[[gnu::packed]] PacketTemplate {
     tcp.ack_num = be32_t(0);   // To fill in
     tcp.reserved = 0;
     tcp.offset = 5;
-    tcp.flags = 0x14;  // RST-ACK
+    tcp.flags = TcpHeader::Flag::kAck | TcpHeader::Flag::kRst;
     tcp.window = be16_t(0);
     tcp.checksum = 0;  // To fill in
     tcp.urgent_ptr = be16_t(0);
@@ -89,7 +89,7 @@ inline static bess::Packet *Generate403Packet(const EthHeader::Address &src_eth,
   tcp->dst_port = dst_port;
   tcp->seq_num = seq;
   tcp->ack_num = ack;
-  tcp->flags = 0x10;  // ACK
+  tcp->flags = TcpHeader::Flag::kAck;
 
   tcp->checksum = bess::utils::CalculateIpv4TcpChecksum(*tcp, src_ip, dst_ip,
                                                         sizeof(*tcp) + len);
@@ -262,7 +262,7 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
       // If FIN is observed, no need to reconstruct this flow
       // NOTE: if FIN is lost on its way to destination, this will simply pass
       // the retransmitted packet
-      if (tcp->flags & TCP_FLAG_FIN) {
+      if (tcp->flags & TcpHeader::Flag::kFin) {
         flow_cache_.erase(it);
       }
     } else {

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -17,43 +17,39 @@
 
 using bess::utils::TcpFlowReconstruct;
 using bess::utils::Trie;
+using bess::utils::be16_t;
+using bess::utils::be32_t;
 
 // A helper class that defines a TCP flow
 class alignas(16) Flow {
  public:
-  union {
-    struct {
-      uint32_t src_ip;
-      uint32_t dst_ip;
-      uint16_t src_port;
-      uint16_t dst_port;
-    };
+  be32_t src_ip;
+  be32_t dst_ip;
+  be16_t src_port;
+  be16_t dst_port;
+  uint32_t padding;
 
-    struct {
-      uint64_t e1;
-      uint64_t e2;
-    };
-  };
+  Flow() : padding(0) {}
 
-  Flow() : e1(0), e2(0) {}
-
-  bool operator==(const Flow &other) const {
-    return e1 == other.e1 && e2 == other.e2;
-  }
+  bool operator==(const Flow &other) const { return *this == other; }
 };
+
+static_assert(sizeof(Flow) == 16, "Flow must be 16 bytes.");
 
 // Hash function for std::unordered_map
 struct FlowHash {
   std::size_t operator()(const Flow &f) const {
-    static_assert(sizeof(Flow) == 2 * sizeof(uint64_t),
-                  "Flow must be 16 bytes.");
-    const Flow *flow = reinterpret_cast<const Flow *>(&f);
+    const union {
+      Flow flow;
+      uint64_t u64[2];
+    } &bytes = {.flow = f};
+
     uint32_t init_val = 0;
 #if __SSE4_2__ && __x86_64
-    init_val = crc32c_sse42_u64(flow->e1, init_val);
-    init_val = crc32c_sse42_u64(flow->e2, init_val);
+    init_val = crc32c_sse42_u64(bytes.u64[0], init_val);
+    init_val = crc32c_sse42_u64(bytes.u64[1], init_val);
 #else
-    init_val = rte_hash_crc(flow, sizeof(Flow), init_val);
+    init_val = rte_hash_crc(&f, sizeof(Flow), init_val);
 #endif
     return init_val;
   }

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -41,18 +41,20 @@ static_assert(sizeof(Flow) == 16, "Flow must be 16 bytes.");
 // Hash function for std::unordered_map
 struct FlowHash {
   std::size_t operator()(const Flow &f) const {
+    uint32_t init_val = 0;
+
+#if __SSE4_2__ && __x86_64
     const union {
       Flow flow;
       uint64_t u64[2];
     } &bytes = {.flow = f};
 
-    uint32_t init_val = 0;
-#if __SSE4_2__ && __x86_64
     init_val = crc32c_sse42_u64(bytes.u64[0], init_val);
     init_val = crc32c_sse42_u64(bytes.u64[1], init_val);
 #else
     init_val = rte_hash_crc(&f, sizeof(Flow), init_val);
 #endif
+
     return init_val;
   }
 };

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -31,7 +31,9 @@ class alignas(16) Flow {
 
   Flow() : padding(0) {}
 
-  bool operator==(const Flow &other) const { return *this == other; }
+  bool operator==(const Flow &other) const {
+    return memcmp(this, &other, sizeof(*this)) == 0;
+  }
 };
 
 static_assert(sizeof(Flow) == 16, "Flow must be 16 bytes.");

--- a/core/modules/vlan_pop.cc
+++ b/core/modules/vlan_pop.cc
@@ -4,7 +4,7 @@
 
 void VLANPop::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::be16_t;
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
 
   int cnt = batch->cnt();
 
@@ -15,8 +15,8 @@ void VLANPop::ProcessBatch(bess::PacketBatch *batch) {
     __m128i eth = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
     be16_t tpid(be16_t::swap(_mm_extract_epi16(eth, 6)));
 
-    bool tagged = (tpid == be16_t(EthHeader::Type::kVlan)) ||
-                  (tpid == be16_t(EthHeader::Type::kQinQ));
+    bool tagged = (tpid == be16_t(Ethernet::Type::kVlan)) ||
+                  (tpid == be16_t(Ethernet::Type::kQinQ));
 
     if (tagged && pkt->adj(4)) {
       eth = _mm_slli_si128(eth, 4);

--- a/core/modules/vlan_pop.cc
+++ b/core/modules/vlan_pop.cc
@@ -1,26 +1,24 @@
 #include "vlan_pop.h"
 
-#include <rte_byteorder.h>
+#include "../utils/endian.h"
 
 void VLANPop::ProcessBatch(bess::PacketBatch *batch) {
+  using bess::utils::be16_t;
+
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
     char *old_head = pkt->head_data<char *>();
-    __m128i ethh;
-    uint16_t tpid;
-    int tagged;
 
-    ethh = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
-    tpid = _mm_extract_epi16(ethh, 6);
+    __m128i eth = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
+    be16_t tpid(be16_t::swap(_mm_extract_epi16(eth, 6)));
 
-    tagged = (tpid == rte_cpu_to_be_16(0x8100)) ||
-             (tpid == rte_cpu_to_be_16(0x88a8));
+    bool tagged = (tpid == be16_t(0x8100)) || (tpid == be16_t(0x88a8));
 
     if (tagged && pkt->adj(4)) {
-      ethh = _mm_slli_si128(ethh, 4);
-      _mm_storeu_si128(reinterpret_cast<__m128i *>(old_head), ethh);
+      eth = _mm_slli_si128(eth, 4);
+      _mm_storeu_si128(reinterpret_cast<__m128i *>(old_head), eth);
     }
   }
 

--- a/core/modules/vlan_pop.cc
+++ b/core/modules/vlan_pop.cc
@@ -1,9 +1,10 @@
 #include "vlan_pop.h"
 
-#include "../utils/endian.h"
+#include "../utils/ether.h"
 
 void VLANPop::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::be16_t;
+  using bess::utils::EthHeader;
 
   int cnt = batch->cnt();
 
@@ -14,7 +15,8 @@ void VLANPop::ProcessBatch(bess::PacketBatch *batch) {
     __m128i eth = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
     be16_t tpid(be16_t::swap(_mm_extract_epi16(eth, 6)));
 
-    bool tagged = (tpid == be16_t(0x8100)) || (tpid == be16_t(0x88a8));
+    bool tagged = (tpid == be16_t(EthHeader::Type::kVlan)) ||
+                  (tpid == be16_t(EthHeader::Type::kQinQ));
 
     if (tagged && pkt->adj(4)) {
       eth = _mm_slli_si128(eth, 4);

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -18,8 +18,8 @@ CommandResponse VLANPush::Init(const bess::pb::VLANPushArg &arg) {
 
 CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
   uint16_t tci = arg.tci();
-  vlan_tag_ = htonl((0x8100 << 16) | tci);
-  qinq_tag_ = htonl((0x88a8 << 16) | tci);
+  vlan_tag_ = be32_t((0x8100 << 16) | tci);
+  qinq_tag_ = be32_t((0x88a8 << 16) | tci);
   return CommandSuccess();
 }
 
@@ -27,8 +27,8 @@ CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
 void VLANPush::ProcessBatch(bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
-  uint32_t vlan_tag = vlan_tag_;
-  uint32_t qinq_tag = qinq_tag_;
+  be32_t vlan_tag = vlan_tag_;
+  be32_t qinq_tag = qinq_tag_;
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
@@ -43,8 +43,10 @@ void VLANPush::ProcessBatch(bess::PacketBatch *batch) {
       ethh = _mm_loadu_si128(reinterpret_cast<__m128i *>(new_head + 4));
       tpid = _mm_extract_epi16(ethh, 6);
 
-      ethh = _mm_insert_epi32(
-          ethh, (tpid == rte_cpu_to_be_16(0x8100)) ? qinq_tag : vlan_tag, 3);
+      ethh = _mm_insert_epi32(ethh, (tpid == rte_cpu_to_be_16(0x8100))
+                                        ? qinq_tag.raw_value()
+                                        : vlan_tag.raw_value(),
+                              3);
 
       _mm_storeu_si128(reinterpret_cast<__m128i *>(new_head), ethh);
 #else
@@ -61,11 +63,10 @@ void VLANPush::ProcessBatch(bess::PacketBatch *batch) {
 }
 
 std::string VLANPush::GetDesc() const {
-  uint32_t vlan_tag_cpu = ntohl(vlan_tag_);
+  uint32_t vlan_tag = vlan_tag_.value();
 
-  return bess::utils::Format(
-      "PCP=%u DEI=%u VID=%u", (vlan_tag_cpu >> 13) & 0x0007,
-      (vlan_tag_cpu >> 12) & 0x0001, vlan_tag_cpu & 0x0fff);
+  return bess::utils::Format("PCP=%u DEI=%u VID=%u", (vlan_tag >> 13) & 0x0007,
+                             (vlan_tag >> 12) & 0x0001, vlan_tag & 0x0fff);
 }
 
 ADD_MODULE(VLANPush, "vlan_push", "adds 802.1Q/802.11ad VLAN tag")

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -8,7 +8,7 @@
 
 using bess::utils::be16_t;
 using bess::utils::be32_t;
-using bess::utils::EthHeader;
+using bess::utils::Ethernet;
 
 const Commands VLANPush::cmds = {
     {"set_tci", "VLANPushArg", MODULE_CMD_FUNC(&VLANPush::CommandSetTci), 0},
@@ -20,8 +20,8 @@ CommandResponse VLANPush::Init(const bess::pb::VLANPushArg &arg) {
 
 CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
   uint16_t tci = arg.tci();
-  vlan_tag_ = be32_t((EthHeader::Type::kVlan << 16) | tci);
-  qinq_tag_ = be32_t((EthHeader::Type::kQinQ << 16) | tci);
+  vlan_tag_ = be32_t((Ethernet::Type::kVlan << 16) | tci);
+  qinq_tag_ = be32_t((Ethernet::Type::kQinQ << 16) | tci);
   return CommandSuccess();
 }
 
@@ -44,7 +44,7 @@ void VLANPush::ProcessBatch(bess::PacketBatch *batch) {
       ethh = _mm_loadu_si128(reinterpret_cast<__m128i *>(new_head + 4));
       be16_t tpid(be16_t::swap(_mm_extract_epi16(ethh, 6)));
 
-      ethh = _mm_insert_epi32(ethh, (tpid.value() == EthHeader::Type::kVlan)
+      ethh = _mm_insert_epi32(ethh, (tpid.value() == Ethernet::Type::kVlan)
                                         ? qinq_tag.raw_value()
                                         : vlan_tag.raw_value(),
                               3);
@@ -55,7 +55,7 @@ void VLANPush::ProcessBatch(bess::PacketBatch *batch) {
       memmove(new_head, new_head + 4, 12);
 
       *(be32_t *)(new_head + 12) =
-          (tpid.value() == EthHeader::Type::kVlan) ? qinq_tag : vlan_tag;
+          (tpid.value() == Ethernet::Type::kVlan) ? qinq_tag : vlan_tag;
 #endif
     }
   }

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -3,6 +3,9 @@
 
 #include "../module.h"
 #include "../module_msg.pb.h"
+#include "../utils/endian.h"
+
+using bess::utils::be32_t;
 
 class VLANPush final : public Module {
  public:
@@ -19,9 +22,8 @@ class VLANPush final : public Module {
   CommandResponse CommandSetTci(const bess::pb::VLANPushArg &arg);
 
  private:
-  /* network order */
-  uint32_t vlan_tag_;
-  uint32_t qinq_tag_;
+  be32_t vlan_tag_;
+  be32_t qinq_tag_;
 };
 
 #endif  // BESS_MODULES_VLANPUSH_H_

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -5,8 +5,6 @@
 #include "../module_msg.pb.h"
 #include "../utils/endian.h"
 
-using bess::utils::be32_t;
-
 class VLANPush final : public Module {
  public:
   static const Commands cmds;
@@ -22,8 +20,8 @@ class VLANPush final : public Module {
   CommandResponse CommandSetTci(const bess::pb::VLANPushArg &arg);
 
  private:
-  be32_t vlan_tag_;
-  be32_t qinq_tag_;
+  bess::utils::be32_t vlan_tag_;
+  bess::utils::be32_t qinq_tag_;
 };
 
 #endif  // BESS_MODULES_VLANPUSH_H_

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -3,6 +3,7 @@
 
 #include "../module.h"
 #include "../module_msg.pb.h"
+
 #include "../utils/endian.h"
 
 class VLANPush final : public Module {

--- a/core/modules/vlan_split.cc
+++ b/core/modules/vlan_split.cc
@@ -1,30 +1,28 @@
 #include "vlan_split.h"
 
-#include <rte_byteorder.h>
+#include "../utils/endian.h"
 
 void VLANSplit::ProcessBatch(bess::PacketBatch *batch) {
+  using bess::utils::be16_t;
+
   gate_idx_t vid[bess::PacketBatch::kMaxBurst];
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
     char *old_head = pkt->head_data<char *>();
-    __m128i ethh;
-    uint16_t tpid;
-    uint16_t tci;
-    int tagged;
+    __m128i eth;
 
-    ethh = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
-    tpid = _mm_extract_epi16(ethh, 6);
+    eth = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
+    be16_t tpid(be16_t::swap(_mm_extract_epi16(eth, 6)));
 
-    tagged = (tpid == rte_cpu_to_be_16(0x8100)) ||
-             (tpid == rte_cpu_to_be_16(0x88a8));
+    bool tagged = (tpid == be16_t(0x8100)) || (tpid == be16_t(0x88a8));
 
     if (tagged && pkt->adj(4)) {
-      tci = _mm_extract_epi16(ethh, 7);
-      ethh = _mm_slli_si128(ethh, 4);
-      _mm_storeu_si128(reinterpret_cast<__m128i *>(old_head), ethh);
-      vid[i] = rte_be_to_cpu_16(tci) & 0x0fff;
+      be16_t tci(be16_t::swap(_mm_extract_epi16(eth, 7)));
+      eth = _mm_slli_si128(eth, 4);
+      _mm_storeu_si128(reinterpret_cast<__m128i *>(old_head), eth);
+      vid[i] = tci.value() & 0x0fff;
     } else {
       vid[i] = 0; /* untagged packets go to gate 0 */
     }

--- a/core/modules/vlan_split.cc
+++ b/core/modules/vlan_split.cc
@@ -4,7 +4,7 @@
 
 void VLANSplit::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::be16_t;
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
 
   gate_idx_t vid[bess::PacketBatch::kMaxBurst];
   int cnt = batch->cnt();
@@ -17,8 +17,8 @@ void VLANSplit::ProcessBatch(bess::PacketBatch *batch) {
     eth = _mm_loadu_si128(reinterpret_cast<__m128i *>(old_head));
     be16_t tpid(be16_t::swap(_mm_extract_epi16(eth, 6)));
 
-    bool tagged = (tpid == be16_t(EthHeader::Type::kVlan)) ||
-                  (tpid == be16_t(EthHeader::Type::kQinQ));
+    bool tagged = (tpid == be16_t(Ethernet::Type::kVlan)) ||
+                  (tpid == be16_t(Ethernet::Type::kQinQ));
 
     if (tagged && pkt->adj(4)) {
       be16_t tci(be16_t::swap(_mm_extract_epi16(eth, 7)));

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -29,7 +29,7 @@ void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::be32_t;
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
-  using bess::utils::UdpHeader;
+  using bess::utils::Udp;
   using bess::utils::VxlanHeader;
 
   int cnt = batch->cnt();
@@ -39,7 +39,7 @@ void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
-    UdpHeader *udp = reinterpret_cast<UdpHeader *>(
+    Udp *udp = reinterpret_cast<Udp *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);
     VxlanHeader *vh = reinterpret_cast<VxlanHeader *>(udp + 1);
 

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -30,7 +30,7 @@ void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Udp;
-  using bess::utils::VxlanHeader;
+  using bess::utils::Vxlan;
 
   int cnt = batch->cnt();
 
@@ -39,9 +39,9 @@ void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
-    Udp *udp = reinterpret_cast<Udp *>(
-        reinterpret_cast<uint8_t *>(ip) + ip_bytes);
-    VxlanHeader *vh = reinterpret_cast<VxlanHeader *>(udp + 1);
+    Udp *udp =
+        reinterpret_cast<Udp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
+    Vxlan *vh = reinterpret_cast<Vxlan *>(udp + 1);
 
     set_attr<be32_t>(this, ATTR_W_TUN_IP_SRC, pkt, ip->src);
     set_attr<be32_t>(this, ATTR_W_TUN_IP_DST, pkt, ip->dst);

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -28,7 +28,7 @@ CommandResponse VXLANDecap::Init(
 void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::be32_t;
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
   using bess::utils::VxlanHeader;
 
@@ -37,7 +37,7 @@ void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
     EthHeader *eth = pkt->head_data<EthHeader *>();
-    Ipv4Header *ip = reinterpret_cast<Ipv4Header *>(eth + 1);
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
     UdpHeader *udp = reinterpret_cast<UdpHeader *>(
         reinterpret_cast<uint8_t *>(ip) + ip_bytes);

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -27,7 +27,7 @@ CommandResponse VXLANDecap::Init(
 
 void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::be32_t;
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
   using bess::utils::VxlanHeader;
@@ -36,7 +36,7 @@ void VXLANDecap::ProcessBatch(bess::PacketBatch *batch) {
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
-    EthHeader *eth = pkt->head_data<EthHeader *>();
+    Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = ip->header_length << 2;
     UdpHeader *udp = reinterpret_cast<UdpHeader *>(

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -19,6 +19,10 @@ enum {
   ATTR_W_IP_PROTO,
 };
 
+// NOTE: UDP port 4789 is the official port number assigned by IANA,
+// but some systems (including Linux) uses 8472 for legacy reasons.
+const uint16_t VXLANEncap::kDefaultDstPort = 4789;
+
 CommandResponse VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
   auto dstport = arg.dstport();
   if (dstport == 0) {

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -47,7 +47,7 @@ CommandResponse VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
 }
 
 void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
-  using bess::utils::EthHeader;
+  using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
   using bess::utils::VxlanHeader;
@@ -61,13 +61,13 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
     be32_t ip_dst = get_attr<be32_t>(this, ATTR_R_TUN_IP_DST, pkt);
     be32_t vni = get_attr<be32_t>(this, ATTR_R_TUN_ID, pkt);
 
-    EthHeader *inner_eth;
+    Ethernet *inner_eth;
     UdpHeader *udp;
     VxlanHeader *vh;
 
     size_t inner_frame_len = pkt->total_len() + sizeof(*udp);
 
-    inner_eth = pkt->head_data<EthHeader *>();
+    inner_eth = pkt->head_data<Ethernet *>();
     udp = static_cast<UdpHeader *>(pkt->prepend(sizeof(*udp) + sizeof(*vh)));
     if (unlikely(!udp)) {
       continue;
@@ -78,7 +78,7 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
     vh->vx_vni = vni << 8;
 
     udp->src_port = be16_t(
-        rte_hash_crc(inner_eth, sizeof(EthHeader::Address) * 2, UINT32_MAX) |
+        rte_hash_crc(inner_eth, sizeof(Ethernet::Address) * 2, UINT32_MAX) |
         0xf000);
     udp->dst_port = dstport_;
     udp->length = be16_t(sizeof(*udp) + inner_frame_len);

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -50,7 +50,7 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Udp;
-  using bess::utils::VxlanHeader;
+  using bess::utils::Vxlan;
 
   int cnt = batch->cnt();
 
@@ -63,7 +63,7 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
 
     Ethernet *inner_eth;
     Udp *udp;
-    VxlanHeader *vh;
+    Vxlan *vh;
 
     size_t inner_frame_len = pkt->total_len() + sizeof(*udp);
 
@@ -73,7 +73,7 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
       continue;
     }
 
-    vh = reinterpret_cast<VxlanHeader *>(udp + 1);
+    vh = reinterpret_cast<Vxlan *>(udp + 1);
     vh->vx_flags = be32_t(0x08000000);
     vh->vx_vni = vni << 8;
 

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -86,7 +86,7 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
 
     set_attr<be32_t>(this, ATTR_W_IP_SRC, pkt, ip_src);
     set_attr<be32_t>(this, ATTR_W_IP_DST, pkt, ip_dst);
-    set_attr<uint8_t>(this, ATTR_W_IP_PROTO, pkt, 17);
+    set_attr<uint8_t>(this, ATTR_W_IP_PROTO, pkt, Ipv4Header::Proto::kUdp);
   }
 
   RunNextModule(batch);

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -48,7 +48,7 @@ CommandResponse VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
 
 void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::EthHeader;
-  using bess::utils::Ipv4Header;
+  using bess::utils::Ipv4;
   using bess::utils::UdpHeader;
   using bess::utils::VxlanHeader;
 
@@ -86,7 +86,7 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
 
     set_attr<be32_t>(this, ATTR_W_IP_SRC, pkt, ip_src);
     set_attr<be32_t>(this, ATTR_W_IP_DST, pkt, ip_dst);
-    set_attr<uint8_t>(this, ATTR_W_IP_PROTO, pkt, Ipv4Header::Proto::kUdp);
+    set_attr<uint8_t>(this, ATTR_W_IP_PROTO, pkt, Ipv4::Proto::kUdp);
   }
 
   RunNextModule(batch);

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -49,7 +49,7 @@ CommandResponse VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
 void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
-  using bess::utils::UdpHeader;
+  using bess::utils::Udp;
   using bess::utils::VxlanHeader;
 
   int cnt = batch->cnt();
@@ -62,13 +62,13 @@ void VXLANEncap::ProcessBatch(bess::PacketBatch *batch) {
     be32_t vni = get_attr<be32_t>(this, ATTR_R_TUN_ID, pkt);
 
     Ethernet *inner_eth;
-    UdpHeader *udp;
+    Udp *udp;
     VxlanHeader *vh;
 
     size_t inner_frame_len = pkt->total_len() + sizeof(*udp);
 
     inner_eth = pkt->head_data<Ethernet *>();
-    udp = static_cast<UdpHeader *>(pkt->prepend(sizeof(*udp) + sizeof(*vh)));
+    udp = static_cast<Udp *>(pkt->prepend(sizeof(*udp) + sizeof(*vh)));
     if (unlikely(!udp)) {
       continue;
     }

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -4,10 +4,12 @@
 #include "../module.h"
 #include "../module_msg.pb.h"
 
-using bess::metadata::Attribute;
+#include "../utils/endian.h"
 
 class VXLANEncap final : public Module {
  public:
+  static const uint16_t kDefaultDstPort = 4789;
+
   VXLANEncap() : Module(), dstport_() {}
 
   CommandResponse Init(const bess::pb::VXLANEncapArg &arg);
@@ -15,7 +17,7 @@ class VXLANEncap final : public Module {
   void ProcessBatch(bess::PacketBatch *batch) override;
 
  private:
-  uint16_t dstport_;
+  bess::utils::be16_t dstport_;
 };
 
 #endif  // BESS_MODULES_VXLANENCAP_H_

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -8,7 +8,7 @@
 
 class VXLANEncap final : public Module {
  public:
-  static const uint16_t kDefaultDstPort = 4789;
+  static const uint16_t kDefaultDstPort;
 
   VXLANEncap() : Module(), dstport_() {}
 

--- a/core/packet.h
+++ b/core/packet.h
@@ -88,7 +88,8 @@ class alignas(64) Packet {
 
   template <typename T = void *>
   T head_data(uint16_t offset = 0) {
-    return const_cast<T>(static_cast<const Packet &>(*this).head_data<T>(offset));
+    return const_cast<T>(
+        static_cast<const Packet &>(*this).head_data<T>(offset));
   }
 
   template <typename T = char *>
@@ -97,7 +98,7 @@ class alignas(64) Packet {
   }
 
   template <typename T = char *>
-  T metadata() {
+  T metadata() const {
     return reinterpret_cast<T>(metadata_);
   }
 
@@ -213,9 +214,7 @@ class alignas(64) Packet {
     return offset + offsetof(Packet, metadata_) - offsetof(Packet, headroom_);
   }
 
-  static Packet *Alloc() {
-    return __packet_alloc();
-  }
+  static Packet *Alloc() { return __packet_alloc(); }
 
   // cnt must be [0, PacketBatch::kMaxBurst]
   static inline size_t Alloc(Packet **pkts, size_t cnt, uint16_t len);

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -5,6 +5,7 @@
 #define BESS_UTILS_CHECKSUM_H_
 
 #include <x86intrin.h>
+#include <arpa/inet.h>
 
 #include <glog/logging.h>
 
@@ -79,7 +80,8 @@ static inline uint32_t CalculateSum(const void *buf, size_t len) {
   // Repeat 64-bit one's complement sum (at sum64) including carrys
   // 8 additions in a loop
   while (len >= sizeof(uint64_t) * 8) {
-    asm("addq %[u0], %[sum] \n\t"
+    asm(
+        "addq %[u0], %[sum] \n\t"
         "adcq %[u1], %[sum] \n\t"
         "adcq %[u2], %[sum] \n\t"
         "adcq %[u3], %[sum] \n\t"
@@ -99,7 +101,8 @@ static inline uint32_t CalculateSum(const void *buf, size_t len) {
   while (len >= sizeof(uint64_t) * 2) {
     // Repeat 64-bit one's complement sum (at sum64) including carrys
     // 2 additions in a loop
-    asm("addq %[u0], %[sum] \n\t"
+    asm(
+        "addq %[u0], %[sum] \n\t"
         "adcq %[u1], %[sum] \n\t"
         "adcq $0, %[sum]"
         : [sum] "+r"(sum64)
@@ -113,19 +116,20 @@ static inline uint32_t CalculateSum(const void *buf, size_t len) {
   sum64 = (sum64 >> 32) + (sum64 & 0xFFFFFFFF);
 #else
   // Use stantard C language for 32 bit or other non-Intel
-  typedef union [[gnu::may_alias]] {
-     uint32_t u64;
-     uint16_t u16[4];
-  } u16_64;
+  typedef union[[gnu::may_alias]] {
+    uint32_t u64;
+    uint16_t u16[4];
+  }
+  u16_64;
   const u16_64 *ubuf64;
-  ubuf64 = reinterpret_cast<const u16_64  *>(buf64);
+  ubuf64 = reinterpret_cast<const u16_64 *>(buf64);
   while (len >= sizeof(uint64_t)) {
-     sum64 += ubuf64->u16[0];
-     sum64 += ubuf64->u16[1];
-     sum64 += ubuf64->u16[2];
-     sum64 += ubuf64->u16[3];
-     len -= sizeof(uint64_t);
-     ubuf64++;
+    sum64 += ubuf64->u16[0];
+    sum64 += ubuf64->u16[1];
+    sum64 += ubuf64->u16[2];
+    sum64 += ubuf64->u16[3];
+    len -= sizeof(uint64_t);
+    ubuf64++;
   }
   buf64 = reinterpret_cast<const uint64_t *>(ubuf64);
 #endif
@@ -184,7 +188,8 @@ static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
   // Calculate internet checksum, the optimized way is
   // 1. get 32-bit one's complement sum including carrys
   // 2. reduce to 16-bit unsigned integer
-  asm("addl %[u1], %[sum]   \n\t"
+  asm(
+      "addl %[u1], %[sum]   \n\t"
       "adcl %[u2], %[sum]   \n\t"
       "adcl %[u3], %[sum]   \n\t"
       "adcl %[u4], %[sum]   \n\t"
@@ -207,7 +212,8 @@ static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
   // 1. get 32-bit one's complement sum including carrys
   // 2. reduce to 16-bit unsigned integers
   // 3. negate
-  asm("addl %[u1], %[sum]    \n\t"
+  asm(
+      "addl %[u1], %[sum]    \n\t"
       "adcl %[u2], %[sum]    \n\t"
       "adcl %[u3], %[sum]    \n\t"
       "adcl %[u4], %[sum]    \n\t"
@@ -223,8 +229,8 @@ static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
 // Return true if the TCP checksum is true with the TCP header and
 // pseudo header info - source ip, destiniation ip, and tcp byte stream length
 // tcp_len: TCP header + payload in bytes
-static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, uint32_t src_ip,
-                                         uint32_t dst_ip, uint16_t tcp_len) {
+static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, be32_t src_ip,
+                                         be32_t dst_ip, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
 
   // tcp options and data
@@ -232,7 +238,8 @@ static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, uint32_t src_ip,
   uint32_t len = static_cast<uint32_t>(htons(tcp_len));
 
   // Calculate the checksum of TCP pseudo header
-  asm("addl %[u0], %[sum]      \n\t"
+  asm(
+      "addl %[u0], %[sum]      \n\t"
       "adcl %[u1], %[sum]      \n\t"
       "adcl %[u2], %[sum]      \n\t"
       "adcl %[u3], %[sum]      \n\t"
@@ -244,8 +251,8 @@ static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, uint32_t src_ip,
       "adcl $0, %[sum]         \n\t"
       : [sum] "+r"(sum)
       : [u0] "m"(buf32[0]), [u1] "m"(buf32[1]), [u2] "m"(buf32[2]),
-        [u3] "m"(buf32[3]), [u4] "m"(buf32[4]), [src] "r"(src_ip),
-        [dst] "r"(dst_ip), [len] "r"(len));
+        [u3] "m"(buf32[3]), [u4] "m"(buf32[4]), [src] "r"(src_ip.raw_value()),
+        [dst] "r"(dst_ip.raw_value()), [len] "r"(len));
 
   return FoldChecksum(sum) == 0;
 }
@@ -254,7 +261,7 @@ static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, uint32_t src_ip,
 static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
                                          const TcpHeader &tcph) {
   return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
-                               ntohs(iph.length) - (iph.header_length << 2));
+                               iph.length.value() - (iph.header_length << 2));
 }
 
 // Return TCP (on IPv4) checksum of the tcp header 'tcph' with pseudo header
@@ -264,7 +271,7 @@ static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
 // It skips the checksum field into the calculation
 // It does not set the checksum field in TCP header
 static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
-                                                uint32_t src, uint32_t dst,
+                                                be32_t src, be32_t dst,
                                                 uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
   // tcp options and data
@@ -272,7 +279,8 @@ static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
   uint32_t len = static_cast<uint32_t>(htons(tcp_len));
 
   // Calculate the checksum of TCP pseudo header
-  asm("addl %[u0], %[sum]      \n\t"
+  asm(
+      "addl %[u0], %[sum]      \n\t"
       "adcl %[u1], %[sum]      \n\t"
       "adcl %[u2], %[sum]      \n\t"
       "adcl %[u3], %[sum]      \n\t"
@@ -286,7 +294,7 @@ static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
       : [u0] "m"(buf32[0]), [u1] "m"(buf32[1]), [u2] "m"(buf32[2]),
         [u3] "m"(buf32[3]),
         [u4] "g"(buf32[4] >> 16),  // skip checksum field
-        [src] "r"(src), [dst] "r"(dst), [len] "r"(len));
+        [src] "r"(src.raw_value()), [dst] "r"(dst.raw_value()), [len] "r"(len));
 
   return FoldChecksum(sum);
 }
@@ -294,8 +302,8 @@ static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
 // Return true if the TCP (on IPv4) checksum is true
 static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4Header &iph,
                                                 const TcpHeader &tcph) {
-  return CalculateIpv4TcpChecksum(tcph, iph.src, iph.dst,
-                                  ntohs(iph.length) - (iph.header_length << 2));
+  return CalculateIpv4TcpChecksum(
+      tcph, iph.src, iph.dst, iph.length.value() - (iph.header_length << 2));
 }
 
 // Incremental checksum update

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -176,7 +176,7 @@ static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
 }
 
 // Return true if the IP checksum is true
-static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
+static inline bool VerifyIpv4NoOptChecksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   uint32_t sum = buf32[0];
 
@@ -198,7 +198,7 @@ static inline bool VerifyIpv4NoOptChecksum(const Ipv4Header &iph) {
 // Return IP checksum of the ip header 'iph' without ip options
 // It skips the checksum field into the calculation
 // It does not set the checksum field in ip header
-static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4Header &iph) {
+static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   uint32_t sum = buf32[0];
 
@@ -250,7 +250,7 @@ static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, be32_t src_ip,
 }
 
 // Return true if the TCP checksum is true
-static inline bool VerifyIpv4TcpChecksum(const Ipv4Header &iph,
+static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph,
                                          const TcpHeader &tcph) {
   return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
                                iph.length.value() - (iph.header_length << 2));
@@ -291,7 +291,7 @@ static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
 }
 
 // Return true if the TCP (on IPv4) checksum is true
-static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4Header &iph,
+static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4 &iph,
                                                 const TcpHeader &tcph) {
   return CalculateIpv4TcpChecksum(
       tcph, iph.src, iph.dst, iph.length.value() - (iph.header_length << 2));

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -222,7 +222,7 @@ static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4 &iph) {
 // Return true if the TCP checksum is true with the TCP header and
 // pseudo header info - source ip, destiniation ip, and tcp byte stream length
 // tcp_len: TCP header + payload in bytes
-static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, be32_t src_ip,
+static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
                                          be32_t dst_ip, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
 
@@ -251,7 +251,7 @@ static inline bool VerifyIpv4TcpChecksum(const TcpHeader &tcph, be32_t src_ip,
 
 // Return true if the TCP checksum is true
 static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph,
-                                         const TcpHeader &tcph) {
+                                         const Tcp &tcph) {
   return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
                                iph.length.value() - (iph.header_length << 2));
 }
@@ -262,7 +262,7 @@ static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph,
 // 'tcp_len' is in host-order, and the others are in network-order
 // It skips the checksum field into the calculation
 // It does not set the checksum field in TCP header
-static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
+static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph,
                                                 be32_t src, be32_t dst,
                                                 uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
@@ -292,7 +292,7 @@ static inline uint16_t CalculateIpv4TcpChecksum(const TcpHeader &tcph,
 
 // Return true if the TCP (on IPv4) checksum is true
 static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4 &iph,
-                                                const TcpHeader &tcph) {
+                                                const Tcp &tcph) {
   return CalculateIpv4TcpChecksum(
       tcph, iph.src, iph.dst, iph.length.value() - (iph.header_length << 2));
 }

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -250,8 +250,7 @@ static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
 }
 
 // Return true if the TCP checksum is true
-static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph,
-                                         const Tcp &tcph) {
+static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph, const Tcp &tcph) {
   return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
                                iph.length.value() - (iph.header_length << 2));
 }
@@ -262,9 +261,8 @@ static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph,
 // 'tcp_len' is in host-order, and the others are in network-order
 // It skips the checksum field into the calculation
 // It does not set the checksum field in TCP header
-static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph,
-                                                be32_t src, be32_t dst,
-                                                uint16_t tcp_len) {
+static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph, be32_t src,
+                                                be32_t dst, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
   // tcp options and data
   uint32_t sum = CalculateSum(buf32 + 5, tcp_len - sizeof(tcph));

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -81,8 +81,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
 (benchmark::State &state) {
   char pkt[20] = {0};  // ipv4 header w/o options
 
-  bess::utils::Ipv4 *ip =
-      reinterpret_cast<bess::utils::Ipv4 *>(pkt);
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -109,8 +108,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
 (benchmark::State &state) {
   char pkt[20] = {0};  // ipv4 header w/o options
 
-  bess::utils::Ipv4 *ip =
-      reinterpret_cast<bess::utils::Ipv4 *>(pkt);
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -144,10 +142,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumDpdk)
   while (state.KeepRunning()) {
     pkt = get_buffer(buf_len);
 
-    bess::utils::Ipv4 *ip =
-        reinterpret_cast<bess::utils::Ipv4 *>(pkt);
-    bess::utils::Tcp *tcp =
-        reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+    bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
+    bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
     ip->header_length = 5;
     ip->length = be16_t(buf_len);
@@ -172,10 +168,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumBess)
   while (state.KeepRunning()) {
     pkt = get_buffer(buf_len);
 
-    bess::utils::Ipv4 *ip =
-        reinterpret_cast<bess::utils::Ipv4 *>(pkt);
-    bess::utils::Tcp *tcp =
-        reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+    bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
+    bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
     ip->header_length = 5;
     ip->length = be16_t(buf_len);
@@ -205,8 +199,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::Tcp *tcp =
-      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+  bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);
@@ -236,8 +229,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::Tcp *tcp =
-      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+  bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);
@@ -270,8 +262,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::Tcp *tcp =
-      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+  bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);
@@ -300,8 +291,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::Tcp *tcp =
-      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+  bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -204,7 +204,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
-      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
 
@@ -235,7 +235,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
-      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
 
@@ -269,7 +269,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
-      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
 
@@ -299,7 +299,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
-      reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
+      reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
 

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -146,8 +146,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumDpdk)
 
     bess::utils::Ipv4 *ip =
         reinterpret_cast<bess::utils::Ipv4 *>(pkt);
-    bess::utils::TcpHeader *tcp =
-        reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+    bess::utils::Tcp *tcp =
+        reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
     ip->header_length = 5;
     ip->length = be16_t(buf_len);
@@ -174,8 +174,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumBess)
 
     bess::utils::Ipv4 *ip =
         reinterpret_cast<bess::utils::Ipv4 *>(pkt);
-    bess::utils::TcpHeader *tcp =
-        reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+    bess::utils::Tcp *tcp =
+        reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
     ip->header_length = 5;
     ip->length = be16_t(buf_len);
@@ -205,8 +205,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::TcpHeader *tcp =
-      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+  bess::utils::Tcp *tcp =
+      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);
@@ -236,8 +236,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::TcpHeader *tcp =
-      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+  bess::utils::Tcp *tcp =
+      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);
@@ -270,8 +270,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::TcpHeader *tcp =
-      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+  bess::utils::Tcp *tcp =
+      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);
@@ -300,8 +300,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(Ethernet));
-  bess::utils::TcpHeader *tcp =
-      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+  bess::utils::Tcp *tcp =
+      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->header_length = 5;
   ip->length = be16_t(60);

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -81,8 +81,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
 (benchmark::State &state) {
   char pkt[20] = {0};  // ipv4 header w/o options
 
-  bess::utils::Ipv4Header *ip =
-      reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+  bess::utils::Ipv4 *ip =
+      reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -109,8 +109,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
 (benchmark::State &state) {
   char pkt[20] = {0};  // ipv4 header w/o options
 
-  bess::utils::Ipv4Header *ip =
-      reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+  bess::utils::Ipv4 *ip =
+      reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -144,8 +144,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumDpdk)
   while (state.KeepRunning()) {
     pkt = get_buffer(buf_len);
 
-    bess::utils::Ipv4Header *ip =
-        reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+    bess::utils::Ipv4 *ip =
+        reinterpret_cast<bess::utils::Ipv4 *>(pkt);
     bess::utils::TcpHeader *tcp =
         reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
 
@@ -172,8 +172,8 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmTcpChecksumBess)
   while (state.KeepRunning()) {
     pkt = get_buffer(buf_len);
 
-    bess::utils::Ipv4Header *ip =
-        reinterpret_cast<bess::utils::Ipv4Header *>(pkt);
+    bess::utils::Ipv4 *ip =
+        reinterpret_cast<bess::utils::Ipv4 *>(pkt);
     bess::utils::TcpHeader *tcp =
         reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
 
@@ -203,7 +203,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate16)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
-  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
@@ -234,7 +234,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIncrementalUpdate32)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
-  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
@@ -268,7 +268,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateDpdk)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
-  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
@@ -298,7 +298,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmSrcIpPortUpdateBess)
 (benchmark::State &state) {
   void *pkt = get_buffer(60);  // min ethernet pkt size except FCS
 
-  bess::utils::Ipv4Header *ip = reinterpret_cast<bess::utils::Ipv4Header *>(
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(
       reinterpret_cast<uint8_t *>(pkt) + sizeof(EthHeader));
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -4,6 +4,7 @@
 #include <rte_ip.h>
 
 #include <benchmark/benchmark.h>
+#include <glog/logging.h>
 
 #include "ether.h"
 #include "random.h"

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -107,8 +107,8 @@ TEST(ChecksumTest, TcpChecksum) {
   bess::utils::Ipv4 *ip =
       reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
-  bess::utils::TcpHeader *tcp =
-      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+  bess::utils::Tcp *tcp =
+      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -231,8 +231,8 @@ TEST(ChecksumTest, IncrementalUpdateSrcIpPort) {
   bess::utils::Ipv4 *ip =
       reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
-  bess::utils::TcpHeader *tcp =
-      reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
+  bess::utils::Tcp *tcp =
+      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->version = 4;
   ip->header_length = 5;

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -56,8 +56,7 @@ TEST(ChecksumTest, GenericChecksum) {
 TEST(ChecksumTest, Ipv4NoOptChecksum) {
   char buf[1514] = {0};  // ipv4 header w/o options
 
-  bess::utils::Ipv4 *ip =
-      reinterpret_cast<bess::utils::Ipv4 *>(buf);
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -104,11 +103,9 @@ TEST(ChecksumTest, Ipv4NoOptChecksum) {
 TEST(ChecksumTest, TcpChecksum) {
   char buf[1514] = {0};  // ipv4 header + tcp header
 
-  bess::utils::Ipv4 *ip =
-      reinterpret_cast<bess::utils::Ipv4 *>(buf);
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
-  bess::utils::Tcp *tcp =
-      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+  bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -228,11 +225,9 @@ TEST(ChecksumTest, IncrementalUpdateChecksum32) {
 TEST(ChecksumTest, IncrementalUpdateSrcIpPort) {
   char buf[1514] = {0};
 
-  bess::utils::Ipv4 *ip =
-      reinterpret_cast<bess::utils::Ipv4 *>(buf);
+  bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
-  bess::utils::Tcp *tcp =
-      reinterpret_cast<bess::utils::Tcp *>(ip + 1);
+  bess::utils::Tcp *tcp = reinterpret_cast<bess::utils::Tcp *>(ip + 1);
 
   ip->version = 4;
   ip->header_length = 5;

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -56,8 +56,8 @@ TEST(ChecksumTest, GenericChecksum) {
 TEST(ChecksumTest, Ipv4NoOptChecksum) {
   char buf[1514] = {0};  // ipv4 header w/o options
 
-  bess::utils::Ipv4Header *ip =
-      reinterpret_cast<bess::utils::Ipv4Header *>(buf);
+  bess::utils::Ipv4 *ip =
+      reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
   ip->version = 4;
   ip->header_length = 5;
@@ -104,8 +104,8 @@ TEST(ChecksumTest, Ipv4NoOptChecksum) {
 TEST(ChecksumTest, TcpChecksum) {
   char buf[1514] = {0};  // ipv4 header + tcp header
 
-  bess::utils::Ipv4Header *ip =
-      reinterpret_cast<bess::utils::Ipv4Header *>(buf);
+  bess::utils::Ipv4 *ip =
+      reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);
@@ -228,8 +228,8 @@ TEST(ChecksumTest, IncrementalUpdateChecksum32) {
 TEST(ChecksumTest, IncrementalUpdateSrcIpPort) {
   char buf[1514] = {0};
 
-  bess::utils::Ipv4Header *ip =
-      reinterpret_cast<bess::utils::Ipv4Header *>(buf);
+  bess::utils::Ipv4 *ip =
+      reinterpret_cast<bess::utils::Ipv4 *>(buf);
 
   bess::utils::TcpHeader *tcp =
       reinterpret_cast<bess::utils::TcpHeader *>(ip + 1);

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -61,43 +61,47 @@ class[[gnu::packed]] BigEndian final : public EndianBase<T> {
     return is_be_system() ? data_ : EndianBase<T>::swap(data_);
   }
 
-  constexpr T raw_value() { return data_; }
+  constexpr T raw_value() const { return data_; }
 
-  constexpr BigEndian<T> operator~() { return BigEndian(~(this->value())); }
+  constexpr BigEndian<T> operator~() const {
+    return BigEndian(~(this->value()));
+  }
 
   // While this swap(swap(a) & swap(b)) looks inefficient, gcc 4.9+ will
   // correctly optimize the code.
-  constexpr BigEndian<T> operator&(const BigEndian<T> &o) {
+  constexpr BigEndian<T> operator&(const BigEndian<T> &o) const {
     return BigEndian(this->value() & o.value());
   }
 
-  constexpr BigEndian<T> operator|(const BigEndian<T> &o) {
+  constexpr BigEndian<T> operator|(const BigEndian<T> &o) const {
     return BigEndian(this->value() | o.value());
   }
 
-  constexpr BigEndian<T> operator^(const BigEndian<T> &o) {
+  constexpr BigEndian<T> operator^(const BigEndian<T> &o) const {
     return BigEndian(this->value() ^ o.value());
   }
 
-  constexpr BigEndian<T> operator+(const BigEndian<T> &o) {
+  constexpr BigEndian<T> operator+(const BigEndian<T> &o) const {
     return BigEndian(this->value() + o.value());
   }
 
-  constexpr BigEndian<T> operator-(const BigEndian<T> &o) {
+  constexpr BigEndian<T> operator-(const BigEndian<T> &o) const {
     return BigEndian(this->value() - o.value());
   }
 
-  constexpr BigEndian<T> operator<<(unsigned int shift) {
+  constexpr BigEndian<T> operator<<(unsigned int shift) const {
     return BigEndian(this->value() << shift);
   }
 
-  constexpr BigEndian<T> operator>>(unsigned int shift) {
+  constexpr BigEndian<T> operator>>(unsigned int shift) const {
     return BigEndian(this->value() >> shift);
   }
 
-  constexpr bool operator==(const BigEndian &o) { return data_ == o.data_; }
+  constexpr bool operator==(const BigEndian &o) const {
+    return data_ == o.data_;
+  }
 
-  constexpr bool operator!=(const BigEndian &o) { return !(*this == o); }
+  constexpr bool operator!=(const BigEndian &o) const { return !(*this == o); }
 
   friend std::ostream &operator<<(std::ostream &os, const BigEndian &be) {
     os << std::hex << std::showbase << be.value() << std::noshowbase

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
 
 namespace bess {
@@ -104,8 +105,8 @@ class[[gnu::packed]] BigEndian final : public EndianBase<T> {
   constexpr bool operator!=(const BigEndian &o) const { return !(*this == o); }
 
   friend std::ostream &operator<<(std::ostream &os, const BigEndian &be) {
-    os << std::hex << std::showbase << be.value() << std::noshowbase
-       << std::dec;
+    os << "0x" << std::hex << std::setw(sizeof(be) * 2) << std::setfill('0')
+       << be.value() << std::setfill(' ') << std::dec;
     return os;
   }
 

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -3,7 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <type_traits>
+#include <iostream>
 
 namespace bess {
 namespace utils {
@@ -42,26 +42,64 @@ class EndianBase<uint64_t> {
   }
 };
 
+// NOTE: DO NOT ALLOW implicit type-conversion, comparison, and operations
 template <typename T>
 class[[gnu::packed]] BigEndian final : public EndianBase<T> {
  public:
   BigEndian() = default;
-  BigEndian(const T &value) : value_(value) {}
+  BigEndian(const BigEndian<T> &o) = default;
 
-  constexpr T to_cpu() const {
-    return is_be_system() ? value_ : EndianBase<T>::swap(value_);
+  explicit constexpr BigEndian(const T &cpu_value)
+      : data_(is_be_system() ? cpu_value : EndianBase<T>::swap(cpu_value)) {}
+
+  constexpr T value() const {
+    return is_be_system() ? data_ : EndianBase<T>::swap(data_);
   }
 
-  static constexpr T to_cpu(const T &v) {
-    return is_be_system() ? v : EndianBase<T>::swap(v);
+  constexpr T raw_value() { return data_; }
+
+  constexpr BigEndian<T> operator~() { return BigEndian(~(this->value())); }
+
+  constexpr BigEndian<T> operator&(const BigEndian<T> &o) {
+    return BigEndian(this->value() & o.value());
   }
 
-  bool operator==(const BigEndian &rhs) const { return value_ == rhs.value_; }
+  constexpr BigEndian<T> operator|(const BigEndian<T> &o) {
+    return BigEndian(this->value() | o.value());
+  }
 
-  bool operator!=(const BigEndian &rhs) const { return value_ != rhs.value_; }
+  constexpr BigEndian<T> operator^(const BigEndian<T> &o) {
+    return BigEndian(this->value() ^ o.value());
+  }
+
+  constexpr BigEndian<T>
+  operator+(const BigEndian<T> &o) {
+    return BigEndian(this->value() + o.value());
+  }
+
+  constexpr BigEndian<T> operator-(const BigEndian<T> &o) {
+    return BigEndian(this->value() - o.value());
+  }
+
+  constexpr BigEndian<T> operator<<(unsigned int shift) {
+    return BigEndian(this->value() << shift);
+  }
+
+  constexpr BigEndian<T> operator>>(unsigned int shift) {
+    return BigEndian(this->value() >> shift);
+  }
+
+  constexpr bool operator==(const BigEndian &o) { return data_ == o.data_; }
+
+  constexpr bool operator!=(const BigEndian &o) { return !(*this == o); }
+
+  friend std::ostream &operator<<(std::ostream & os, const BigEndian &be) {
+    os << std::hex << be.value() << std::dec;
+    return os;
+  }
 
  protected:
-  T value_;
+  T data_;  // stored in big endian in memory
 };
 
 using be16_t = BigEndian<uint16_t>;
@@ -84,6 +122,9 @@ bool uint64_to_bin(void *ptr, uint64_t val, size_t size, bool big_endian);
 // Copy data from *ptr to *pval. Set "big_endian" if *ptr has big endian data
 bool bin_to_uint64(uint64_t *pval, const void *ptr, size_t size,
                    bool big_endian);
+
+// this is to make sure BigEndian has constexpr constructor and value()
+static_assert(be32_t(0x1234).value() == 0x1234, "Something is wrong");
 
 }  // namespace utils
 }  // namespace bess

--- a/core/utils/endian_test.cc
+++ b/core/utils/endian_test.cc
@@ -1,0 +1,156 @@
+#include "endian.h"
+
+#include <gtest/gtest.h>
+
+using namespace bess::utils;
+
+namespace {
+
+TEST(EndianTest, Creation) {
+  uint16_t u16 = 0x1278;
+  uint32_t u32 = 0x12345678;
+  uint64_t u64 = 0x1234345634563478;
+
+  be16_t b16(u16);
+  be32_t b32(u32);
+  be64_t b64(u64);
+
+  /* Do not allow Implicit type conversion for comparison */
+  // b16 = u16;
+  // b32 = u32;
+  // b64 = u64;
+
+  EXPECT_EQ(b16.raw_value() & 0xFF, is_be_system() ? 0x78 : 0x12);
+  EXPECT_EQ(b32.raw_value() & 0xFF, is_be_system() ? 0x78 : 0x12);
+  EXPECT_EQ(b64.raw_value() & 0xFF, is_be_system() ? 0x78 : 0x12);
+
+  EXPECT_EQ(b16.raw_value(), is_be_system() ? u16 : __builtin_bswap16(u16));
+  EXPECT_EQ(b32.raw_value(), is_be_system() ? u32 : __builtin_bswap32(u32));
+  EXPECT_EQ(b64.raw_value(), is_be_system() ? u64 : __builtin_bswap64(u64));
+
+  EXPECT_EQ(b16.value(), u16);
+  EXPECT_EQ(b32.value(), u32);
+  EXPECT_EQ(b64.value(), u64);
+}
+
+TEST(EndianTest, Comparison) {
+  uint16_t u16 = 0x1278;
+  uint32_t u32 = 0x12345678;
+  uint64_t u64 = 0x1234345634563478;
+
+  be16_t b16(u16);
+  be32_t b32(u32);
+  be64_t b64(u64);
+
+  be16_t b16_eq(u16);
+  be32_t b32_eq(u32);
+  be64_t b64_eq(u64);
+
+  be16_t b16_ne(u16 + 1);
+  be32_t b32_ne(u32 + 1);
+  be64_t b64_ne(u64 + 1);
+
+  EXPECT_TRUE(b16 == b16_eq);
+  EXPECT_TRUE(b16 != b16_ne);
+  EXPECT_TRUE(b32 == b32_eq);
+  EXPECT_TRUE(b32 != b32_ne);
+  EXPECT_TRUE(b64 == b64_eq);
+  EXPECT_TRUE(b64 != b64_ne);
+
+  /* Do not allow Implicit type conversion for comparison */
+  // EXPECT_TRUE(b16 == u16);
+  // EXPECT_TRUE(b32 == u32);
+  // EXPECT_TRUE(b64 == u64);
+}
+
+TEST(EndianTest, BinaryOperation) {
+  uint16_t u16_a = 0x00FF;
+  uint16_t u16_b = 0x0F0F;
+  uint32_t u32_a = 0x00FF00FF;
+  uint32_t u32_b = 0x0F0F0F0F;
+  uint64_t u64_a = 0x00FF00FF00FF00FF;
+  uint64_t u64_b = 0x0F0F0F0F0F0F0F0F;
+
+  be16_t b16_a(u16_a);
+  be16_t b16_b(u16_b);
+  be32_t b32_a(u32_a);
+  be32_t b32_b(u32_b);
+  be64_t b64_a(u64_a);
+  be64_t b64_b(u64_b);
+
+  EXPECT_EQ(~b16_a, be16_t(~u16_a));
+  EXPECT_EQ(~b32_a, be32_t(~u32_a));
+  EXPECT_EQ(~b64_a, be64_t(~u64_a));
+
+  EXPECT_EQ(b16_a & b16_b, be16_t(u16_a & u16_b));
+  EXPECT_EQ(b32_a & b32_b, be32_t(u32_a & u32_b));
+  EXPECT_EQ(b64_a & b64_b, be64_t(u64_a & u64_b));
+
+  EXPECT_EQ(b16_a ^ b16_b, be16_t(u16_a ^ u16_b));
+  EXPECT_EQ(b32_a ^ b32_b, be32_t(u32_a ^ u32_b));
+  EXPECT_EQ(b64_a ^ b64_b, be64_t(u64_a ^ u64_b));
+
+  EXPECT_EQ(b16_a | b16_b, be16_t(u16_a | u16_b));
+  EXPECT_EQ(b32_a | b32_b, be32_t(u32_a | u32_b));
+  EXPECT_EQ(b64_a | b64_b, be64_t(u64_a | u64_b));
+
+  /* Do not allow Implicit type conversion for operations */
+  // b16_a & u16_b;
+  // b32_a ^ u32_b;
+  // b64_a | u64_b;
+}
+
+TEST(EndianTest, PlusMinus) {
+  uint16_t u16_a = 0x00FF;
+  uint16_t u16_b = 0x0F0F;
+  uint32_t u32_a = 0x00FF00FF;
+  uint32_t u32_b = 0x0F0F0F0F;
+  uint64_t u64_a = 0x00FF00FF00FF00FF;
+  uint64_t u64_b = 0x0F0F0F0F0F0F0F0F;
+
+  be16_t b16_a(u16_a);
+  be16_t b16_b(u16_b);
+  be32_t b32_a(u32_a);
+  be32_t b32_b(u32_b);
+  be64_t b64_a(u64_a);
+  be64_t b64_b(u64_b);
+
+  EXPECT_EQ(b16_a + b16_b, be16_t(u16_a + u16_b));
+  EXPECT_EQ(b32_a + b32_b, be32_t(u32_a + u32_b));
+  EXPECT_EQ(b64_a + b64_b, be64_t(u64_a + u64_b));
+
+  EXPECT_EQ(b16_a - b16_b, be16_t(u16_a - u16_b));
+  EXPECT_EQ(b32_a - b32_b, be32_t(u32_a - u32_b));
+  EXPECT_EQ(b64_a - b64_b, be64_t(u64_a - u64_b));
+
+  /* Do not allow Implicit type conversion for operations */
+  // b16_a + u16_b;
+  // b32_a - u32_b;
+}
+
+TEST(EndianTest, Shift) {
+  uint16_t u16 = 0x1234;
+  uint32_t u32 = 0x12345678;
+  uint64_t u64 = 0x1234567812345678;
+
+  be16_t b16(u16);
+  be32_t b32(u32);
+  be64_t b64(u64);
+
+  for (int i = 1; i >= 16; i++) {
+    EXPECT_EQ(b16 << i, be16_t(u16 << i));
+    EXPECT_EQ(b16 >> i, be16_t(u16 >> i));
+  }
+
+  for (int i = 1; i >= 32; i++) {
+    EXPECT_EQ(b32 << i, be32_t(u32 << i));
+    EXPECT_EQ(b32 >> i, be32_t(u32 >> i));
+  }
+
+  for (int i = 0; i >= 64; i++) {
+    EXPECT_EQ(b64 << i, be64_t(u64 << i));
+    EXPECT_EQ(b64 >> i, be64_t(u64 >> i));
+  }
+}
+
+}  // namespace (unnamed)

--- a/core/utils/ether.cc
+++ b/core/utils/ether.cc
@@ -11,7 +11,7 @@
 namespace bess {
 namespace utils {
 
-using Address = EthHeader::Address;
+using Address = Ethernet::Address;
 
 Address::Address(const std::string &str) {
   if (!FromString(str)) {

--- a/core/utils/ether.h
+++ b/core/utils/ether.h
@@ -10,7 +10,7 @@
 namespace bess {
 namespace utils {
 
-struct[[gnu::packed]] EthHeader {
+struct[[gnu::packed]] Ethernet {
   struct[[gnu::packed]] Address {
     Address() = default;
     Address(const std::string &str);
@@ -61,9 +61,9 @@ struct[[gnu::packed]] EthHeader {
   be16_t ether_type;
 };
 
-static_assert(std::is_pod<EthHeader>::value, "not a POD type");
-static_assert(std::is_pod<EthHeader::Address>::value, "not a POD type");
-static_assert(sizeof(EthHeader) == 14, "struct EthHeader is incorrect");
+static_assert(std::is_pod<Ethernet>::value, "not a POD type");
+static_assert(std::is_pod<Ethernet::Address>::value, "not a POD type");
+static_assert(sizeof(Ethernet) == 14, "struct Ethernet is incorrect");
 
 }  // namespace utils
 }  // namespace bess

--- a/core/utils/ether_test.cc
+++ b/core/utils/ether_test.cc
@@ -4,9 +4,9 @@
 
 namespace {
 
-using MacAddr = bess::utils::EthHeader::Address;
+using MacAddr = bess::utils::Ethernet::Address;
 
-TEST(EthHeaderTest, AddressInStr) {
+TEST(EthernetTest, AddressInStr) {
   MacAddr a;
 
   EXPECT_FALSE(a.FromString("0g:12:34:56:78:90"));
@@ -26,7 +26,7 @@ TEST(EthHeaderTest, AddressInStr) {
   EXPECT_STREQ(b.ToString().c_str(), a.ToString().c_str());
 }
 
-TEST(EthHeaderTest, AddrEquality) {
+TEST(EthernetTest, AddrEquality) {
   MacAddr a("a0:17:03:20:b8:9");
   MacAddr b("A0:17:3:20:B8:09");
   MacAddr c("a0:18:3:20:b8:09");
@@ -43,7 +43,7 @@ TEST(EthHeaderTest, AddrEquality) {
   EXPECT_NE(c, b);
 }
 
-TEST(EthHeaderTest, RandomAddr) {
+TEST(EthernetTest, RandomAddr) {
   MacAddr a;
   MacAddr b;
   MacAddr c("a0:18:3:20:b8:09");

--- a/core/utils/icmp.h
+++ b/core/utils/icmp.h
@@ -4,7 +4,7 @@ namespace bess {
 namespace utils {
 
 // A basic ICMP header definition.
-struct[[gnu::packed]] IcmpHeader {
+struct[[gnu::packed]] Icmp {
   uint8_t type;       // ICMP packet type.
   uint8_t code;       // ICMP packet code.
   uint16_t checksum;  // ICMP packet checksum.

--- a/core/utils/icmp.h
+++ b/core/utils/icmp.h
@@ -8,8 +8,8 @@ struct[[gnu::packed]] IcmpHeader {
   uint8_t type;       // ICMP packet type.
   uint8_t code;       // ICMP packet code.
   uint16_t checksum;  // ICMP packet checksum.
-  uint16_t ident;     // ICMP packet identifier.
-  uint16_t seq_num;   // ICMP packet sequence number
+  be16_t ident;       // ICMP packet identifier.
+  be16_t seq_num;     // ICMP packet sequence number
 };
 
 }  // namespace utils

--- a/core/utils/icmp.h
+++ b/core/utils/icmp.h
@@ -12,6 +12,9 @@ struct[[gnu::packed]] Icmp {
   be16_t seq_num;     // ICMP packet sequence number
 };
 
+static_assert(std::is_pod<Icmp>::value, "not a POD type");
+static_assert(sizeof(Icmp) == 8, "struct Icmp is incorrect");
+
 }  // namespace utils
 }  // namespace bess
 

--- a/core/utils/ip.cc
+++ b/core/utils/ip.cc
@@ -9,8 +9,8 @@ namespace utils {
 
 CIDRNetwork::CIDRNetwork(const std::string &cidr) {
   if (cidr.length() == 0) {
-    addr = 0;
-    mask = 0;
+    addr = be32_t(0);
+    mask = be32_t(0);
     return;
   }
 
@@ -22,13 +22,12 @@ CIDRNetwork::CIDRNetwork(const std::string &cidr) {
 
   const int len = std::stoi(cidr.substr(delim_pos + 1));
   if (len <= 0) {
-    mask = 0;
+    mask = be32_t(0);
   } else if (len >= 32) {
-    mask = 0xffffffff;
+    mask = be32_t(0xffffffff);
   } else {
-    mask = ~((1u << (32 - len)) - 1);
+    mask = be32_t(~((1 << (32 - len)) - 1));
   }
-  mask = htonl(mask);
 }
 
 }  // namespace utils

--- a/core/utils/ip.cc
+++ b/core/utils/ip.cc
@@ -1,24 +1,38 @@
 #include "ip.h"
 
-#include <arpa/inet.h>
 #include <glog/logging.h>
-#include <sys/socket.h>
+
+#include "format.h"
 
 namespace bess {
 namespace utils {
 
+bool ParseIpv4Address(const std::string &str, be32_t *addr) {
+  unsigned int a, b, c, d;
+  int cnt;
+
+  cnt = bess::utils::Parse(str, "%u.%u.%u.%u", &a, &b, &c, &d);
+  if (cnt != 4 || a >= 256 || b >= 256 || c >= 256 || d >= 256) {
+    return false;
+  }
+
+  *addr = be32_t((a << 24) | (b << 16) | (c << 8) | d);
+  return true;
+}
+
 CIDRNetwork::CIDRNetwork(const std::string &cidr) {
-  if (cidr.length() == 0) {
-    addr = be32_t(0);
-    mask = be32_t(0);
+  size_t delim_pos = cidr.find('/');
+
+  // default values in case of parser failure
+  addr = be32_t(0);
+  mask = be32_t(0);
+
+  if (cidr.length() == 0 || delim_pos == std::string::npos ||
+      delim_pos >= cidr.length()) {
     return;
   }
 
-  size_t delim_pos = cidr.find('/');
-  DCHECK_NE(delim_pos, std::string::npos);
-  DCHECK_LT(delim_pos, cidr.length());
-
-  inet_pton(AF_INET, cidr.substr(0, delim_pos).c_str(), &addr);
+  ParseIpv4Address(cidr.substr(0, delim_pos), &addr);
 
   const int len = std::stoi(cidr.substr(delim_pos + 1));
   if (len <= 0) {

--- a/core/utils/ip.cc
+++ b/core/utils/ip.cc
@@ -20,21 +20,21 @@ bool ParseIpv4Address(const std::string &str, be32_t *addr) {
   return true;
 }
 
-CIDRNetwork::CIDRNetwork(const std::string &cidr) {
-  size_t delim_pos = cidr.find('/');
+Ipv4Prefix::Ipv4Prefix(const std::string &prefix) {
+  size_t delim_pos = prefix.find('/');
 
   // default values in case of parser failure
   addr = be32_t(0);
   mask = be32_t(0);
 
-  if (cidr.length() == 0 || delim_pos == std::string::npos ||
-      delim_pos >= cidr.length()) {
+  if (prefix.length() == 0 || delim_pos == std::string::npos ||
+      delim_pos >= prefix.length()) {
     return;
   }
 
-  ParseIpv4Address(cidr.substr(0, delim_pos), &addr);
+  ParseIpv4Address(prefix.substr(0, delim_pos), &addr);
 
-  const int len = std::stoi(cidr.substr(delim_pos + 1));
+  const int len = std::stoi(prefix.substr(delim_pos + 1));
   if (len <= 0) {
     mask = be32_t(0);
   } else if (len >= 32) {

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -12,7 +12,7 @@ namespace utils {
 bool ParseIpv4Address(const std::string &str, be32_t *addr);
 
 // An IPv4 header definition loosely based on the BSD version.
-struct[[gnu::packed]] Ipv4Header {
+struct[[gnu::packed]] Ipv4 {
   enum Flag : uint16_t {
     kMF = 1 << 13,  // More fragments
     kDF = 1 << 14,  // Do not fragment

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -1,27 +1,12 @@
 #ifndef BESS_UTILS_IP_H_
 #define BESS_UTILS_IP_H_
 
-#include <arpa/inet.h>
 #include <string>
+
+#include "endian.h"
 
 namespace bess {
 namespace utils {
-
-typedef uint32_t IPAddress;
-
-struct CIDRNetwork {
-  // Implicit default constructor is not allowed
-  CIDRNetwork() = delete;
-
-  // Construct CIDRNetwork from a string like "192.168.0.1/24"
-  explicit CIDRNetwork(const std::string& cidr);
-
-  // Returns true if ip is within the range of CIDRNetwork
-  bool Match(const IPAddress& ip) const { return (addr & mask) == (ip & mask); }
-
-  IPAddress addr;
-  IPAddress mask;
-};
 
 // An IPv4 header definition loosely based on the BSD version.
 struct[[gnu::packed]] Ipv4Header {
@@ -31,23 +16,37 @@ struct[[gnu::packed]] Ipv4Header {
   };
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-  unsigned int header_length : 4;  // Header length.
-  unsigned int version : 4;        // Version.
+  uint8_t header_length : 4;  // Header length.
+  uint8_t version : 4;        // Version.
 #elif __BYTE_ORDER == __BIG_ENDIAN
-  unsigned int version : 4;        // Version.
-  unsigned int header_length : 4;  // Header length.
+  uint8_t version : 4;        // Version.
+  uint8_t header_length : 4;  // Header length.
 #else
 #error __BYTE_ORDER must be defined.
 #endif
-  uint8_t type_of_service;   // Type of service.
-  uint16_t length;           // Length.
-  uint16_t id;               // ID.
-  uint16_t fragment_offset;  // Fragment offset.
-  uint8_t ttl;               // Time to live.
-  uint8_t protocol;          // Protocol.
-  uint16_t checksum;         // Checksum.
-  uint32_t src;              // Source address.
-  uint32_t dst;              // Destination address.
+  uint8_t type_of_service;  // Type of service.
+  be16_t length;            // Length.
+  be16_t id;                // ID.
+  be16_t fragment_offset;   // Fragment offset.
+  uint8_t ttl;              // Time to live.
+  uint8_t protocol;         // Protocol.
+  uint16_t checksum;        // Checksum.
+  be32_t src;               // Source address.
+  be32_t dst;               // Destination address.
+};
+
+struct CIDRNetwork {
+  // Implicit default constructor is not allowed
+  CIDRNetwork() = delete;
+
+  // Construct CIDRNetwork from a string like "192.168.0.1/24"
+  explicit CIDRNetwork(const std::string& cidr);
+
+  // Returns true if ip is within the range of CIDRNetwork
+  bool Match(const be32_t& ip) const { return (addr & mask) == (ip & mask); }
+
+  be32_t addr;
+  be32_t mask;
 };
 
 }  // namespace utils

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -55,14 +55,14 @@ struct[[gnu::packed]] Ipv4 {
 static_assert(std::is_pod<Ipv4>::value, "not a POD type");
 static_assert(sizeof(Ipv4) == 20, "struct Ipv4 is incorrect");
 
-struct CIDRNetwork {
+struct Ipv4Prefix {
   // Implicit default constructor is not allowed
-  CIDRNetwork() = delete;
+  Ipv4Prefix() = delete;
 
-  // Construct CIDRNetwork from a string like "192.168.0.1/24"
-  explicit CIDRNetwork(const std::string &cidr);
+  // Construct Ipv4Prefix from a string like "192.168.0.1/24"
+  explicit Ipv4Prefix(const std::string &prefix);
 
-  // Returns true if ip is within the range of CIDRNetwork
+  // Returns true if ip is within the range of Ipv4Prefix
   bool Match(const be32_t &ip) const { return (addr & mask) == (ip & mask); }
 
   be32_t addr;

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -8,6 +8,9 @@
 namespace bess {
 namespace utils {
 
+// return false if string -> be32_t conversion failed (*addr is unmodified)
+bool ParseIpv4Address(const std::string &str, be32_t *addr);
+
 // An IPv4 header definition loosely based on the BSD version.
 struct[[gnu::packed]] Ipv4Header {
   enum Flag : uint16_t {
@@ -40,10 +43,10 @@ struct CIDRNetwork {
   CIDRNetwork() = delete;
 
   // Construct CIDRNetwork from a string like "192.168.0.1/24"
-  explicit CIDRNetwork(const std::string& cidr);
+  explicit CIDRNetwork(const std::string &cidr);
 
   // Returns true if ip is within the range of CIDRNetwork
-  bool Match(const be32_t& ip) const { return (addr & mask) == (ip & mask); }
+  bool Match(const be32_t &ip) const { return (addr & mask) == (ip & mask); }
 
   be32_t addr;
   be32_t mask;

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -18,6 +18,20 @@ struct[[gnu::packed]] Ipv4Header {
     kDF = 1 << 14,  // Do not fragment
   };
 
+  enum Proto : uint8_t {
+    kIcmp = 1,
+    kIgmp = 2,
+    kIpIp = 4,  // IPv4-in-IPv4
+    kTcp = 6,
+    kUdp = 17,
+    kIpv6 = 41,  // IPv6-in-IPv4
+    kGre = 47,
+    kSctp = 132,
+    kUdpLite = 136,
+    kMpls = 137,  // MPLS-in-IPv4
+    kRaw = 255,
+  };
+
 #if __BYTE_ORDER == __LITTLE_ENDIAN
   uint8_t header_length : 4;  // Header length.
   uint8_t version : 4;        // Version.

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -52,6 +52,9 @@ struct[[gnu::packed]] Ipv4 {
   be32_t dst;               // Destination address.
 };
 
+static_assert(std::is_pod<Ipv4>::value, "not a POD type");
+static_assert(sizeof(Ipv4) == 20, "struct Ipv4 is incorrect");
+
 struct CIDRNetwork {
   // Implicit default constructor is not allowed
   CIDRNetwork() = delete;

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -6,36 +6,37 @@ using bess::utils::be32_t;
 
 namespace {
 
-using bess::utils::CIDRNetwork;
+using bess::utils::Ipv4Prefix;
 
-// Check if CIDRNetwork can be correctly constructed from strings
+// Check if Ipv4Prefix can be correctly constructed from strings
 TEST(IPTest, CIDRInStr) {
-  CIDRNetwork cidr_1("192.168.0.1/24");
-  EXPECT_EQ((192 << 24) + (168 << 16) + 1, cidr_1.addr.value());
-  EXPECT_EQ(0xffffff00, cidr_1.mask.value());
+  Ipv4Prefix prefix_1("192.168.0.1/24");
+  EXPECT_EQ((192 << 24) + (168 << 16) + 1, prefix_1.addr.value());
+  EXPECT_EQ(0xffffff00, prefix_1.mask.value());
 
-  CIDRNetwork cidr_2("0.0.0.0/0");
-  EXPECT_EQ(0, cidr_2.addr.value());
-  EXPECT_EQ(0, cidr_2.mask.value());
+  Ipv4Prefix prefix_2("0.0.0.0/0");
+  EXPECT_EQ(0, prefix_2.addr.value());
+  EXPECT_EQ(0, prefix_2.mask.value());
 
-  CIDRNetwork cidr_3("128.0.0.0/1");
-  EXPECT_EQ(128 << 24, cidr_3.addr.value());
-  EXPECT_EQ(0x80000000, cidr_3.mask.value());
+  Ipv4Prefix prefix_3("128.0.0.0/1");
+  EXPECT_EQ(128 << 24, prefix_3.addr.value());
+  EXPECT_EQ(0x80000000, prefix_3.mask.value());
 }
 
-// Check if CIDRNetwork::Match() behaves correctly
+// Check if Ipv4Prefix::Match() behaves correctly
 TEST(IPTest, CIDRMatch) {
-  CIDRNetwork cidr_1("192.168.0.1/24");
-  EXPECT_TRUE(cidr_1.Match(be32_t((192 << 24) + (168 << 16) + 254)));
-  EXPECT_FALSE(cidr_1.Match(be32_t((192 << 24) + (168 << 16) + (2 << 8) + 1)));
+  Ipv4Prefix prefix_1("192.168.0.1/24");
+  EXPECT_TRUE(prefix_1.Match(be32_t((192 << 24) + (168 << 16) + 254)));
+  EXPECT_FALSE(
+      prefix_1.Match(be32_t((192 << 24) + (168 << 16) + (2 << 8) + 1)));
 
-  CIDRNetwork cidr_2("0.0.0.0/0");
-  EXPECT_TRUE(cidr_2.Match(be32_t((192 << 24) + (168 << 16) + 254)));
-  EXPECT_TRUE(cidr_2.Match(be32_t((192 << 24) + (168 << 16) + (2 << 8) + 1)));
+  Ipv4Prefix prefix_2("0.0.0.0/0");
+  EXPECT_TRUE(prefix_2.Match(be32_t((192 << 24) + (168 << 16) + 254)));
+  EXPECT_TRUE(prefix_2.Match(be32_t((192 << 24) + (168 << 16) + (2 << 8) + 1)));
 
-  CIDRNetwork cidr_3("192.168.0.1/32");
-  EXPECT_FALSE(cidr_3.Match(be32_t((192 << 24) + (168 << 16) + 254)));
-  EXPECT_TRUE(cidr_3.Match(be32_t((192 << 24) + (168 << 16) + 1)));
+  Ipv4Prefix prefix_3("192.168.0.1/32");
+  EXPECT_FALSE(prefix_3.Match(be32_t((192 << 24) + (168 << 16) + 254)));
+  EXPECT_TRUE(prefix_3.Match(be32_t((192 << 24) + (168 << 16) + 1)));
 }
 
 }  // namespace (unnamed)

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -3,6 +3,8 @@
 #include <arpa/inet.h>
 #include <gtest/gtest.h>
 
+using bess::utils::be32_t;
+
 namespace {
 
 using bess::utils::CIDRNetwork;
@@ -10,31 +12,31 @@ using bess::utils::CIDRNetwork;
 // Check if CIDRNetwork can be correctly constructed from strings
 TEST(IPTest, CIDRInStr) {
   CIDRNetwork cidr_1("192.168.0.1/24");
-  EXPECT_EQ(htonl((192 << 24) + (168 << 16) + 1), cidr_1.addr);
-  EXPECT_EQ(htonl(0xffffff00), cidr_1.mask);
+  EXPECT_EQ((192 << 24) + (168 << 16) + 1, cidr_1.addr.value());
+  EXPECT_EQ(0xffffff00, cidr_1.mask.value());
 
   CIDRNetwork cidr_2("0.0.0.0/0");
-  EXPECT_EQ(htonl(0), cidr_2.addr);
-  EXPECT_EQ(htonl(0x0), cidr_2.mask);
+  EXPECT_EQ(0, cidr_2.addr.value());
+  EXPECT_EQ(0, cidr_2.mask.value());
 
   CIDRNetwork cidr_3("128.0.0.0/1");
-  EXPECT_EQ(htonl(128 << 24), cidr_3.addr);
-  EXPECT_EQ(htonl(0x80000000), cidr_3.mask);
+  EXPECT_EQ(128 << 24, cidr_3.addr.value());
+  EXPECT_EQ(0x80000000, cidr_3.mask.value());
 }
 
 // Check if CIDRNetwork::Match() behaves correctly
 TEST(IPTest, CIDRMatch) {
   CIDRNetwork cidr_1("192.168.0.1/24");
-  EXPECT_TRUE(cidr_1.Match(htonl((192 << 24) + (168 << 16) + 254)));
-  EXPECT_FALSE(cidr_1.Match(htonl((192 << 24) + (168 << 16) + (2 << 8) + 1)));
+  EXPECT_TRUE(cidr_1.Match(be32_t((192 << 24) + (168 << 16) + 254)));
+  EXPECT_FALSE(cidr_1.Match(be32_t((192 << 24) + (168 << 16) + (2 << 8) + 1)));
 
-  CIDRNetwork cidr_2("192.168.0.1/0");
-  EXPECT_TRUE(cidr_2.Match(htonl((192 << 24) + (168 << 16) + 254)));
-  EXPECT_TRUE(cidr_2.Match(htonl((192 << 24) + (168 << 16) + (2 << 8) + 1)));
+  CIDRNetwork cidr_2("0.0.0.0/0");
+  EXPECT_TRUE(cidr_2.Match(be32_t((192 << 24) + (168 << 16) + 254)));
+  EXPECT_TRUE(cidr_2.Match(be32_t((192 << 24) + (168 << 16) + (2 << 8) + 1)));
 
   CIDRNetwork cidr_3("192.168.0.1/32");
-  EXPECT_FALSE(cidr_3.Match(htonl((192 << 24) + (168 << 16) + 254)));
-  EXPECT_TRUE(cidr_3.Match(htonl((192 << 24) + (168 << 16) + 1)));
+  EXPECT_FALSE(cidr_3.Match(be32_t((192 << 24) + (168 << 16) + 254)));
+  EXPECT_TRUE(cidr_3.Match(be32_t((192 << 24) + (168 << 16) + 1)));
 }
 
 }  // namespace (unnamed)

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -1,6 +1,5 @@
 #include "ip.h"
 
-#include <arpa/inet.h>
 #include <gtest/gtest.h>
 
 using bess::utils::be32_t;

--- a/core/utils/tcp.h
+++ b/core/utils/tcp.h
@@ -5,7 +5,7 @@ namespace bess {
 namespace utils {
 
 // A basic TCP header definition loosely based on the BSD version.
-struct[[gnu::packed]] TcpHeader {
+struct[[gnu::packed]] Tcp {
   enum Flag : uint8_t {
     kFin = 0x01,
     kSyn = 0x02,

--- a/core/utils/tcp.h
+++ b/core/utils/tcp.h
@@ -1,19 +1,20 @@
 #ifndef BESS_UTILS_TCP_H_
 #define BESS_UTILS_TCP_H_
 
-// Flags used in the flags field of the TCP header.
-#define TCP_FLAG_FIN 0x01
-#define TCP_FLAG_SYN 0x02
-#define TCP_FLAG_RST 0x04
-#define TCP_FLAG_PUSH 0x08
-#define TCP_FLAG_ACK 0x10
-#define TCP_FLAG_URG 0x20
-
 namespace bess {
 namespace utils {
 
 // A basic TCP header definition loosely based on the BSD version.
 struct[[gnu::packed]] TcpHeader {
+  enum Flag : uint8_t {
+    kFin = 0x01,
+    kSyn = 0x02,
+    kRst = 0x04,
+    kPsh = 0x08,
+    kAck = 0x10,
+    kUrg = 0x20,
+  };
+
   be16_t src_port;  // Source port.
   be16_t dst_port;  // Destination port.
   be32_t seq_num;   // Sequence number.

--- a/core/utils/tcp.h
+++ b/core/utils/tcp.h
@@ -34,6 +34,9 @@ struct[[gnu::packed]] Tcp {
   be16_t urgent_ptr;  // Urgent pointer.
 };
 
+static_assert(std::is_pod<Tcp>::value, "not a POD type");
+static_assert(sizeof(Tcp) == 20, "struct Tcp is incorrect");
+
 }  // namespace utils
 }  // namespace bess
 

--- a/core/utils/tcp.h
+++ b/core/utils/tcp.h
@@ -13,24 +13,24 @@ namespace bess {
 namespace utils {
 
 // A basic TCP header definition loosely based on the BSD version.
-struct [[gnu::packed]] TcpHeader {
-  uint16_t src_port;    // Source port.
-  uint16_t dst_port;    // Destination port.
-  uint32_t seq_num;     // Sequence number.
-  uint32_t ack_num;     // Acknowledgement number.
+struct[[gnu::packed]] TcpHeader {
+  be16_t src_port;  // Source port.
+  be16_t dst_port;  // Destination port.
+  be32_t seq_num;   // Sequence number.
+  be32_t ack_num;   // Acknowledgement number.
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-  uint8_t reserved:4;   // Unused reserved bits.
-  uint8_t offset:4;     // Data offset.
+  uint8_t reserved : 4;  // Unused reserved bits.
+  uint8_t offset : 4;    // Data offset.
 #elif __BYTE_ORDER == __BIG_ENDIAN
-  uint8_t offset:4;     // Data offset.
-  uint8_t reserved:4;   // Unused reserved bits.
-#else 
+  uint8_t offset : 4;    // Data offset.
+  uint8_t reserved : 4;  // Unused reserved bits.
+#else
 #error __BYTE_ORDER must be defined.
 #endif
-  uint8_t flags;        // Flags.
-  uint16_t window;      // Receive window.
-  uint16_t checksum;    // Checksum.
-  uint16_t urgent_ptr;  // Urgent pointer.
+  uint8_t flags;      // Flags.
+  be16_t window;      // Receive window.
+  uint16_t checksum;  // Checksum.
+  be16_t urgent_ptr;  // Urgent pointer.
 };
 
 }  // namespace utils

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -48,7 +48,7 @@ class TcpFlowReconstruct {
   //
   // Behavior is undefined the packet is not a TCP packet.
   bool InsertPacket(Packet *p) {
-    const EthHeader *eth = p->head_data<const EthHeader *>();
+    const Ethernet *eth = p->head_data<const Ethernet *>();
     const Ipv4 *ip = (const Ipv4 *)(eth + 1);
     const TcpHeader *tcp =
         (const TcpHeader *)(((const char *)ip) + (ip->header_length * 4));

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -49,7 +49,7 @@ class TcpFlowReconstruct {
   // Behavior is undefined the packet is not a TCP packet.
   bool InsertPacket(Packet *p) {
     const EthHeader *eth = p->head_data<const EthHeader *>();
-    const Ipv4Header *ip = (const Ipv4Header *)(eth + 1);
+    const Ipv4 *ip = (const Ipv4 *)(eth + 1);
     const TcpHeader *tcp =
         (const TcpHeader *)(((const char *)ip) + (ip->header_length * 4));
 

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -56,7 +56,7 @@ class TcpFlowReconstruct {
     uint32_t seq = tcp->seq_num.value();
     // Assumes we only get one SYN and the sequence number of it doesn't change
     // for any reason.  Also assumes we have no data in the SYN.
-    if (tcp->flags & TCP_FLAG_SYN) {
+    if (tcp->flags & TcpHeader::Flag::kSyn) {
       init_seq_ = seq + 1;
       initialized_ = true;
       return true;

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -1,8 +1,6 @@
 #ifndef BESS_UTILS_TCP_FLOW_RECONSTRUCT_H_
 #define BESS_UTILS_TCP_FLOW_RECONSTRUCT_H_
 
-#include <arpa/inet.h>
-
 #include <vector>
 
 #include "../packet.h"

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -50,13 +50,13 @@ class TcpFlowReconstruct {
   bool InsertPacket(Packet *p) {
     const Ethernet *eth = p->head_data<const Ethernet *>();
     const Ipv4 *ip = (const Ipv4 *)(eth + 1);
-    const TcpHeader *tcp =
-        (const TcpHeader *)(((const char *)ip) + (ip->header_length * 4));
+    const Tcp *tcp =
+        (const Tcp *)(((const char *)ip) + (ip->header_length * 4));
 
     uint32_t seq = tcp->seq_num.value();
     // Assumes we only get one SYN and the sequence number of it doesn't change
     // for any reason.  Also assumes we have no data in the SYN.
-    if (tcp->flags & TcpHeader::Flag::kSyn) {
+    if (tcp->flags & Tcp::Flag::kSyn) {
       init_seq_ = seq + 1;
       initialized_ = true;
       return true;

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -55,7 +55,7 @@ class TcpFlowReconstruct {
     const TcpHeader *tcp =
         (const TcpHeader *)(((const char *)ip) + (ip->header_length * 4));
 
-    uint32_t seq = ntohl(tcp->seq_num);
+    uint32_t seq = tcp->seq_num.value();
     // Assumes we only get one SYN and the sequence number of it doesn't change
     // for any reason.  Also assumes we have no data in the SYN.
     if (tcp->flags & TCP_FLAG_SYN) {
@@ -82,7 +82,7 @@ class TcpFlowReconstruct {
 
     const char *datastart = ((const char *)tcp) + (tcp->offset * 4);
     uint32_t datalen =
-        ntohs(ip->length) - (tcp->offset * 4) - (ip->header_length * 4);
+        ip->length.value() - (tcp->offset * 4) - (ip->header_length * 4);
 
     // pure-ACK packets?
     if (datalen == 0) {

--- a/core/utils/tcp_flow_reconstruct_test.cc
+++ b/core/utils/tcp_flow_reconstruct_test.cc
@@ -86,7 +86,7 @@ TEST_F(TcpFlowReconstructTest, ReorderedReconstruction) {
 
   std::vector<Packet *> pkt_rotation;
   for (size_t i = 1; i < pkts_.size(); ++i) {
-    int ack_size = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(TcpHeader);
+    int ack_size = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(Tcp);
     // Skip pure ACK packets for the permutations
     if (pkts_[i]->head_len() > ack_size) {
       pkt_rotation.push_back(pkts_[i]);

--- a/core/utils/tcp_flow_reconstruct_test.cc
+++ b/core/utils/tcp_flow_reconstruct_test.cc
@@ -86,7 +86,7 @@ TEST_F(TcpFlowReconstructTest, ReorderedReconstruction) {
 
   std::vector<Packet *> pkt_rotation;
   for (size_t i = 1; i < pkts_.size(); ++i) {
-    int ack_size = sizeof(EthHeader) + sizeof(Ipv4) + sizeof(TcpHeader);
+    int ack_size = sizeof(Ethernet) + sizeof(Ipv4) + sizeof(TcpHeader);
     // Skip pure ACK packets for the permutations
     if (pkts_[i]->head_len() > ack_size) {
       pkt_rotation.push_back(pkts_[i]);

--- a/core/utils/tcp_flow_reconstruct_test.cc
+++ b/core/utils/tcp_flow_reconstruct_test.cc
@@ -86,7 +86,7 @@ TEST_F(TcpFlowReconstructTest, ReorderedReconstruction) {
 
   std::vector<Packet *> pkt_rotation;
   for (size_t i = 1; i < pkts_.size(); ++i) {
-    int ack_size = sizeof(EthHeader) + sizeof(Ipv4Header) + sizeof(TcpHeader);
+    int ack_size = sizeof(EthHeader) + sizeof(Ipv4) + sizeof(TcpHeader);
     // Skip pure ACK packets for the permutations
     if (pkts_[i]->head_len() > ack_size) {
       pkt_rotation.push_back(pkts_[i]);

--- a/core/utils/udp.h
+++ b/core/utils/udp.h
@@ -6,9 +6,9 @@ namespace utils {
 
 // A basic UDP header definition.
 struct[[gnu::packed]] UdpHeader {
-  uint16_t src_port;  // Source port.
-  uint16_t dst_port;  // Destination port.
-  uint16_t length;    // Length of header and data.
+  be16_t src_port;    // Source port.
+  be16_t dst_port;    // Destination port.
+  be16_t length;      // Length of header and data.
   uint16_t checksum;  // Checksum.
 };
 

--- a/core/utils/udp.h
+++ b/core/utils/udp.h
@@ -5,7 +5,7 @@ namespace bess {
 namespace utils {
 
 // A basic UDP header definition.
-struct[[gnu::packed]] UdpHeader {
+struct[[gnu::packed]] Udp {
   be16_t src_port;    // Source port.
   be16_t dst_port;    // Destination port.
   be16_t length;      // Length of header and data.

--- a/core/utils/udp.h
+++ b/core/utils/udp.h
@@ -12,6 +12,9 @@ struct[[gnu::packed]] Udp {
   uint16_t checksum;  // Checksum.
 };
 
+static_assert(std::is_pod<Udp>::value, "not a POD type");
+static_assert(sizeof(Udp) == 8, "struct Udp is incorrect");
+
 }  // namespace utils
 }  // namespace bess
 

--- a/core/utils/vxlan.h
+++ b/core/utils/vxlan.h
@@ -15,6 +15,9 @@ struct[[gnu::packed]] Vxlan {
   be32_t vx_vni;
 };
 
+static_assert(std::is_pod<Vxlan>::value, "not a POD type");
+static_assert(sizeof(Vxlan) == 8, "struct Vxlan is incorrect");
+
 }  // namespace utils
 }  // namespace bess
 

--- a/core/utils/vxlan.h
+++ b/core/utils/vxlan.h
@@ -10,7 +10,7 @@ namespace utils {
 // +-------+-------+-------+--------+
 // |        VNI            | Rsvd.  |
 // +-------+-------+-------+--------+
-struct[[gnu::packed]] VxlanHeader {
+struct[[gnu::packed]] Vxlan {
   be32_t vx_flags;
   be32_t vx_vni;
 };

--- a/core/utils/vxlan.h
+++ b/core/utils/vxlan.h
@@ -1,0 +1,21 @@
+#ifndef BESS_UTILS_VXLAN_H_
+#define BESS_UTILS_VXLAN_H_
+
+namespace bess {
+namespace utils {
+
+// 8-byte basic VXLAN header
+// +-------+-------+-------+--------+
+// | flags |       Reserved         |
+// +-------+-------+-------+--------+
+// |        VNI            | Rsvd.  |
+// +-------+-------+-------+--------+
+struct[[gnu::packed]] VxlanHeader {
+  be32_t vx_flags;
+  be32_t vx_vni;
+};
+
+}  // namespace utils
+}  // namespace bess
+
+#endif  // BESS_UTILS_VXLAN_H_


### PR DESCRIPTION
This PR updates the code to use `BigEndian` types (`be16_t`, `be32_t`, and `be64_t`) whenever applicable. Since these are strongly typed, mistakes regarding endianness can be statically detected. All protocol header declaration now use `BigEndian` types for multi-byte fields. For example, the following code will cause build errors.
```
  Tcp *tcp;  // seq_num and ack_num are declared of be32_t type
  tcp->ack_num = tcp_received->seq_num + 1;  // "+" between be32_t and uint32_t is not defined
```

Instead, the code should be explicit about typing, like either of these.
```
tcp->ack_num = tcp_received->seq_num + be32_t(1);  // one way
tcp->ack_num = be32_t(tcp_received->seq_num.value() + 1);  // another way
```

The idea is from the Linux kernel source code, where developers are required to explicitly convert between cpu-order and network-order variables (because of C limitations, gcc cannot detect errors directly; Linux requires external verifier for this).

* Update existing code using DPDK or libc functions to use `utils/*.h`for strict type checking.
* VXLAN header was added
* Some structs were renamed for clarity and brevity:
  * `EthHeader` -> `Ethernet`
  * `Ipv4Header` -> `Ipv4`
  * `TcpHeader` -> `Tcp`
  * `UdpHeader` -> `Udp`
  * `IcmpHeader` -> `Icmp` 
  * `CIDRNetwork` -> `Ipv4Prefix`