### PR TITLE
travis: fix typo in sanitzer flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 env:
   global:
     - ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-3.8/bin/llvm-symbolizer
-    - ASAN_OPTIONS=log_path=/tmp/saniziter,log_exe_name=1
+    - ASAN_OPTIONS=log_path=/tmp/sanitizer,log_exe_name=1
     - LSAN_OPTIONS=suppressions=$TRAVIS_BUILD_DIR/core/lsan.suppress
     - UBSAN_OPTIONS=suppressions=$TRAVIS_BUILD_DIR/core/ubsan.suppress,print_stacktrace=1
   matrix:


### PR DESCRIPTION
There is a typo in the definition of ASAN_OPTIONS that prevents travis
from outputting the sanitzer log. This commit fixes the typo.