### PR TITLE
Fix potential gRPC race

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -33,15 +33,8 @@
 #include "utils/time.h"
 #include "worker.h"
 
-using grpc::Server;
-using grpc::ServerBuilder;
-using grpc::ServerContext;
-using grpc::ServerReader;
-using grpc::ServerReaderWriter;
-using grpc::ServerWriter;
 using grpc::Status;
 using grpc::ServerContext;
-using grpc::ServerBuilder;
 
 using bess::priority_t;
 using bess::resource_t;
@@ -1643,11 +1636,11 @@ class BESSControlImpl final : public BESSControl::Service {
 };
 
 // TODO: C++-ify
-static std::unique_ptr<Server> server;
+static std::unique_ptr<grpc::Server> server;
 static BESSControlImpl service;
 
 void SetupControl() {
-  ServerBuilder builder;
+  grpc::ServerBuilder builder;
 
   if (FLAGS_p) {
     std::string server_address = bess::utils::Format("127.0.0.1:%d", FLAGS_p);
@@ -1655,6 +1648,7 @@ void SetupControl() {
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   }
 
+  builder.SetSyncServerOption(grpc::ServerBuilder::MAX_POLLERS, 1);
   builder.RegisterService(&service);
   server = builder.BuildAndStart();
 }

--- a/core/bessctl.h
+++ b/core/bessctl.h
@@ -21,8 +21,7 @@ class ApiServer {
   ApiServer& operator=(const ApiServer&) = delete;
 
   // Adds a host:port pair. host can be an ipv6 address.
-  // Returns false if failed.
-  bool Listen(const std::string &host, int port);
+  void Listen(const std::string &host, int port);
 
   // Runs the API server until it is shutdown by KillBess RPC.
   void Run();

--- a/core/bessctl.h
+++ b/core/bessctl.h
@@ -1,8 +1,35 @@
 #ifndef BESS_BESSCTL_H_
 #define BESS_BESSCTL_H_
 
-void SetupControl();
+#include <string>
 
-void RunControl();
+namespace grpc {
+  class ServerBuilder;
+}  // namespace grpc
+
+// gRPC server encapsulation. Usage:
+//   ApiServer server;
+//   server.Listen('0.0.0.0', 777);
+//   server.Listen('127.0.0.1', 888);
+//   server.run();
+class ApiServer {
+ public:
+  ApiServer() : builder_(nullptr) {}
+
+  // This class is neither copyable nor movable.
+  ApiServer(const ApiServer&) = delete;
+  ApiServer& operator=(const ApiServer&) = delete;
+
+  // Adds a host:port pair. host can be an ipv6 address.
+  // Returns false if failed.
+  bool Listen(const std::string &host, int port);
+
+  // Runs the API server until it is shutdown by KillBess RPC.
+  void Run();
+
+ private:
+  grpc::ServerBuilder *builder_;
+  static bool grpc_cb_set_;
+};
 
 #endif  // BESS_BESSCTL_H_

--- a/core/main.cc
+++ b/core/main.cc
@@ -53,18 +53,21 @@ int main(int argc, char *argv[]) {
 
   PortBuilder::InitDrivers();
 
-  SetupControl();
+  {
+    ApiServer server;
+    server.Listen("127.0.0.1", FLAGS_p);
 
-  // Signal the parent that all initialization has been finished.
-  if (!FLAGS_f) {
-    uint64_t one = 1;
-    if (write(signal_fd, &one, sizeof(one)) < 0) {
-      PLOG(FATAL) << "write(signal_fd)";
+    // Signal the parent that all initialization has been finished.
+    if (!FLAGS_f) {
+      uint64_t one = 1;
+      if (write(signal_fd, &one, sizeof(one)) < 0) {
+        PLOG(FATAL) << "write(signal_fd)";
+      }
+      close(signal_fd);
     }
-    close(signal_fd);
-  }
 
-  RunControl();
+    server.Run();
+  }
 
   rte_eal_mp_wait_lcore();
   bess::close_mempool();

--- a/core/utils/ether.cc
+++ b/core/utils/ether.cc
@@ -6,7 +6,7 @@
 #include "copy.h"
 #include "endian.h"
 #include "format.h"
-#include "time.h"
+#include "random.h"
 
 namespace bess {
 namespace utils {
@@ -31,12 +31,10 @@ std::string Address::ToString() const {
 }
 
 void Address::Randomize() {
-  uint64_t tsc = rdtsc();
+  Random rng;
 
-  if (is_be_system()) {
-    bess::utils::Copy(bytes, reinterpret_cast<char *>(&tsc) + 2, sizeof(bytes));
-  } else {
-    bess::utils::Copy(bytes, &tsc, sizeof(bytes));
+  for (size_t i = 0; i < Address::kSize; i++) {
+    bytes[i] = rng.Get() & 0xff;
   }
 
   bytes[0] &= 0xfe;  // not broadcast/multicast


### PR DESCRIPTION
gRPC servers are internally multi-threaded, so all RPC handlers must be thread-safe. BESS API handlers are not. This means, if there are multiple client connections, the daemon may crash due to race condition.

gRPC does not currently support a knob to limit the number of handler threads (only "idle" handler threads can be limited). Instead, I introduced a mutex to serialize all RPCs over concurrent connections. Since it could be tedious and error-prone to insert a mutex block in every handler, `mutex::lock()` and `mutex::unlock()` have been added to the callback functions called by all RPC messages.

In addition, the gRPC server has been encapsulated as a class object.