### PR TITLE
Fix packet exhaustion in DRR modules

### DIFF
--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -332,6 +332,7 @@ void DRR::Enqueue(Flow* f, bess::Packet* newpkt, int* err) {
         RoundToPowerTwo(llring_count(f->queue) * kQueueGrowthFactor);
     f->queue = ResizeQueue(f->queue, slots, err);
     if (*err != 0) {
+      bess::Packet::Free(newpkt);
       return;
     }
   }
@@ -339,6 +340,8 @@ void DRR::Enqueue(Flow* f, bess::Packet* newpkt, int* err) {
   *err = llring_enqueue(f->queue, reinterpret_cast<void*>(newpkt));
   if (*err == 0) {
     f->timer = get_epoch_time();
+  } else {
+    bess::Packet::Free(newpkt);
   }
 }
 

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -52,7 +52,7 @@ class DRR final : public Module {
   static const int kQueueGrowthFactor =
       2;  // the scale at which a flow's queue grows
   static const int kFlowQueueMax =
-      200000;                   // the max flow queue size if non-specified
+      8192;                     // the max flow queue size if non-specified
   static const int kTtl = 300;  // time to live for flow entries
   static const int kDefaultQuantum =
       1500;  // default value to initialize qauntum_ to


### PR DESCRIPTION
The DRR module leaks `Packet` objects in two ways:
* When the module fails to enqueue packets, they're not properly freed.
* The default per-flow queue size is huge: 200,000. Two flows are enough to exhaust the entire packet pool (262,144), if queues start building up. It is now reduced to 8,192.

Since the DRR module in `samples/drr.bess` depletes the packet pool, the `fast` and `slow` traffic classes shows incorrect behavior as follows. Due to failure of packet allocations, they cannot keep up with the their limits (90kpps and 40kpps). It results in excessive scheduling of these TCs.
```
localhost:10514 $ monitor tc
16:03:51.536827          CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
--------------------------------------------------------------------------------------------
W0 !default_rr_0        1729.016    16239298       0.105      67.351       0.006   16469.467
W0 fast                 1165.459    10993218       0.030      20.157       0.003   38855.298
W0 !leaf_src1:0         1165.904    10997460       0.030      20.157       0.003   38870.142
W0 slow                  558.965     5240201       0.025      16.790       0.005   22371.824
W0 !leaf_src2:0          559.164     5242083       0.025      16.790       0.005   22379.729
W0 medium                  4.129        1560       0.050      30.363      32.000      82.678
W0 !leaf_q:0               4.131        1561       0.050      30.383      32.000      82.674
--------------------------------------------------------------------------------------------
```

The corrected behavior is like this:
```
16:20:35.515949          CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
--------------------------------------------------------------------------------------------
W0 !default_rr_0          21.689        5621       0.180     117.690      32.000     120.566
W0 fast                   12.947        2810       0.090      60.435      32.000     143.958
W0 !leaf_src1:0           12.945        2810       0.090      60.439      32.000     143.934
W0 slow                    6.010        1249       0.040      26.874      32.000     150.278
W0 !leaf_src2:0            6.003        1248       0.040      26.852      32.000     150.241
W0 medium                  2.736        1560       0.050      30.369      32.000      54.777
W0 !leaf_q:0               2.738        1561       0.050      30.388      32.000      54.780
--------------------------------------------------------------------------------------------
```