### PR TITLE
libbess-python: attach_module() to 'priority' or 'weighted_fair'.

### DIFF
--- a/bessctl/conf/samples/tc/complextree.bess
+++ b/bessctl/conf/samples/tc/complextree.bess
@@ -35,10 +35,14 @@ bess.resume_all()
 bess.pause_all()
 
 src0::Source() -> Sink()
+src1::Source() -> Sink()
+src2::Source() -> Sink()
 
 bess.resume_all()
 bess.pause_all()
 
 bess.attach_module(src0.name, 'rl')
+bess.attach_module(src1.name, '1', share=2)
+bess.attach_module(src2.name, 'main', priority=1000)
 bess.update_tc_params('rl', resource='bit', limit={'bit': 300000})
 # Do not resume_all here, bessctl will automatically resume

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -495,13 +495,19 @@ class BESS(object):
         return self._request('UpdateTcParams', request)
 
     def attach_module(self, module_name, parent='', wid=-1,
-                      module_taskid=0):
+                      module_taskid=0, priority=None, share=None):
         request = bess_msg.UpdateTcParentRequest()
         class_ = getattr(request, 'class')
         class_.leaf_module_name = module_name
         class_.leaf_module_taskid = module_taskid
         class_.parent = parent
         class_.wid = wid
+
+        if priority is not None:
+            class_.priority = priority
+
+        if share is not None:
+            class_.share = share
 
         return self._request('UpdateTcParent', request)
 


### PR DESCRIPTION
attach_module() didn't allow attaching to 'priority' or 'weighted_fair'
parents, because it didn't have a way to specify the 'priority' or
'share' parameters.  This commit adds the parameters (they're similar to
what we have in add_tc()).