### PR TITLE
Enhance versioning

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -103,7 +103,6 @@ PROTO_HEADERS := $(patsubst %.cc,%.h, $(PROTO_SRCS))
 PROTOCFLAGS += --proto_path=$(PROTO_DIR) --cpp_out=. --grpc_out=. --plugin=protoc-gen-grpc=`which grpc_cpp_plugin`
 
 ALL_SRCS := $(wildcard *.cc utils/*.cc modules/*.cc drivers/*.cc hooks/*.cc)
-HEADERS := $(wildcard *.h utils/*.h modules/*.h drivers/*.h hooks/*.h)
 
 TEST_SRCS := $(filter %_test.cc gtest_main.cc, $(ALL_SRCS))
 TEST_OBJS := $(TEST_SRCS:.cc=.o)
@@ -119,15 +118,16 @@ MODULE_OBJS := $(MODULE_SRCS:.cc=.o)
 MODULE_LIBS := $(MODULE_OBJS:.o=.so)
 
 SRCS := $(filter-out $(TEST_SRCS) $(BENCH_SRCS) $(MODULE_SRCS), $(ALL_SRCS)) $(PROTO_SRCS)
+HEADERS := $(wildcard *.h utils/*.h drivers/*.h hooks/*.h)
 OBJS := $(SRCS:.cc=.o)
 
 EXEC := bessd
 
 GTEST_DIR := /usr/src/gtest
 
-.PHONY: all clean tags cscope tests benchmarks protobuf force
+.PHONY: all clean tags cscope tests benchmarks protobuf
 
-all: version.h $(EXEC) modules tests benchmarks
+all: $(EXEC) modules tests benchmarks
 
 clean:
 	rm -rf $(EXEC) .deps/*.d .deps/*/*.d *_test */*_test *_bench */*_bench \
@@ -158,8 +158,12 @@ VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null)
 DEFAULT_VERSION := unknown
 
 VERSION_LINE := \#define VERSION \"$(or $(VERSION), $(DEFAULT_VERSION))\"
-version.h: force
-	@echo "$(VERSION_LINE)"| cmp -s - $@ || echo "$(VERSION_LINE)" > $@
+version.h: $(SRCS) $(filter-out version.h, $(HEADERS))
+	@echo "$(VERSION_LINE)" > $@
+
+# Make sure version.h is created before its use.
+# This is necessary since ./deps/main.d might not be there yet.
+main.o: version.h
 
 # This build wrapper takes 4 parameters:
 # $(1): build type (CXX, LD, ...)

--- a/core/Makefile
+++ b/core/Makefile
@@ -152,7 +152,7 @@ protobuf: $(PROTO_SRCS)
 modules: protobuf $(MODULE_OBJS) $(MODULE_LIBS)
 
 # Generate version string from the current status of the git working copy
-VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null)
+VERSION := $(shell git describe --dirty --always --tags 2>/dev/null)
 
 # Default if previous command fails (e.g., when building from a tarball)
 DEFAULT_VERSION := unknown

--- a/core/Makefile
+++ b/core/Makefile
@@ -152,12 +152,12 @@ protobuf: $(PROTO_SRCS)
 modules: protobuf $(MODULE_OBJS) $(MODULE_LIBS)
 
 # Generate version string from the current status of the git working copy
-VERSION := $(shell git describe --dirty --always --tags 2>/dev/null)
+VERSION = $(shell git describe --dirty --always --tags 2>/dev/null)
 
 # Default if previous command fails (e.g., when building from a tarball)
-DEFAULT_VERSION := unknown
+DEFAULT_VERSION = unknown
 
-VERSION_LINE := \#define VERSION \"$(or $(VERSION), $(DEFAULT_VERSION))\"
+VERSION_LINE = \#define VERSION \"$(or $(VERSION), $(DEFAULT_VERSION))\"
 version.h: $(SRCS) $(filter-out version.h, $(HEADERS))
 	@echo "$(VERSION_LINE)" > $@
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -152,7 +152,7 @@ protobuf: $(PROTO_SRCS)
 modules: protobuf $(MODULE_OBJS) $(MODULE_LIBS)
 
 # Generate version string from the current status of the git working copy
-VERSION = $(shell git describe --dirty --always --tags 2>/dev/null)
+VERSION ?= $(shell git describe --dirty --always --tags 2>/dev/null)
 
 # Default if previous command fails (e.g., when building from a tarball)
 DEFAULT_VERSION = unknown

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -340,7 +340,7 @@ static bool SkipSymbol(char *symbol) {
   _exit(EXIT_FAILURE);
 }
 
-[[gnu::noinline, noreturn]] void GoPanic() {
+[[ gnu::noinline, noreturn ]] void GoPanic() {
   if (oops_msg == "")
     oops_msg = DumpStack();
 
@@ -446,11 +446,13 @@ static void DumpType() {
     DCHECK_EQ(ret, 0);
   }
 
-  std::cout << Format("%-24s %8zu %8zu", type_name.c_str(),
-                                   sizeof(T), alignof(T)) << std::endl;
+  std::cout << Format("%-24s %8zu %8zu", type_name.c_str(), sizeof(T),
+                      alignof(T))
+            << std::endl;
 }
 
 void DumpTypes(void) {
+  std::cout << "bessd " << google::VersionString() << std::endl;
   std::cout << Format("gcc %d.%d.%d", __GNUC__, __GNUC_MINOR__,
                       __GNUC_PATCHLEVEL__)
             << std::endl;

--- a/core/main.cc
+++ b/core/main.cc
@@ -35,6 +35,8 @@ int main(int argc, char *argv[]) {
     signal_fd = bess::bessd::Daemonize();
   }
 
+  LOG(INFO) << "bessd " << google::VersionString();
+
   // Store our PID (child's, if daemonized) in the PID file.
   bess::bessd::WritePidfile(pidfile_fd, getpid());
 


### PR DESCRIPTION
`version.h` is updated whenever `Makefile` is executed. This confuses `make`, since it thinks something useful has been done:
```sh
$ make
...
$ make
$        # "make: Nothing to be done for 'all'." is not shown since version.h has been updated.
```

This PR fixes this behavior of `Makefile`, not updating `version.h` when unnecessary (e.g., modifying modules or unit tests). Also other minor updates include:
* Allow custom versioning w/o `git describe`
  * This enables building BESS when git is not available.
* Print out version info in log messages and `bessd -t`
* Use 7 characters for commit hashes