### PR TITLE
Provide additional context info upon API failures

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -84,6 +84,8 @@ class BESSCLI(cli.CLI):
 
             self.ferr.write('  BESS daemon response - errno=%d (%s: %s)\n' %
                             (e.code, err_code, os.strerror(e.code)))
+            for k, v in sorted(e.info.items()):
+                self.ferr.write('%12s: %s\n' % (str(k), str(v)))
 
             raise self.HandledError()
 


### PR DESCRIPTION
For complex controllers for BESS scripts, it could be challenging to figure out what caused API errors and why. This PR adds some additional information in case of BESS API errors.

### Before:
```
localhost:10514 $ run samples/broken
...
*** Error: burst size must be [0,32]
  BESS daemon response - errno=22 (EINVAL: Invalid argument)
```

### After:
```
localhost:10514 $ run samples/broken
...
*** Error: burst size must be [0,32]
  BESS daemon response - errno=22 (EINVAL: Invalid argument)
     command: set_burst
 command_arg: {'burst': 100}
      module: s
       query: ModuleCommand
   query_arg: {'cmd': u'set_burst', 'name': u's', 'arg': {...}}
```