### PR TITLE
Skip ZeroCopyVPort unittests when run by a non-root user

### DIFF
--- a/core/drivers/vport_zc_test.cc
+++ b/core/drivers/vport_zc_test.cc
@@ -13,42 +13,57 @@
 #include "../port.h"
 
 class ZeroCopyVPortTest : public ::testing::Test {
- public:
-  static bool dpdk_inited;
-
  protected:
   virtual void SetUp() {
-    if (!dpdk_inited) {
-      init_dpdk("vport_zc_test", 2048, 0, true);
-      dpdk_inited = true;
+    port_ = nullptr;
+
+    if (!dpdk_inited_) {
+      if (geteuid() == 0) {
+        init_dpdk("vport_zc_test", 2048, 0, true);
+        dpdk_inited_ = true;
+      } else {
+        LOG(INFO) << "This test requires root privileges. Skipping...";
+        return;
+      }
     }
+
     bess::pb::EmptyArg arg;
     ADD_DRIVER(ZeroCopyVPort, "zcvport",
                "zero copy virtual port for trusted user apps")
     ASSERT_TRUE(__driver__ZeroCopyVPort);
     const PortBuilder &builder =
         PortBuilder::all_port_builders().find("ZeroCopyVPort")->second;
-    port = reinterpret_cast<ZeroCopyVPort *>(builder.CreatePort("p0"));
-    ASSERT_NE(nullptr, port);
-    port->num_queues[PACKET_DIR_INC] = 1;
-    port->num_queues[PACKET_DIR_OUT] = 1;
-    ASSERT_EQ(0, port->Init(arg).error().code());
+    port_ = reinterpret_cast<ZeroCopyVPort *>(builder.CreatePort("p0"));
+    ASSERT_NE(nullptr, port_);
+    port_->num_queues[PACKET_DIR_INC] = 1;
+    port_->num_queues[PACKET_DIR_OUT] = 1;
+    ASSERT_EQ(0, port_->Init(arg).error().code());
   }
 
   virtual void TearDown() {
+    if (!dpdk_inited_) {
+      return;
+    }
+
     PortBuilder::all_port_builders_holder(true);
     PortBuilder::all_ports_.clear();
-    if (port) {
-      port->DeInit();
-      delete port;
+    if (port_) {
+      port_->DeInit();
+      delete port_;
     }
   }
-  ZeroCopyVPort *port;
+
+  ZeroCopyVPort *port_;
+  static bool dpdk_inited_;
 };
 
-bool ZeroCopyVPortTest::dpdk_inited = false;
+bool ZeroCopyVPortTest::dpdk_inited_ = false;
 
 TEST_F(ZeroCopyVPortTest, Send) {
+  if (!dpdk_inited_) {
+    return;
+  }
+
   int cnt;
   bess::PacketBatch tx_batch;
   bess::Packet pkts[bess::PacketBatch::kMaxBurst];
@@ -64,12 +79,16 @@ TEST_F(ZeroCopyVPortTest, Send) {
 
     tx_batch.add(pkt);
   }
-  cnt = port->SendPackets(0, tx_batch.pkts(), tx_batch.cnt());
+  cnt = port_->SendPackets(0, tx_batch.pkts(), tx_batch.cnt());
   ASSERT_EQ(tx_batch.cnt(), cnt);
   bess::Packet::Free(&tx_batch);
 }
 
 TEST_F(ZeroCopyVPortTest, Recv) {
+  if (!dpdk_inited_) {
+    return;
+  }
+
   bess::PacketBatch tx_batch;
   bess::PacketBatch rx_batch;
   bess::Packet pkts[bess::PacketBatch::kMaxBurst];
@@ -87,11 +106,11 @@ TEST_F(ZeroCopyVPortTest, Recv) {
   }
 
   // Packets arrived from somewhere
-  llring_enqueue_bulk(port->inc_qs_[0],
+  llring_enqueue_bulk(port_->inc_qs_[0],
                       reinterpret_cast<void **>(tx_batch.pkts()),
                       tx_batch.cnt());
 
-  rx_batch.set_cnt(port->RecvPackets(0, rx_batch.pkts(), tx_batch.cnt()));
+  rx_batch.set_cnt(port_->RecvPackets(0, rx_batch.pkts(), tx_batch.cnt()));
   ASSERT_EQ(tx_batch.cnt(), rx_batch.cnt());
   tx_batch.clear();
   bess::Packet::Free(&rx_batch);

--- a/core/drivers/vport_zc_test.cc
+++ b/core/drivers/vport_zc_test.cc
@@ -19,7 +19,7 @@ class ZeroCopyVPortTest : public ::testing::Test {
 
     if (!dpdk_inited_) {
       if (geteuid() == 0) {
-        init_dpdk("vport_zc_test", 2048, 0, true);
+        init_dpdk("vport_zc_test", 1024, 0, true);
         dpdk_inited_ = true;
       } else {
         LOG(INFO) << "This test requires root privileges. Skipping...";


### PR DESCRIPTION
The unittests for ZeroCopyVPort silently fails if not run by root during DPDK initialization. This commit will just skip (with a log message) the test in that case.