### PR TITLE
Account for tasks instead of workers

### DIFF
--- a/bessctl/conf/testing/test_constraint_checker.bess
+++ b/bessctl/conf/testing/test_constraint_checker.bess
@@ -1,0 +1,42 @@
+# This is taken from queue.bess
+src::Source() \
+        -> queue::Queue() \
+        -> VLANPush(tci=2) \
+        -> Sink()
+
+bess.add_tc('fast', policy='rate_limit', resource='packet', limit={'packet': 9000000})
+bess.attach_module(src.name, 'fast')
+
+bess.add_tc('slow', policy='rate_limit', resource='packet', limit={'packet': 1000000})
+bess.attach_module(queue.name, 'slow')
+ret = bess.check_constraints()
+assert(not ret)
+bess.reset_all()
+
+# From nat.bess -- check that revisiting the same module works correctly.
+nat::NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+
+# Swap src/dst MAC
+mac::MACSwap()
+
+# Swap src/dst IP addresses / ports
+ip::IPSwap()
+
+Source() -> 0:nat:0 -> mac -> ip -> 1:nat:1 -> Sink()
+ret = bess.check_constraints()
+assert(not ret)
+
+bess.reset_all()
+
+# Check a combination.
+nat2::NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+
+# Swap src/dst MAC
+mac2::MACSwap()
+
+# Swap src/dst IP addresses / ports
+ip2::IPSwap()
+
+Source() -> 0:nat2:0 -> Queue() -> ip2 -> 1:nat2:1 -> Sink()
+ret = bess.check_constraints()
+assert(not ret)

--- a/bessctl/conf/testing/test_constraint_checker.bess
+++ b/bessctl/conf/testing/test_constraint_checker.bess
@@ -1,42 +1,67 @@
-# This is taken from queue.bess
-src::Source() \
-        -> queue::Queue() \
+
+def queue_test():
+    # This is taken from queue.bess
+    src = Source()
+    src -> queue::Queue() \
         -> VLANPush(tci=2) \
         -> Sink()
+    
+    bess.add_tc('fast', policy='rate_limit', resource='packet', limit={'packet': 9000000})
+    bess.attach_module(src.name, 'fast')
+    
+    bess.add_tc('slow', policy='rate_limit', resource='packet', limit={'packet': 1000000})
+    bess.attach_module(queue.name, 'slow')
 
-bess.add_tc('fast', policy='rate_limit', resource='packet', limit={'packet': 9000000})
-bess.attach_module(src.name, 'fast')
+def nat_test():
+    # From nat.bess -- check that revisiting the same module works correctly.
+    nat = NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+    
+    # Swap src/dst MAC
+    mac = MACSwap()
+    
+    # Swap src/dst IP addresses / ports
+    ip = IPSwap()
+    
+    Source() -> 0:nat:0 -> mac -> ip -> 1:nat:1 -> Sink()
 
-bess.add_tc('slow', policy='rate_limit', resource='packet', limit={'packet': 1000000})
-bess.attach_module(queue.name, 'slow')
-ret = bess.check_constraints()
-assert(not ret)
-bess.reset_all()
+def nat_queue_test():
+    # Check a combination.
+    nat = NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
 
-# From nat.bess -- check that revisiting the same module works correctly.
-nat::NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+    # Swap src/dst IP addresses / ports
+    ip = IPSwap()
 
-# Swap src/dst MAC
-mac::MACSwap()
+    Source() -> 0:nat:0 -> Queue() -> ip -> 1:nat:1 -> Sink()
 
-# Swap src/dst IP addresses / ports
-ip::IPSwap()
+def nat_negative_test():
+    src0 = Source()
+    src1 = Source()
+    bess.add_worker(0, 0)
+    bess.add_worker(1, 1)
+    nat = NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+    src0 -> 0:nat:0 -> Sink()
+    src1 -> 1:nat:1 -> Sink()
+    bess.attach_module(src0.name, wid = 0)
+    bess.attach_module(src1.name, wid = 1)
+    
 
-Source() -> 0:nat:0 -> mac -> ip -> 1:nat:1 -> Sink()
-ret = bess.check_constraints()
-assert(not ret)
+def test_no_error(test):
+    test()
+    ret = bess.check_constraints()
+    assert(not ret)
 
-bess.reset_all()
+    bess.reset_all()
 
-# Check a combination.
-nat2::NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+def test_fatal_error(test):
+    test()
+    try:
+        ret = bess.check_constraints()
+        assert(False) # Should never get here.
+    except bess.ConstraintError as e:
+        pass
+    bess.reset_all()
 
-# Swap src/dst MAC
-mac2::MACSwap()
-
-# Swap src/dst IP addresses / ports
-ip2::IPSwap()
-
-Source() -> 0:nat2:0 -> Queue() -> ip2 -> 1:nat2:1 -> Sink()
-ret = bess.check_constraints()
-assert(not ret)
+test_no_error(queue_test)
+test_no_error(nat_test)
+test_no_error(nat_queue_test)
+test_fatal_error(nat_negative_test)

