### PR TITLE
Correct the unit of max_burst parameter for ratelimit TCs

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -908,34 +908,53 @@ def show_worker_list(cli, worker_ids):
 
 
 def _limit_to_str(limit):
-    buf = []
-
     if 'count' in limit:
-        buf.append('%d times' % limit['count'])
-
-    if 'cycle' in limit:
-        buf.append('%.3f Mhz' % (limit['cycle'] / 1e6))
-
-    if 'packet' in limit:
+        return '%d times/s' % limit['count']
+    elif 'cycle' in limit:
+        return '%.3f MHz' % (limit['cycle'] / 1e6)
+    elif 'packet' in limit:
         if limit['packet'] < 1e3:
-            buf.append('%.d pps' % limit['packet'])
+            return '%.d pps' % limit['packet']
         elif limit['packet'] < 1e6:
-            buf.append('%.3f kpps' % (limit['packet'] / 1e3))
+            return '%.3f kpps' % (limit['packet'] / 1e3)
         else:
-            buf.append('%.3f Mpps' % (limit['packet'] / 1e6))
-
-    if 'bit' in limit:
+            return '%.3f Mpps' % (limit['packet'] / 1e6)
+    elif 'bit' in limit:
         if limit['bit'] < 1e3:
-            buf.append('%.d bps' % limit['bit'])
+            return '%.d bps' % limit['bit']
         elif limit['bit'] < 1e6:
-            buf.append('%.3f kbps' % (limit['bit'] / 1e3))
+            return '%.3f kbps' % (limit['bit'] / 1e3)
         else:
-            buf.append('%.3f Mbps' % (limit['bit'] / 1e6))
-
-    if buf:
-        return 'limits: ' + ', '.join(buf)
+            return '%.3f Mbps' % (limit['bit'] / 1e6)
     else:
         return 'unlimited'
+
+
+def _burst_to_str(burst):
+    # no output if max_burst is not set
+    if len(burst.values()) == 0 or burst.values()[0] == 0:
+        return ''
+
+    if 'count' in burst:
+        return 'burst: %d times' % burst['count']
+    elif 'cycle' in burst:
+        return 'burst: %d cycles' % burst['cycle']
+    elif 'packet' in burst:
+        if burst['packet'] < 1e3:
+            return 'burst: %.d pkts' % burst['packet']
+        elif burst['packet'] < 1e6:
+            return 'burst: %.3f kpkts' % (burst['packet'] / 1e3)
+        else:
+            return 'burst: %.3f Mpkts' % (burst['packet'] / 1e6)
+    elif 'bit' in burst:
+        if burst['bit'] < 1e3:
+            return 'burst: %.d bits' % burst['bit']
+        elif burst['bit'] < 1e6:
+            return 'burst: %.3f kbits' % (burst['bit'] / 1e3)
+        else:
+            return 'burst: %.3f Mbits' % (burst['bit'] / 1e6)
+    else:
+        return ''
 
 
 def _show_tcs_node(cli, node, indent, prefix, lastsibling):
@@ -1010,6 +1029,7 @@ def _build_tcs_tree(tcs):
 
         if c_.policy == "rate_limit":
             nodes[c_.name]["show_list"].append(_limit_to_str(c_.limit))
+            nodes[c_.name]["show_list"].append(_burst_to_str(c_.max_burst))
 
     return root
 

