### PR TITLE
Fix pep8 package name

### DIFF
--- a/env/packages.yml
+++ b/env/packages.yml
@@ -39,8 +39,14 @@
         - libgtest-dev
         - linux-headers-generic
         - lcov
-        - python-pep8
         - python-autopep8
+
+    - name: Install release-specific packages
+      apt: name={{item}} state=latest update_cache=yes
+      become: true
+      with_items:
+        - python-pep8
+      when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16
 
     - name: Install Linux headers
       apt: name=linux-headers-{{ ansible_kernel }} state=latest update_cache=yes


### PR DESCRIPTION
The name is `pep8` in both trusty and xenial: http://packages.ubuntu.com/trusty/python/pep8