--- a/core/module.cc
+++ b/core/module.cc
@@ -268,9 +268,10 @@ placement_constraint Module::ComputePlacementConstraints(
 }
 
 void Module::AddActiveWorker(int wid, const ModuleTask *t) {
-  if (!(active_workers_[wid])) {  // Have not already accounted for
-                                  // worker.
+  if (!HaveVisitedWorker(t)) {  // Have not already accounted for
+                                // worker.
     active_workers_[wid] = true;
+    visited_tasks_.push_back(t);
     // Check if we should propagate downstream. We propagate if either
     // `propagate_workers_` is true or if the current module created the task.
     bool propagate = propagate_workers_;

--- a/core/module.h
+++ b/core/module.h
@@ -483,11 +483,7 @@ class Task {
    */
   void AddActiveWorker(int wid) {
     if (module_) {
-      LOG(WARNING) << "Adding active worker for wid " << wid << " to "
-                   << module_->name();
       module_->AddActiveWorker(wid, t_);
-    } else {
-      LOG(WARNING) << "No module";
     }
   }
 

--- a/core/module.h
+++ b/core/module.h
@@ -177,6 +177,7 @@ class Module {
         igates_(),
         ogates_(),
         active_workers_(Worker::kMaxWorkers, false),
+        visited_tasks_(),
         node_constraints_(UNCONSTRAINED_SOCKET),
         min_allowed_workers_(1),
         max_allowed_workers_(1),
@@ -292,6 +293,7 @@ class Module {
    */
   void ResetActiveWorkerSet() {
     std::fill(active_workers_.begin(), active_workers_.end(), false);
+    visited_tasks_.clear();
   }
 
   const std::vector<bool> &active_workers() const { return active_workers_; }
@@ -303,6 +305,19 @@ class Module {
     return std::count_if(active_workers_.begin(), active_workers_.end(),
                          [](bool b) { return b; });
   }
+
+  /*!
+   * Check if we have already seen a task
+   */
+  inline bool HaveVisitedWorker(const ModuleTask *task) const {
+    return std::find(visited_tasks_.begin(), visited_tasks_.end(), task) !=
+           visited_tasks_.end();
+  }
+
+  /*!
+   * Number of tasks that access this module
+   */
+  inline size_t num_active_tasks() const { return visited_tasks_.size(); }
 
   virtual void AddActiveWorker(int wid, const ModuleTask *task);
 
@@ -335,6 +350,8 @@ class Module {
   std::vector<bess::OGate *> ogates_;
   // Set of active workers accessing this module.
   std::vector<bool> active_workers_;
+  // Set of tasks we have already accounted for when propagating workers.
+  std::vector<const ModuleTask *> visited_tasks_;
 
  protected:
   // TODO[apanda]: Move to some constraint structure?

--- a/core/modules/queue.cc
+++ b/core/modules/queue.cc
@@ -176,9 +176,8 @@ CommandResponse Queue::CommandSetSize(
 }
 
 CheckConstraintResult Queue::CheckModuleConstraints() const {
-  int active_workers = num_active_workers() - tasks().size();
   CheckConstraintResult status = CHECK_OK;
-  if (active_workers < 1) {  // Assume multi-producer.
+  if (num_active_tasks() - tasks().size() < 1) {  // Assume multi-producer.
     LOG(ERROR) << "Queue has no producers";
     status = CHECK_NONFATAL_ERROR;
   }

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -190,6 +190,7 @@ class BESS(object):
 
     def check_constraints(self):
         response = self.check_scheduling_constraints()
+        error = False
         if len(response.violations) != 0 or len(response.modules) != 0:
             print 'Placement violations found'
             for violation in response.violations:
@@ -210,9 +211,12 @@ class BESS(object):
             for module in response.modules:
                 print 'constraints violated for module %s --'\
                     ' please check bessd log' % module.name
+            error = True
         if response.fatal:
             raise self.ConstraintError("Fatal violation of "
                                        "scheduling constraints")
+            error = True
+        return error
 
     def uncheck_resume_all(self):
         return self._request('ResumeAll')

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -215,7 +215,6 @@ class BESS(object):
         if response.fatal:
             raise self.ConstraintError("Fatal violation of "
                                        "scheduling constraints")
-            error = True
         return error
 
     def uncheck_resume_all(self):

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 
 BESSCTL='./bessctl/bessctl'
-SCRIPTS='./bessctl/conf/samples'
+SCRIPTS='./bessctl/conf'
 OUTFILE='sanity_check.out'
 
-TESTS='exactmatch.bess
-  flowgen.bess
-  generic_encap.bess
-  hash_lb.bess
-  igate.bess
-  iplookup.bess
-  l2_forward.bess
-  multicore.bess
-  queue.bess
-  roundrobin.bess
-  s2s.bess
-  tc/complextree.bess
-  unix_port.bess
-  update.bess
-  vlantest.bess
-  wildcardmatch.bess
-  nat.bess
-  worker_split.bess
-  qtest.bess
-  ../testing/test_constraint_checker.bess'
+TESTS='samples/exactmatch.bess
+  samples/flowgen.bess
+  samples/generic_encap.bess
+  samples/hash_lb.bess
+  samples/igate.bess
+  samples/iplookup.bess
+  samples/l2_forward.bess
+  samples/multicore.bess
+  samples/queue.bess
+  samples/roundrobin.bess
+  samples/s2s.bess
+  samples/tc/complextree.bess
+  samples/unix_port.bess
+  samples/update.bess
+  samples/vlantest.bess
+  samples/wildcardmatch.bess
+  samples/nat.bess
+  samples/worker_split.bess
+  samples/qtest.bess
+  testing/test_constraint_checker.bess'
 
 function fail
 {

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -22,7 +22,8 @@ TESTS='exactmatch.bess
   wildcardmatch.bess
   nat.bess
   worker_split.bess
-  qtest.bess'
+  qtest.bess
+  ../testing/test_constraint_checker.bess'
 
 function fail
 {


### PR DESCRIPTION
Previously we were ensuring that each worker was propagated exactly once
through a module. This doesn't work since multiple tasks in a worker
might be using the same module. This change fixes this misaccounting.
Also fixes related bugs in queue.cc