### PR TITLE
debug: Fix build with recent glog, gflags and g++.

### DIFF
--- a/core/debug.cc
+++ b/core/debug.cc
@@ -9,6 +9,7 @@
 #include <ucontext.h>
 #include <unistd.h>
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <rte_config.h>
 #include <rte_version.h>


### PR DESCRIPTION
On my system building bess fails with:

```
debug.cc: In function ‘void bess::debug::DumpTypes()’:
debug.cc:455:28: error: ‘VersionString’ is not a member of ‘google’
   std::cout << "bessd " << google::VersionString() << std::endl;
                            ^~~~~~
debug.cc:455:28: note: suggested alternative:
In file included from bess_msg.pb.h:9:0,
                 from message.h:6,
                 from module.h:11,
                 from debug.cc:24:
/usr/include/google/protobuf/stubs/common.h:124:32: note:   ‘google::protobuf::internal::VersionString’
 std::string LIBPROTOBUF_EXPORT VersionString(int version);
                                ^~~~~~~~~~~~~
debug.cc: In function ‘void bess::debug::GoPanic()’:
debug.cc:359:1: error: ‘noreturn’ function does return [-Werror]
 }
 ^
```

including gflags.h directly fixes it.