### PR TITLE
add byte tracking gate hook

### DIFF
--- a/core/hooks/track_bytes.cc
+++ b/core/hooks/track_bytes.cc
@@ -1,0 +1,8 @@
+#include "track_bytes.h"
+
+void TrackBytes::ProcessBatch(const bess::PacketBatch *batch) {
+  size_t cnt = batch->cnt();
+  for (size_t i = 0; i < cnt; i++) {
+    bytes_ += batch->pkts()[i]->data_len();
+  }
+}

--- a/core/hooks/track_bytes.h
+++ b/core/hooks/track_bytes.h
@@ -1,0 +1,24 @@
+#ifndef BESS_HOOKS_TRACK_BYTES_
+#define BESS_HOOKS_TRACK_BYTES_
+
+#include "../module.h"
+
+const std::string kGateHookTrackBytes = "track_bytes";
+const uint16_t kGateHookPriorityTrackBytes = 2;
+
+// TrackBytes counts the number of bytes seen by a gate.
+class TrackBytes final : public bess::GateHook {
+ public:
+  TrackBytes()
+      : bess::GateHook(kGateHookTrackBytes, kGateHookPriorityTrackBytes),
+        bytes_(){};
+
+  uint64_t bytes() const { return bytes_; }
+
+  void ProcessBatch(const bess::PacketBatch *batch);
+
+ private:
+  uint64_t bytes_;
+};
+
+#endif  // BESS_HOOKS_TRACK_BYTES_

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -395,8 +395,9 @@ class BESS(object):
         request.gate = gate
         return self._request('DisableTcpdump', request)
 
-    def enable_track(self, m, direction='out', gate=None):
+    def enable_track(self, m, direction='out', gate=None, is_bytes=False):
         request = bess_msg.EnableTrackRequest()
+
         request.name = m
         if gate is None:
             request.use_gate = False
@@ -404,10 +405,13 @@ class BESS(object):
             request.use_gate = True
             request.gate = gate
         request.is_igate = (direction == 'in')
+        request.is_bytes = is_bytes
+
         return self._request('EnableTrack', request)
 
-    def disable_track(self, m, direction='out', gate=None):
+    def disable_track(self, m, direction='out', gate=None, is_bytes=False):
         request = bess_msg.DisableTrackRequest()
+
         request.name = m
         if gate is None:
             request.use_gate = False
@@ -415,7 +419,9 @@ class BESS(object):
             request.use_gate = True
             request.gate = gate
         request.is_igate = (direction == 'in')
-        return self._request('DisableTrack', request)
+        request.is_bytes = is_bytes
+
+        return self._request('DisableTrackBytes', request)
 
     def list_workers(self):
         return self._request('ListWorkers')

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -345,15 +345,17 @@ message GetModuleInfoResponse {
     repeated OGate ogates = 2;  /// The list of upstream output gates
     uint64 cnt = 3;             /// # of packet batches seen
     uint64 pkts = 4;            /// # of packets seen
-    double timestamp = 5;       /// The time that cnt/pkts counters were read
+    uint64 bytes = 5;           /// # of bytes seen
+    double timestamp = 6;       /// The time that cnt/pkts counters were read
   }
   message OGate {
     uint64 ogate = 1;      /// Output gate ID
     uint64 cnt = 2;        /// # of packet batches seen
     uint64 pkts = 3;       /// # of packets seen
-    double timestamp = 4;  /// The time thatcnt/pkts counters were read
-    string name = 5;       /// Name of the "next" module it connects to
-    uint64 igate = 6;      /// Input gate ID of the "next" module
+    uint64 bytes = 4;           /// # of bytes seen
+    double timestamp = 5;  /// The time thatcnt/pkts counters were read
+    string name = 6;       /// Name of the "next" module it connects to
+    uint64 igate = 7;      /// Input gate ID of the "next" module
   }
   message Attribute {
     string name = 1;   /// Name of per-packet metadata attribute
@@ -405,6 +407,7 @@ message EnableTrackRequest {
   int64 gate = 2;     /// Gate ID, starting from 0
   bool is_igate = 3;  /// Either input gate (True) or output gate (False)
   bool use_gate = 4;  /// If False, the hook is installed on all igates & ogates
+  bool is_bytes = 5;  /// If True, the TrackBytes hook is installed. Otherwise, Track is installed.
 
   // FIXME: use oneof {igate, ogate)
   // FIXME: get rid of use_gate (e.g., gate == -1)
@@ -415,6 +418,7 @@ message DisableTrackRequest {
   int64 gate = 2;     /// Gate ID, starting from 0
   bool is_igate = 3;  /// Either input gate (True) or output gate (False)
   bool use_gate = 4;  /// If False, the hook is installed on all igates & ogates
+  bool is_bytes = 5;  /// If True, the TrackBytes hook is installed. Otherwise, Track is installed.
 
   // FIXME: use oneof {igate, ogate)
   // FIXME: get rid of use_gate (e.g., gate == -1)


### PR DESCRIPTION
This commit adds a gate hook called TrackBytes and corresponding bessctl
commands `enable track bytes`, `monitor pipeline bytes`, and `show
pipeline bytes`.

Example Usage
-------------
```
localhost:10514 $ run samples/s2s
localhost:10514 $ track bytes enable source0
localhost:10514 $ show pipeline bytes
+---------+                     +-------+
| source0 |  :0 3705477728 0:   | sink0 |
| Source  | ------------------> | Sink  |
+---------+                     +-------+
localhost:10514 $ monitor pipeline bytes
+---------+                   +-------+
| source0 |  :0 101106.0 0:   | sink0 |
| Source  | ----------------> | Sink  |
+---------+                   +-------+
```