### PR TITLE
travis: avoid redundant builds for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: cpp
 services:
   - docker
 
+branches:
+  only: 
+    - master
+
 env:
   global:
     - ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-3.8/bin/llvm-symbolizer


### PR DESCRIPTION
Currently Travis launches two builds for pull requests submitted from
branches of NetSys/bess. This is the dominant workflow at the moment and
as a result Travis is doing a lot of extra work and the feedback
loop on pull requests is unnecessarily long.

This commit does away with the extra work by limiting Travis to only run
push jobs on the master branch.