### PR TITLE
Fix incorrect "gates" arguments in examples

### DIFF
--- a/bessctl/conf/samples/hash_lb.bess
+++ b/bessctl/conf/samples/hash_lb.bess
@@ -10,7 +10,7 @@ pkt_bytes = str(eth/ip/udp/payload)
 Source() \
     -> Rewrite(templates=[pkt_bytes]) \
     -> RandomUpdate(fields=[{'offset': 34, 'size': 2, 'min': 1, 'max': 1023}]) \
-    -> hlb::HashLB(gates=[3], mode='l4')
+    -> hlb::HashLB(gates=[0, 1, 2], mode='l4')
 
 hlb:0 -> Sink()
 hlb:1 -> Sink()

--- a/bessctl/conf/samples/igate.bess
+++ b/bessctl/conf/samples/igate.bess
@@ -7,7 +7,7 @@ b:1 -> Sink()
 c::Bypass() -> Sink()
 Source() -> 1:c:1 -> Sink()
 
-src0::Source() -> rr::RoundRobin(gates=[2])
+src0::Source() -> rr::RoundRobin(gates=[0, 1])
 rr:0 -> 0:d::Bypass():0 -> dst::Sink()
 rr:1 -> 1:d:1 -> dst
 src1::Source() -> 0:d

--- a/bessctl/conf/samples/multicore-phy.bess
+++ b/bessctl/conf/samples/multicore-phy.bess
@@ -10,7 +10,7 @@ bess.add_worker(1, 1)
 p0 = PMDPort(pci='82:00.0')
 p1 = PMDPort(pci='82:00.1')
 p2 = PMDPort(pci='07:00.0')
-hlb = HashLB(gates=[2], mode='l2')
+hlb = HashLB(gates=[0, 1], mode='l2')
 src0::PortInc(port=p0.name) -> Sink()
 src1::PortInc(port=p2.name) -> PortOut(port=p1.name)
 

--- a/bessctl/conf/samples/roundrobin.bess
+++ b/bessctl/conf/samples/roundrobin.bess
@@ -1,4 +1,4 @@
-Source() -> rr1::RoundRobin(gates=[3])
+Source() -> rr1::RoundRobin(gates=[0, 1, 2])
 sink1::Sink()
 rr1:0 -> sink1
 rr1:1 -> sink1


### PR DESCRIPTION
`gates` takes a list of gate numbers, not the number of gates.