### PR TITLE
Fix queue constraint checking

### DIFF
--- a/bessctl/conf/samples/qtest.bess
+++ b/bessctl/conf/samples/qtest.bess
@@ -1,0 +1,24 @@
+bess.add_worker(wid=0, core=0)
+bess.add_worker(wid=1, core=1)
+
+src1 = Source()
+src2 = Source()
+queue = queue::Queue()
+sink = Sink()
+
+src1 -> queue
+queue -> sink
+src2 -> sink
+
+# Set up worker 1's TC tree with a RR (root)--Rate Limit--Source 1
+bess.add_tc('w1root', policy='round_robin', wid=0)
+bess.add_tc('slow', parent='w1root', policy='rate_limit', resource='packet', limit={'packet': 100})
+bess.attach_module(src1.name, 'slow')
+
+# Set up worker 2's TC tree with a Priority (root) and Queue with priority 0
+# and Rate Limit--Source 2 with priority 1
+bess.add_tc('w2root', policy='priority', wid=1)
+bess.add_tc('queue_rr', parent='w2root', policy='round_robin', priority=0)
+bess.attach_module(queue.name, 'queue_rr')
+bess.add_tc('fast', parent='w2root', priority=1, policy='rate_limit', resource='packet', limit={'packet': 100000})
+bess.attach_module(src2.name, 'fast')

--- a/core/modules/queue.cc
+++ b/core/modules/queue.cc
@@ -175,5 +175,21 @@ CommandResponse Queue::CommandSetSize(
   return SetSize(arg.size());
 }
 
+CheckConstraintResult Queue::CheckModuleConstraints() const {
+  int active_workers = num_active_workers() - tasks().size();
+  CheckConstraintResult status = CHECK_OK;
+  if (active_workers < 1) {  // Assume multi-producer.
+    LOG(ERROR) << "Queue has no producers";
+    status = CHECK_NONFATAL_ERROR;
+  }
+
+  if (tasks().size() > 1) {  // Assume single consumer.
+    LOG(ERROR) << "More than one consumer for the queue" << name();
+    return CHECK_FATAL_ERROR;
+  }
+
+  return status;
+}
+
 ADD_MODULE(Queue, "queue",
            "terminates current task and enqueue packets for new task")

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -27,17 +27,18 @@ class Queue final : public Module {
 
   CheckConstraintResult CheckModuleConstraints() const override {
     int active_workers = num_active_workers() - tasks().size();
-    if (active_workers != 1) {  // Assume single writer.
-      LOG(ERROR) << "More than one queue writer for " << name();
+    CheckConstraintResult satus = CHECK_OK;
+    if (active_workers < 1) {  // Assume multi-producer.
+      LOG(ERROR) << "Queue has no producers";
+      satus = CHECK_NONFATAL_ERROR;
+    }
+
+    if (tasks().size() > 1) {  // Assume single consumer.
+      LOG(ERROR) << "More than one consumer for the queue" << name();
       return CHECK_FATAL_ERROR;
     }
 
-    if (tasks().size() > 1) {  // Assume single reader.
-      LOG(ERROR) << "More than one reader for the queue" << name();
-      return CHECK_FATAL_ERROR;
-    }
-
-    return CHECK_OK;
+    return satus;
   }
 
  private:

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -25,21 +25,7 @@ class Queue final : public Module {
   CommandResponse CommandSetBurst(const bess::pb::QueueCommandSetBurstArg &arg);
   CommandResponse CommandSetSize(const bess::pb::QueueCommandSetSizeArg &arg);
 
-  CheckConstraintResult CheckModuleConstraints() const override {
-    int active_workers = num_active_workers() - tasks().size();
-    CheckConstraintResult satus = CHECK_OK;
-    if (active_workers < 1) {  // Assume multi-producer.
-      LOG(ERROR) << "Queue has no producers";
-      satus = CHECK_NONFATAL_ERROR;
-    }
-
-    if (tasks().size() > 1) {  // Assume single consumer.
-      LOG(ERROR) << "More than one consumer for the queue" << name();
-      return CHECK_FATAL_ERROR;
-    }
-
-    return satus;
-  }
+  CheckConstraintResult CheckModuleConstraints() const override;
 
  private:
   int Resize(int slots);

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -25,6 +25,21 @@ class Queue final : public Module {
   CommandResponse CommandSetBurst(const bess::pb::QueueCommandSetBurstArg &arg);
   CommandResponse CommandSetSize(const bess::pb::QueueCommandSetSizeArg &arg);
 
+  CheckConstraintResult CheckModuleConstraints() const override {
+    int active_workers = num_active_workers() - tasks().size();
+    if (active_workers != 1) {  // Assume single writer.
+      LOG(ERROR) << "More than one queue writer for " << name();
+      return CHECK_FATAL_ERROR;
+    }
+
+    if (tasks().size() > 1) {  // Assume single reader.
+      LOG(ERROR) << "More than one reader for the queue" << name();
+      return CHECK_FATAL_ERROR;
+    }
+
+    return CHECK_OK;
+  }
+
  private:
   int Resize(int slots);
   CommandResponse SetSize(uint64_t size);

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -21,7 +21,8 @@ TESTS='exactmatch.bess
   vlantest.bess
   wildcardmatch.bess
   nat.bess
-  worker_split.bess'
+  worker_split.bess
+  qtest.bess'
 
 function fail
 {


### PR DESCRIPTION
Not only should we not propagate workers for queues, but the constraint
checks themselves need to be different. This patch adds a new check
method.