--- a/bessctl/conf/samples/tc/max_burst.bess
+++ b/bessctl/conf/samples/tc/max_burst.bess
@@ -1,0 +1,35 @@
+# Compare worker 0 and worker 1 with "monitor tc"
+
+bess.add_worker(wid=0, core=0)
+bess.add_worker(wid=1, core=1)
+dummy_pkt = '0' * 100
+
+# Worker 0: no burstiness causes inaccurate scheduling
+w0_src0::Source() -> w0_rewrite::Rewrite(templates=[dummy_pkt]) -> Sink()
+w0_src1::Source() -> w0_rewrite
+
+w0_src0.set_burst(burst=1)
+w0_src1.set_burst(burst=32)
+
+bess.add_tc('w0_1000MHz', policy='rate_limit', resource='cycle', limit={'cycle': int(1e9)}, wid=0)
+bess.add_tc('w0_rr', policy='round_robin', parent='w0_1000MHz')
+bess.add_tc('w0_500MHz_0', policy='rate_limit', resource='cycle', limit={'cycle': int(0.5e9)}, parent='w0_rr')
+bess.add_tc('w0_500MHz_1', policy='rate_limit', resource='cycle', limit={'cycle': int(0.5e9)}, parent='w0_rr')
+
+bess.attach_module(w0_src0.name, 'w0_500MHz_0')
+bess.attach_module(w0_src1.name, 'w0_500MHz_1')
+
+# Worker 1: traffic classes with burstiness allowance
+w1_src0::Source() -> w1_rewrite::Rewrite(templates=[dummy_pkt]) -> Sink()
+w1_src1::Source() -> w1_rewrite
+
+w1_src0.set_burst(burst=1)
+w1_src1.set_burst(burst=32)
+
+bess.add_tc('w1_1000MHz', policy='rate_limit', resource='cycle', limit={'cycle': int(1e9)}, wid=1)
+bess.add_tc('w1_rr', policy='round_robin', parent='w1_1000MHz')
+bess.add_tc('w1_500MHz_0', policy='rate_limit', resource='cycle', limit={'cycle': int(0.5e9)}, max_burst={'cycle': 10000}, parent='w1_rr')
+bess.add_tc('w1_500MHz_1', policy='rate_limit', resource='cycle', limit={'cycle': int(0.5e9)}, max_burst={'cycle': 10000}, parent='w1_rr')
+
+bess.attach_module(w1_src0.name, 'w1_500MHz_0')
+bess.attach_module(w1_src1.name, 'w1_500MHz_1')

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -465,7 +465,7 @@ void RateLimitTrafficClass::FinishAndAccountTowardsRoot(
   last_tsc_ = tsc;
 
   uint64_t tokens = tokens_ + limit_ * elapsed_cycles;
-  uint64_t consumed = usage[resource_] << USAGE_AMPLIFIER_POW;
+  uint64_t consumed = to_work_units(usage[resource_]);
   if (tokens < consumed) {
     // Exceeded limit, throttled.
     tokens_ = 0;

--- a/core/traffic_class_test.cc
+++ b/core/traffic_class_test.cc
@@ -277,7 +277,7 @@ TEST(DefaultSchedulerNext, BasicTreeRateLimit) {
 
   ASSERT_EQ(RESOURCE_COUNT, c->resource());
   ASSERT_EQ(50, c->limit_arg());
-  ASSERT_EQ(RateLimitTrafficClass::to_work_units(50), c->limit());
+  ASSERT_EQ(RateLimitTrafficClass::to_work_units_per_cycle(50), c->limit());
   ASSERT_EQ(100, c->max_burst_arg());
   ASSERT_EQ(RateLimitTrafficClass::to_work_units(100), c->max_burst());
 
@@ -287,7 +287,8 @@ TEST(DefaultSchedulerNext, BasicTreeRateLimit) {
 
   ASSERT_EQ(RESOURCE_PACKET, c->resource());
   ASSERT_EQ(new_limit, c->limit_arg());
-  ASSERT_EQ(RateLimitTrafficClass::to_work_units(new_limit), c->limit());
+  ASSERT_EQ(RateLimitTrafficClass::to_work_units_per_cycle(new_limit),
+            c->limit());
   ASSERT_EQ(new_burst, c->max_burst_arg());
   ASSERT_EQ(RateLimitTrafficClass::to_work_units(new_burst), c->max_burst());
 


### PR DESCRIPTION
`max_burst`, which is the maximum token bucket size, cam be used to absorb burstiness of resource scheduling. While its unit should be the amount of "work", it was internally stored in "work/time". This PR addresses this bug.

```
localhost:10514 $ show tc
<worker 0>
  +-- w0_1000MHz               rate_limit          1000.000 MHz
      +-- w0_rr                round_robin
          +-- w0_500MHz_0      rate_limit          500.000 MHz
          |   +-- !leaf_w0_src0:0 leaf
          +-- w0_500MHz_1      rate_limit          500.000 MHz
              +-- !leaf_w0_src1:0 leaf
<worker 1>
  +-- w1_1000MHz               rate_limit          1000.000 MHz
      +-- w1_rr                round_robin
          +-- w1_500MHz_0      rate_limit          500.000 MHz         (burst: 10000 cycles)
          |   +-- !leaf_w1_src0:0 leaf
          +-- w1_500MHz_1      rate_limit          500.000 MHz         (burst: 10000 cycles)
              +-- !leaf_w1_src1:0 leaf
localhost:10514 $ monitor tc
Monitoring traffic classes: w0_1000MHz, w0_rr, w0_500MHz_0, !leaf_w0_src0:0, w0_500MHz_1, !leaf_w0_src1:0, w1_1000MHz, w1_rr, w1_500MHz_0, !leaf_w1_src0:0, w1_500MHz_1, !leaf_w1_src1:0

08:08:29.059552          CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
--------------------------------------------------------------------------------------------
W0 w0_1000MHz            921.930     2256896      19.934   13395.660       8.832      46.249    # <- inaccurate
W0 w0_rr                 921.931     2256915      19.934   13395.734       8.832      46.249
W0 w0_500MHz_0           422.919     1686692       1.687    1133.458       1.000     250.738
W0 !leaf_w0_src0:0       422.918     1686696       1.687    1133.460       1.000     250.737
W0 w0_500MHz_1           499.014      570236      18.248   12262.360      32.000      27.347
W0 !leaf_w0_src1:0       499.015      570238      18.248   12262.401      32.000      27.347
W1 w1_1000MHz            998.631     2866496      23.148   15555.141       8.075      43.142    # <- accurate
W1 w1_rr                 998.626     2866410      23.146   15554.407       8.075      43.144
W1 w1_500MHz_0           499.035     2212278       2.212    1486.651       1.000     225.575
W1 !leaf_w1_src0:0       499.035     2212285       2.212    1486.656       1.000     225.575
W1 w1_500MHz_1           499.602      654192      20.934   14067.751      32.000      23.865
W1 !leaf_w1_src1:0       499.602      654189      20.934   14067.696      32.000      23.866
--------------------------------------------------------------------------------------------
```