### PR TITLE
Update NAT module

### DIFF
--- a/bessctl/conf/perftest/nat.bess
+++ b/bessctl/conf/perftest/nat.bess
@@ -1,0 +1,23 @@
+import scapy.all as scapy
+
+# generate flows by varying src IP addr
+num_flows = int($BESS_FLOWS!'1')
+assert(1 <= num_flows <= 256 ** 3)
+
+bidirectional = bool(int($BESS_BIDIRECTIONAL!'0'))
+
+eth = scapy.Ether(src='02:1e:67:9f:4d:ac', dst='06:16:3e:1b:72:32')
+ip = scapy.IP(src='10.0.0.1', dst='192.168.1.1')
+udp = scapy.UDP(sport=10001, dport=10002)
+payload = 'helloworld'
+pkt_bytes = str(eth/ip/udp/payload)
+
+Source() \
+    -> Rewrite(templates=[pkt_bytes]) \
+    -> RandomUpdate(fields=[{'offset': 26, 'size': 4, 'min': 0x0a000001, 'max': 0x0a000001 + num_flows - 1}]) \
+    -> nat::NAT(ext_addrs=['1.1.1.1', '1.1.1.2'])
+
+if bidirectional:
+    nat -> MACSwap() -> IPSwap() -> 1:nat:1 -> Sink()
+else:
+    nat -> Sink()

--- a/bessctl/conf/samples/nat.bess
+++ b/bessctl/conf/samples/nat.bess
@@ -3,9 +3,6 @@
 import scapy.all as scapy
 import socket
 
-def aton(ip):
-    return socket.inet_aton(ip)
-
 # Craft a packet with the specified IP addresses
 def gen_packet(proto, src_ip, dst_ip):
     eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
@@ -23,7 +20,7 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
            gen_packet(scapy.UDP, '192.168.1.123', '12.34.56.78'),
           ]
 
-nat::NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+nat::NAT(ext_addrs=['192.168.0.1', '192.168.0.2'])
 
 # Swap src/dst MAC
 mac::MACSwap()

--- a/bessctl/conf/testing/module_tests/nat.py
+++ b/bessctl/conf/testing/module_tests/nat.py
@@ -58,8 +58,7 @@ def my_nat_simple_rule_test():
         unnatted_str = s0.recv(2048)
         assert str(eth / ip_unnatted / swap_l4(l4_orig) / l7) == unnatted_str
 
-    nat0::NAT(rules=[{'internal_addr_block':'0.0.0.0/0',
-                      'external_addr_block':'192.168.1.1/32'}])
+    nat0::NAT(ext_addrs=['192.168.1.1'])
 
     port0, s0 = gen_socket_and_port("NATcustom0_" + SCRIPT_STARTTIME)
     port1, s1 = gen_socket_and_port("NATcustom1_" + SCRIPT_STARTTIME)

--- a/bessctl/conf/testing/test_constraint_checker.bess
+++ b/bessctl/conf/testing/test_constraint_checker.bess
@@ -1,48 +1,57 @@
-
 def queue_test():
     # This is taken from queue.bess
     src = Source()
     src -> queue::Queue() \
         -> VLANPush(tci=2) \
         -> Sink()
-    
-    bess.add_tc('fast', policy='rate_limit', resource='packet', limit={'packet': 9000000})
-    src.attach_task(parent='fast')
-    
-    bess.add_tc('slow', policy='rate_limit', resource='packet', limit={'packet': 1000000})
-    queue.attach_task(parent='slow')
+
+    bess.add_tc('fast', policy='rate_limit',
+                resource='packet', limit={'packet': 9000000})
+    bess.attach_module(src.name, 'fast')
+
+    bess.add_tc('slow', policy='rate_limit',
+                resource='packet', limit={'packet': 1000000})
+    bess.attach_module(queue.name, 'slow')
+
 
 def nat_test():
     # From nat.bess -- check that revisiting the same module works correctly.
-    nat = NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
-    
+    nat = NAT(ext_addrs=['192.168.1.1'])
+
     # Swap src/dst MAC
     mac = MACSwap()
-    
+
     # Swap src/dst IP addresses / ports
     ip = IPSwap()
-    
+
     Source() -> 0:nat:0 -> mac -> ip -> 1:nat:1 -> Sink()
+
 
 def nat_queue_test():
     # Check a combination.
-    nat = NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+    nat = NAT(ext_addrs=['192.168.1.1'])
 
     # Swap src/dst IP addresses / ports
     ip = IPSwap()
 
     Source() -> 0:nat:0 -> Queue() -> ip -> 1:nat:1 -> Sink()
 
+
 def nat_negative_test():
     src0 = Source()
     src1 = Source()
     bess.add_worker(0, 0)
     bess.add_worker(1, 1)
-    nat = NAT(rules=[{'internal_addr_block':'0.0.0.0/0', 'external_addr_block':'192.168.1.1/32'}])
+    nat = NAT(ext_addrs=['192.168.1.1'])
     src0 -> 0:nat:0 -> Sink()
     src1 -> 1:nat:1 -> Sink()
+<<<<<<< cae02101c1434ea659c18966d7fa14847639260f
     src0.attach_task(wid=0)
     src1.attach_task(wid=1)
+=======
+    bess.attach_module(src0.name, wid=0)
+    bess.attach_module(src1.name, wid=1)
+>>>>>>> Update NAT arguments
 
 
 def test_no_error(test):
@@ -52,14 +61,16 @@ def test_no_error(test):
 
     bess.reset_all()
 
+
 def test_fatal_error(test):
     test()
     try:
         ret = bess.check_constraints()
-        assert(False) # Should never get here.
+        assert(False)  # Should never get here.
     except bess.ConstraintError as e:
         pass
     bess.reset_all()
+
 
 test_no_error(queue_test)
 test_no_error(nat_test)

--- a/bessctl/conf/testing/test_constraint_checker.bess
+++ b/bessctl/conf/testing/test_constraint_checker.bess
@@ -7,11 +7,11 @@ def queue_test():
 
     bess.add_tc('fast', policy='rate_limit',
                 resource='packet', limit={'packet': 9000000})
-    bess.attach_module(src.name, 'fast')
+    src.attach_task('fast')
 
     bess.add_tc('slow', policy='rate_limit',
                 resource='packet', limit={'packet': 1000000})
-    bess.attach_module(queue.name, 'slow')
+    queue.attach_task('slow')
 
 
 def nat_test():

--- a/bessctl/conf/testing/test_constraint_checker.bess
+++ b/bessctl/conf/testing/test_constraint_checker.bess
@@ -45,13 +45,8 @@ def nat_negative_test():
     nat = NAT(ext_addrs=['192.168.1.1'])
     src0 -> 0:nat:0 -> Sink()
     src1 -> 1:nat:1 -> Sink()
-<<<<<<< cae02101c1434ea659c18966d7fa14847639260f
     src0.attach_task(wid=0)
     src1.attach_task(wid=1)
-=======
-    bess.attach_module(src0.name, wid=0)
-    bess.attach_module(src1.name, wid=1)
->>>>>>> Update NAT arguments
 
 
 def test_no_error(test):

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -81,7 +81,8 @@ static inline std::pair<bool, Endpoint> ExtractEndpoint(const Ipv4 *ip,
     }
   }
 
-  return std::make_pair(false, Endpoint{});
+  return std::make_pair(
+      false, Endpoint{.addr = ip->src, .port = be16_t(0), .protocol = 0});
 }
 
 // Not necessary to inline this function, since it is less frequently called

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -44,8 +44,8 @@ CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
 }
 
 static inline std::pair<bool, Endpoint> ExtractEndpoint(const Ipv4 *ip,
-                                                 const void *l4,
-                                                 NAT::Direction dir) {
+                                                        const void *l4,
+                                                        NAT::Direction dir) {
   IpProto proto = static_cast<IpProto>(ip->protocol);
 
   if (likely(proto == IpProto::kTcp || proto == IpProto::kUdp)) {
@@ -67,11 +67,8 @@ static inline std::pair<bool, Endpoint> ExtractEndpoint(const Ipv4 *ip,
     const Icmp *icmp = static_cast<const Icmp *>(l4);
     Endpoint ret;
 
-    if (icmp->type == 0 ||
-        icmp->type == 8 ||
-        icmp->type == 13 ||
-        icmp->type == 15 ||
-        icmp->type == 16) {
+    if (icmp->type == 0 || icmp->type == 8 || icmp->type == 13 ||
+        icmp->type == 15 || icmp->type == 16) {
       if (dir == NAT::kForward) {
         ret = {
             .addr = ip->src, .port = icmp->ident, .protocol = IpProto::kIcmp};

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -99,16 +99,21 @@ NAT::HashTable::Entry *NAT::CreateNewEntry(const Endpoint &src_internal,
   uint16_t min;
   uint16_t range;  // consider [min, min + range) port range
 
-  if (src_internal.port == be16_t(0)) {
-    // ignore port number 0
-    return nullptr;
-  } else if (src_internal.port & ~be16_t(1023)) {
-    min = 1024;
-    range = 65535 - min + 1;
+  if (src_internal.protocol == IpProto::kIcmp) {
+    min = 0;
+    range = 65535;  // identifier 65535 won't be used, but who cares?
   } else {
-    // Privileged ports are mapped to privileged ports (rfc4787 REQ-5-a)
-    min = 1;
-    range = 1023;
+    if (src_internal.port == be16_t(0)) {
+      // ignore port number 0
+      return nullptr;
+    } else if (src_internal.port & ~be16_t(1023)) {
+      min = 1024;
+      range = 65535 - min + 1;
+    } else {
+      // Privileged ports are mapped to privileged ports (rfc4787 REQ-5-a)
+      min = 1;
+      range = 1023;
+    }
   }
 
   // Start from a random port, then do linear probing

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../utils/checksum.h"
+#include "../utils/common.h"
 #include "../utils/ether.h"
 #include "../utils/format.h"
 #include "../utils/icmp.h"
@@ -18,173 +19,202 @@ using IpProto = bess::utils::Ipv4::Proto;
 using bess::utils::Udp;
 using bess::utils::Tcp;
 using bess::utils::Icmp;
-using bess::utils::UpdateChecksum16;
 using bess::utils::ChecksumIncrement16;
 using bess::utils::ChecksumIncrement32;
 using bess::utils::UpdateChecksumWithIncrement;
-
-const Commands NAT::cmds = {
-    {"add", "NATArg", MODULE_CMD_FUNC(&NAT::CommandAdd), 0},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&NAT::CommandClear), 0}};
-
-inline Flow Flow::ReverseFlow() const {
-  if (proto == IpProto::kIcmp) {
-    return Flow(dst_ip, src_ip, icmp_ident, be16_t(0), IpProto::kIcmp);
-  } else {
-    return Flow(dst_ip, src_ip, dst_port, src_port, proto);
-  }
-}
-
-std::string Flow::ToString() const {
-  return bess::utils::Format("%d %08x:%hu -> %08x:%hu", proto, src_ip.value(),
-                             src_port.value(), dst_ip.value(),
-                             dst_port.value());
-}
+using bess::utils::UpdateChecksum16;
 
 CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
-  InitRules(arg);
+  for (const std::string &ext_addr : arg.ext_addrs()) {
+    be32_t addr;
+    bool ret = bess::utils::ParseIpv4Address(ext_addr, &addr);
+    if (!ret) {
+      return CommandFailure(EINVAL, "invalid IP address %s", ext_addr.c_str());
+    }
+
+    ext_addrs_.push_back(addr);
+  }
+
+  if (ext_addrs_.empty()) {
+    return CommandFailure(EINVAL,
+                          "at least one external IP address must be specified");
+  }
+
   return CommandSuccess();
 }
 
-CommandResponse NAT::CommandAdd(const bess::pb::NATArg &arg) {
-  InitRules(arg);
-  return CommandResponse();
-}
+static inline std::pair<bool, Endpoint> ExtractEndpoint(const Ipv4 *ip,
+                                                 const void *l4,
+                                                 NAT::Direction dir) {
+  IpProto proto = static_cast<IpProto>(ip->protocol);
 
-CommandResponse NAT::CommandClear(const bess::pb::EmptyArg &) {
-  rules_.clear();
-  flow_hash_.Clear();
+  if (likely(proto == IpProto::kTcp || proto == IpProto::kUdp)) {
+    // UDP and TCP share the same layout for port numbers
+    const Udp *udp = static_cast<const Udp *>(l4);
+    Endpoint ret;
 
-  return CommandResponse();
-}
+    if (dir == NAT::kForward) {
+      ret = {.addr = ip->src, .port = udp->src_port, .protocol = proto};
+    } else {
+      ret = {.addr = ip->dst, .port = udp->dst_port, .protocol = proto};
+    }
 
-// Extract a Flow object from IP header ip and L4 header l4
-static inline Flow parse_flow(Ipv4 *ip, void *l4) {
-  Udp *udp = reinterpret_cast<Udp *>(l4);
-  Icmp *icmp = reinterpret_cast<Icmp *>(l4);
-  Flow flow;
-
-  flow.proto = ip->protocol;
-  flow.src_ip = ip->src;
-  flow.dst_ip = ip->dst;
-
-  switch (flow.proto) {
-    case IpProto::kTcp:
-    case IpProto::kUdp:
-      flow.src_port = udp->src_port;
-      flow.dst_port = udp->dst_port;
-      break;
-    case IpProto::kIcmp:
-      switch (icmp->type) {
-        case 0:
-        case 8:
-        case 13:
-        case 15:
-        case 16:
-          flow.icmp_ident = icmp->ident;
-          flow.dst_port = be16_t(0);
-          break;
-        default:
-          VLOG(1) << "Unknown icmp_type: " << icmp->type;
-      }
-      break;
+    return std::make_pair(true, ret);
   }
-  return flow;
+
+  // slow path
+  if (proto == IpProto::kIcmp) {
+    const Icmp *icmp = static_cast<const Icmp *>(l4);
+    Endpoint ret;
+
+    if (icmp->type == 0 ||
+        icmp->type == 8 ||
+        icmp->type == 13 ||
+        icmp->type == 15 ||
+        icmp->type == 16) {
+      if (dir == NAT::kForward) {
+        ret = {
+            .addr = ip->src, .port = icmp->ident, .protocol = IpProto::kIcmp};
+      } else {
+        ret = {
+            .addr = ip->dst, .port = icmp->ident, .protocol = IpProto::kIcmp};
+      }
+
+      return std::make_pair(true, ret);
+    }
+  }
+
+  return std::make_pair(false, Endpoint{});
 }
 
-template <bool src>
-static inline void stamp_flow(Ipv4 *ip, void *l4, const Flow &flow) {
-  Udp *udp = reinterpret_cast<Udp *>(l4);
-  Tcp *tcp = reinterpret_cast<Tcp *>(l4);
-  Icmp *icmp = reinterpret_cast<Icmp *>(l4);
-  uint32_t l3_inc = 0;
-  uint32_t l4_inc = 0;
+// Not necessary to inline this function, since it is less frequently called
+NAT::HashTable::Entry *NAT::CreateNewEntry(const Endpoint &src_internal,
+                                           uint64_t now) {
+  Endpoint src_external;
 
-  if (src) {
-    l3_inc += ChecksumIncrement32(ip->src.raw_value(),
-                                                     flow.src_ip.raw_value());
-    ip->src = flow.src_ip;
+  // An internal IP address is always mapped to the same external IP address,
+  // in an deterministic manner (rfc4787 REQ-2)
+  size_t hashed = rte_hash_crc(&src_internal.addr, sizeof(be32_t), 0);
+  src_external.addr = ext_addrs_[hashed % ext_addrs_.size()];
+  src_external.protocol = src_internal.protocol;
+
+  uint16_t min;
+  uint16_t range;  // consider [min, min + range) port range
+
+  if (src_internal.port == be16_t(0)) {
+    // ignore port number 0
+    return nullptr;
+  } else if (src_internal.port & ~be16_t(1023)) {
+    min = 1024;
+    range = 65535 - min + 1;
   } else {
-    l3_inc += ChecksumIncrement32(ip->dst.raw_value(),
-                                                     flow.dst_ip.raw_value());
-    ip->dst = flow.dst_ip;
+    // Privileged ports are mapped to privileged ports (rfc4787 REQ-5-a)
+    min = 1;
+    range = 1023;
   }
 
-  ip->checksum = UpdateChecksumWithIncrement(ip->checksum, l3_inc);
+  // Start from a random port, then do linear probing
+  uint16_t start_port = min + rng_.GetRange(range);
+  uint16_t port = start_port;
+  int trials = 0;
 
-  switch (flow.proto) {
-    case IpProto::kTcp:
-      if (src) {
-        l4_inc += ChecksumIncrement16(
-            tcp->src_port.raw_value(), flow.src_port.raw_value());
-        tcp->src_port = flow.src_port;
-      } else {
-        l4_inc += ChecksumIncrement16(
-            tcp->dst_port.raw_value(), flow.dst_port.raw_value());
-        tcp->dst_port = flow.dst_port;
+  do {
+    src_external.port = be16_t(port);
+    auto *hash_reverse = map_.Find(src_external);
+    if (hash_reverse == nullptr) {
+found:
+      // Found an available src_internal <-> src_external mapping
+      NatEntry forward_entry;
+      NatEntry reverse_entry;
+
+      reverse_entry.endpoint = src_internal;
+      map_.Insert(src_external, reverse_entry);
+
+      forward_entry.endpoint = src_external;
+      return map_.Insert(src_internal, forward_entry);
+    } else {
+      // A':a' is not free, but it might have been expired.
+      // Check with the forward hash entry since timestamp refreshes only for
+      // forward direction.
+      auto *hash_forward = map_.Find(hash_reverse->second.endpoint);
+
+      // Forward and reverse entries must share the same lifespan.
+      DCHECK(hash_forward != nullptr);
+
+      if (now - hash_forward->second.last_refresh > kTimeOutNs) {
+        // Found an expired mapping. Remove A':a' <-> A'':a''...
+        map_.Remove(hash_forward->first);
+        map_.Remove(hash_reverse->first);
+        goto found;  // and go install A:a <-> A':a'
       }
-      l4_inc += l3_inc;
+    }
 
-      tcp->checksum = UpdateChecksumWithIncrement(tcp->checksum, l4_inc);
-      break;
+    port++;
+    trials++;
 
-    case IpProto::kUdp:
-      if (udp->checksum) {
-        if (src) {
-          l4_inc += ChecksumIncrement16(
-              udp->src_port.raw_value(), flow.src_port.raw_value());
-        } else {
-          l4_inc += ChecksumIncrement16(
-              udp->dst_port.raw_value(), flow.dst_port.raw_value());
-        }
-        l4_inc += l3_inc;
+    // Out of range? Also check if zero due to uint16_t overflow
+    if (port == 0 || port >= min + range) {
+      port = min;
+    }
+  } while (port != start_port && trials < kMaxTrials);
 
-        udp->checksum = UpdateChecksumWithIncrement(udp->checksum, l4_inc);
+  return nullptr;
+}
 
-        if (!udp->checksum) {
-          udp->checksum = 0xFFFF;
-        }
+template <NAT::Direction dir>
+inline void Stamp(Ipv4 *ip, void *l4, const Endpoint &before,
+                  const Endpoint &after) {
+  IpProto proto = static_cast<IpProto>(ip->protocol);
+  DCHECK_EQ(before.protocol, after.protocol);
+  DCHECK_EQ(before.protocol, proto);
+
+  if (dir == NAT::kForward) {
+    ip->src = after.addr;
+  } else {
+    ip->dst = after.addr;
+  }
+
+  uint32_t l3_increment =
+      ChecksumIncrement32(before.addr.raw_value(), after.addr.raw_value());
+  ip->checksum = UpdateChecksumWithIncrement(ip->checksum, l3_increment);
+
+  uint32_t l4_increment =
+      l3_increment +
+      ChecksumIncrement16(before.port.raw_value(), after.port.raw_value());
+
+  if (likely(proto == IpProto::kTcp || proto == IpProto::kUdp)) {
+    Udp *udp = static_cast<Udp *>(l4);
+    if (dir == NAT::kForward) {
+      udp->src_port = after.port;
+    } else {
+      udp->dst_port = after.port;
+    }
+
+    if (proto == IpProto::kTcp) {
+      Tcp *tcp = static_cast<Tcp *>(l4);
+      tcp->checksum = UpdateChecksumWithIncrement(tcp->checksum, l4_increment);
+    } else {
+      // NOTE: UDP checksum is tricky in two ways:
+      // 1. if the old checksum field was 0 (not set), no need to update
+      // 2. if the updated value is 0, use 0xffff (rfc768)
+      if (udp->checksum != 0) {
+        udp->checksum =
+            UpdateChecksumWithIncrement(udp->checksum, l4_increment) ?: 0xffff;
       }
+    }
+  } else {
+    DCHECK_EQ(proto, IpProto::kIcmp);
+    Icmp *icmp = static_cast<Icmp *>(l4);
+    icmp->ident = after.port;
 
-      if (src) {
-        udp->src_port = flow.src_port;
-      } else {
-        udp->dst_port = flow.dst_port;
-      }
-      break;
-
-    case IpProto::kIcmp:
-      switch (icmp->type) {
-        case 0:
-        case 8:
-        case 13:
-        case 15:
-        case 16:
-          icmp->checksum =
-              UpdateChecksum16(icmp->checksum, icmp->ident.raw_value(),
-                               flow.icmp_ident.raw_value());
-          icmp->ident = flow.icmp_ident;
-          break;
-        default:
-          VLOG(1) << "Unknown icmp_type: " << icmp->type;
-      }
-      break;
+    // ICMP does not have a pseudo header
+    icmp->checksum = UpdateChecksum16(icmp->checksum, before.port.raw_value(),
+                                      after.port.raw_value());
   }
 }
 
-// Rewrite IP header and L4 header src info using flow
-static inline void stamp_flow_src(Ipv4 *ip, void *l4, const Flow &flow) {
-  stamp_flow<true>(ip, l4, flow);
-}
-
-// Rewrite IP header and L4 header dst info using flow
-static inline void stamp_flow_dst(Ipv4 *ip, void *l4, const Flow &flow) {
-  stamp_flow<false>(ip, l4, flow);
-}
-
-void NAT::ProcessBatch(bess::PacketBatch *batch) {
-  gate_idx_t incoming_gate = get_igate();
-
+template <NAT::Direction dir>
+inline void NAT::DoProcessBatch(bess::PacketBatch *batch) {
   bess::PacketBatch out_batch;
   bess::PacketBatch free_batch;
   out_batch.clear();
@@ -199,127 +229,54 @@ void NAT::ProcessBatch(bess::PacketBatch *batch) {
     Ethernet *eth = pkt->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
     size_t ip_bytes = (ip->header_length) << 2;
-
     void *l4 = reinterpret_cast<uint8_t *>(ip) + ip_bytes;
 
-    Flow flow = parse_flow(ip, l4);
+    bool valid_protocol;
+    Endpoint before;
+    std::tie(valid_protocol, before) = ExtractEndpoint(ip, l4, dir);
 
-    if (ip->protocol != IpProto::kTcp && ip->protocol != IpProto::kUdp &&
-        ip->protocol != IpProto::kIcmp) {
+    if (!valid_protocol) {
       free_batch.add(pkt);
       continue;
     }
 
-    const auto rule_it =
-        std::find_if(rules_.begin(), rules_.end(),
-                     [&ip](const std::pair<Ipv4Prefix, AvailablePorts> &rule) {
-                       return rule.first.Match(ip->src);
-                     });
+    auto *hash_item = map_.Find(before);
 
-    {
-      auto *res = flow_hash_.Find(flow);
-      if (res != nullptr) {
-        FlowRecord *record = res->second;
-        DCHECK_EQ(record->external_flow.src_port, record->port);
-
-        if (now - record->time < TIME_OUT_NS) {
-          // Entry exists and does not exceed timeout
-          record->time = now;
-          if (incoming_gate == 0) {
-            stamp_flow_src(ip, l4, record->external_flow);
-          } else {
-            stamp_flow_dst(ip, l4, record->internal_flow.ReverseFlow());
-          }
-          out_batch.add(pkt);
-          continue;
-        } else {
-          // Reclaim expired record
-          record->time = 0;
-          if (incoming_gate == 0) {
-            flow_hash_.Remove(flow);
-            Flow rev_flow = record->external_flow.ReverseFlow();
-            flow_hash_.Remove(rev_flow);
-          } else {
-            flow_hash_.Remove(flow);
-            flow_hash_.Remove(record->internal_flow);
-          }
-          AvailablePorts &available_ports = rule_it->second;
-          available_ports.FreeAllocated(std::make_tuple(
-              record->external_flow.src_ip, record->port, record));
-        }
+    if (hash_item == nullptr) {
+      if (dir != kForward || !(hash_item = CreateNewEntry(before, now))) {
+        free_batch.add(pkt);
+        continue;
       }
     }
 
-    // The flow didn't match, and we currently don't support any mechanisms to
-    // allow external flows entry through the NAT.
-    if (incoming_gate == 1) {
-      // Flow from external network, drop.
-      free_batch.add(pkt);
-      continue;
+    // only refresh for outbound packets, rfc4787 REQ-6
+    if (dir == kForward) {
+      hash_item->second.last_refresh = now;
     }
 
-    // The flow must be a new flow if we have gotten this far.  So look for a
-    // rule that tells us what external prefix this packet's flow maps to.
-    if (rule_it == rules_.end()) {
-      // No rules found for this source IP address, drop.
-      free_batch.add(pkt);
-      continue;
-    }
+    Stamp<dir>(ip, l4, before, hash_item->second.endpoint);
 
-    AvailablePorts &available_ports = rule_it->second;
-
-    // Garbage collect.
-    if (available_ports.empty() && now >= available_ports.next_expiry()) {
-      uint64_t expiry = UINT64_MAX;
-
-      for (auto it = flow_hash_.begin(); it != flow_hash_.end(); ++it) {
-        FlowRecord *record = it->second;
-        if (record->time != 0 && (now - record->time) >= TIME_OUT_NS) {
-          // Found expired flow entry.
-          record->time = 0;
-          flow_hash_.Remove(record->internal_flow);
-          Flow rev_flow = record->external_flow.ReverseFlow();
-          flow_hash_.Remove(rev_flow);
-          available_ports.FreeAllocated(
-              std::make_tuple(record->external_flow.src_ip,
-                              record->external_flow.src_port, record));
-        } else if (record->time != 0) {
-          expiry = std::min(expiry, record->time + TIME_OUT_NS);
-        }
-      }
-      available_ports.set_next_expiry(expiry);
-    }
-
-    // Still no available ports, so drop.
-    if (available_ports.empty()) {
-      free_batch.add(pkt);
-      continue;
-    }
-
-    be32_t new_ip;
-    be16_t new_port;
-    FlowRecord *record;
-    std::tie(new_ip, new_port, record) = available_ports.RandomFreeIPAndPort();
-
-    record->port = new_port;
-    record->time = now;
-    record->internal_flow = flow;     // Copy
-    flow_hash_.Insert(flow, record);  // Copy
-
-    flow.src_ip = new_ip;
-    flow.src_port = new_port;
-
-    record->external_flow = flow;
-    Flow rev_flow = flow.ReverseFlow();   // Copy
-    flow_hash_.Insert(rev_flow, record);  // Copy
-
-    stamp_flow_src(ip, l4, flow);
     out_batch.add(pkt);
   }
 
   bess::Packet::Free(&free_batch);
 
-  RunChooseModule(incoming_gate, &out_batch);
+  RunChooseModule(static_cast<gate_idx_t>(dir), &out_batch);
+}
+
+void NAT::ProcessBatch(bess::PacketBatch *batch) {
+  gate_idx_t incoming_gate = get_igate();
+
+  if (incoming_gate == 0) {
+    DoProcessBatch<kForward>(batch);
+  } else {
+    DoProcessBatch<kReverse>(batch);
+  }
+}
+
+std::string NAT::GetDesc() const {
+  // Divide by 2 since the table has both forward and reverse entries
+  return bess::utils::Format("%zu entries", map_.Count() / 2);
 }
 
 ADD_MODULE(NAT, "nat", "Network address translator")

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -1,6 +1,9 @@
 #ifndef BESS_MODULES_NAT_H_
 #define BESS_MODULES_NAT_H_
 
+#include "../module.h"
+#include "../module_msg.pb.h"
+
 #include <rte_config.h>
 #include <rte_hash_crc.h>
 
@@ -10,149 +13,81 @@
 #include <utility>
 #include <vector>
 
-#include "../module.h"
-#include "../module_msg.pb.h"
 #include "../utils/cuckoo_map.h"
-#include "../utils/ip.h"
+#include "../utils/endian.h"
 #include "../utils/random.h"
+
+// Theory of operation:
+//
+// Definitions:
+// Endpoint = <IPv4 address, port>
+// Forward direction = outbound (internal -> external)
+// Reverse direction = inbound (external -> internal)
+//
+// There is a single hash table of Endpoint -> (Endpoint, timestamp), which
+// contains both forward and reverse mapping. They have the same lifespan.
+// (e.g., if one entry is deleted, its peer is also deleted)
+//
+// Suppose the table is empty, and we see a packet A:a ===> B:b.
+// Then we find a free external endpoint A':a' for the internal endpoint A:a
+// from the pool and create two entries:
+// - entry 1  A:a -> A':a'
+// - entry 2  A':a' -> A:a
+// Then the packet is updated to A':a' ===> B:b (with entry 1).
+// When a return packet B:b ===> A':a' comes in, the destination (since it is
+// reverse dir) endpoint is B:b ===> A:a (with entry 2).
 
 using bess::utils::be16_t;
 using bess::utils::be32_t;
-using bess::utils::Ipv4Prefix;
 
-const uint16_t MIN_PORT = 1024;
-const uint16_t MAX_PORT = 65535;
-const uint64_t TIME_OUT_NS = 120ull * 1000 * 1000 * 1000;
+struct alignas(8) Endpoint {
+  be32_t addr;
+  be16_t port;    // identifier if ICMP
+  uint16_t protocol;
 
-// 5 tuple for TCP/UDP packets with an additional icmp_ident for ICMP query pkts
-class alignas(16) Flow {
- public:
-  be32_t src_ip;
-  be32_t dst_ip;
-  union {
-    be16_t src_port;
-    be16_t icmp_ident;  // identifier of ICMP query
-  };
-  be16_t dst_port;
-  uint32_t proto;  // include 24-bit padding
-
-  Flow() {}
-
-  Flow(be32_t sip, be32_t dip, be16_t sp = be16_t(0), be16_t dp = be16_t(0),
-       uint8_t protocol = 0)
-      : src_ip(sip), dst_ip(dip), src_port(sp), dst_port(dp), proto(protocol) {}
-
-  // Returns a new instance of reserse flow
-  Flow ReverseFlow() const;
-
-  bool operator==(const Flow &other) const {
-    return memcmp(this, &other, sizeof(*this)) == 0;
-  }
-
-  std::string ToString() const;
-};
-
-static_assert(sizeof(Flow) == 16, "Flow must be 16 bytes.");
-
-// Stores flow information
-class FlowRecord {
- public:
-  Flow internal_flow;
-  Flow external_flow;
-  uint64_t time;
-  be16_t port;
-
-  FlowRecord() : internal_flow(), external_flow(), time(), port() {}
-};
-
-// A data structure to track available ports for a given subnet of external IPs
-// for the NAT.  Encapsulates the subnet and the mapping from IPs in that subnet
-// to free ports.
-class AvailablePorts {
- public:
-  // Tracks available ports within the given IP prefix.
-  explicit AvailablePorts(const Ipv4Prefix &prefix)
-      : prefix_(prefix),
-        records_(),
-        free_list_(),
-        next_expiry_(),
-        min_(),
-        max_() {
-    min_ = prefix_.addr.value() & prefix_.mask.value();
-    max_ = prefix_.addr.value() | (~prefix_.mask.value());
-
-    for (uint32_t ip = min_; ip <= max_; ip++) {
-      for (uint32_t port = MIN_PORT; port <= MAX_PORT; port++) {
-        records_.emplace_back();
-        free_list_.emplace_back(be32_t(ip), be16_t((uint16_t)port));
-      }
-    }
-    std::random_shuffle(free_list_.begin(), free_list_.end());
-  }
-
-  // Returns a random free IP/port pair within the network and removes it from
-  // the free list.
-  std::tuple<be32_t, be16_t, FlowRecord *> RandomFreeIPAndPort() {
-    be32_t ip;
-    be16_t port;
-
-    std::tie(ip, port) = free_list_.back();
-    free_list_.pop_back();
-
-    size_t index = (port.value() - MIN_PORT) +
-                   (ip.value() - min_) * (MAX_PORT - MIN_PORT + 1);
-    FlowRecord *record = &records_[index];
-
-    return std::make_tuple(ip, port, record);
-  }
-
-  // Adds the index of given IP/port pair back to the free list.
-  void FreeAllocated(const std::tuple<be32_t, be16_t, FlowRecord *> &a) {
-    free_list_.emplace_back(std::get<0>(a), std::get<1>(a));
-  }
-
-  // Returns true if there are no free remaining IP/port pairs.
-  bool empty() const { return free_list_.empty(); }
-
-  const Ipv4Prefix &prefix() const { return prefix_; }
-
-  uint64_t next_expiry() const { return next_expiry_; }
-
-  void set_next_expiry(uint64_t next_expiry) { next_expiry_ = next_expiry; }
-
- private:
-  Ipv4Prefix prefix_;
-  std::vector<FlowRecord> records_;
-  std::vector<std::pair<be32_t, be16_t>> free_list_;
-  uint64_t next_expiry_;
-  uint32_t min_, max_;
-};
-
-struct FlowHash {
-  std::size_t operator()(const Flow &f) const {
-    const union {
-      Flow flow;
-      uint64_t u64[2];
-    } &bytes = {.flow = f};
-
-    uint32_t init_val = 0;
-#if __SSE4_2__ && __x86_64
-    init_val = crc32c_sse42_u64(bytes.u64[0], init_val);
-    init_val = crc32c_sse42_u64(bytes.u64[1], init_val);
+  struct Hash {
+    std::size_t operator()(const Endpoint &e) const {
+#if __SSE4_2__
+      return crc32c_sse42_u32(
+          static_cast<uint32_t>(e.port.raw_value()) << 16 |
+          e.protocol, e.addr.raw_value());
 #else
-    init_val = rte_hash_crc(&bytes.u64[0], sizeof(uint64_t), init_val);
-    init_val = rte_hash_crc(&bytes.u64[1], sizeof(uint64_t), init_val);
+      return rte_hash_crc(&e, sizeof(uint64_t), 0);
 #endif
-    return init_val;
-  }
+    }
+  };
+
+  struct EqualTo {
+    bool operator()(const Endpoint& lhs, const Endpoint& rhs) const {
+      const union {
+        Endpoint endpoint;
+        uint64_t u64;
+      } &left = {.endpoint = lhs}, &right = {.endpoint = rhs};
+
+      return left.u64 == right.u64;
+    }
+  };
+};
+
+static_assert(sizeof(Endpoint) == sizeof(uint64_t), "Incorrect Endpoint");
+
+// timestamp is only refreshed for forward mappings (rfc4787 REQ-6)
+// NAT mapping entry will NOT expire unless it runs out of ports in the pool.
+struct alignas(16) NatEntry {
+  Endpoint endpoint;
+  uint64_t last_refresh;
 };
 
 // NAT module. 2 igates and 2 ogates
-// igate/ogate 0: traffic from internal network to external network
-// igate/ogate 1: traffic from external network to internal network
+// igate/ogate 0: forward dir
+// igate/ogate 1: reverse dir
 class NAT final : public Module {
  public:
-  static const Commands cmds;
+  enum Direction {
+    kForward = 0,  // internal -> external
+    kReverse = 1,  // external -> internal
+  };
+
   static const gate_idx_t kNumIGates = 2;
   static const gate_idx_t kNumOGates = 2;
 
@@ -160,23 +95,28 @@ class NAT final : public Module {
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
-  CommandResponse CommandAdd(const bess::pb::NATArg &arg);
-  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
+  // returns the number of active NAT entries (flows)
+  std::string GetDesc() const override;
 
  private:
-  void InitRules(const bess::pb::NATArg &arg) {
-    for (const auto &rule : arg.rules()) {
-      Ipv4Prefix int_net(rule.internal_addr_block());
-      Ipv4Prefix ext_net(rule.external_addr_block());
-      rules_.emplace_back(std::piecewise_construct,
-                          std::forward_as_tuple(int_net),
-                          std::forward_as_tuple(ext_net));
-    }
-  }
+  using HashTable = bess::utils::CuckooMap<Endpoint, NatEntry, Endpoint::Hash,
+                                           Endpoint::EqualTo>;
 
-  std::vector<std::pair<Ipv4Prefix, AvailablePorts>> rules_;
-  bess::utils::CuckooMap<Flow, FlowRecord *, FlowHash> flow_hash_;
+  // 5 minutes for entry expiration (rfc4787 REQ-5-c)
+  static const uint64_t kTimeOutNs = 300ull * 1000 * 1000 * 1000;
+
+  // how many times shall we try to find a free port number?
+  static const int kMaxTrials = 128;
+
+  HashTable::Entry *CreateNewEntry(const Endpoint &internal, uint64_t now);
+
+  template <Direction dir>
+  void DoProcessBatch(bess::PacketBatch *batch);
+
+  std::vector<be32_t> ext_addrs_;
+
+  HashTable map_;
   Random rng_;
 };
 
-#endif  // BESS_MODULES_NAT_H_(
+#endif  // BESS_MODULES_NAT_H_

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -22,7 +22,9 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
 
     if (ip->ttl > 1) {
-      ip->checksum = bess::utils::UpdateChecksumWithIncrement(ip->checksum, 1);
+      // N to N-1 and 2 to 1 are identical for checksum purpose
+      // We use constant numbers here for efficiency.
+      ip->checksum = bess::utils::UpdateChecksum16(ip->checksum, 2, 1);
       ip->ttl -= 1;
       out_batch.add(pkt);
     } else {

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -22,11 +22,7 @@ void UpdateTTL::ProcessBatch(bess::PacketBatch *batch) {
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
 
     if (ip->ttl > 1) {
-      // The incremental checksum only cares the difference from old_value to
-      // new_value, so putting 1, 0 than ip->ttl, ip->ttl - 1 offers more
-      // optimization opportunities
-      ip->checksum =
-          bess::utils::CalculateChecksumIncremental16(ip->checksum, 1, 0);
+      ip->checksum = bess::utils::UpdateChecksumWithIncrement(ip->checksum, 1);
       ip->ttl -= 1;
       out_batch.add(pkt);
     } else {

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -171,8 +171,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum16) {
 
   buf[0] = new16;
   uint16_t cksum_new = CalculateGenericChecksum(buf, 10);
-  uint16_t cksum_update =
-      CalculateChecksumIncremental16(cksum_old, old16, new16);
+  uint16_t cksum_update = UpdateChecksum16(cksum_old, old16, new16);
 
   EXPECT_EQ(cksum_new, cksum_update);
 
@@ -185,7 +184,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum16) {
     old16 = buf[0];
     new16 = buf[0] = rd.Get() >> 16;
     cksum_new = CalculateGenericChecksum(buf, 10);
-    cksum_update = CalculateChecksumIncremental16(cksum_old, old16, new16);
+    cksum_update = UpdateChecksum16(cksum_old, old16, new16);
     EXPECT_EQ(cksum_new, cksum_update);
   }
 }
@@ -201,8 +200,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum32) {
 
   buf[0] = new32;
   uint16_t cksum_new = CalculateGenericChecksum(buf, 20);
-  uint16_t cksum_update =
-      CalculateChecksumIncremental32(cksum_old, old32, new32);
+  uint16_t cksum_update = UpdateChecksum32(cksum_old, old32, new32);
 
   EXPECT_EQ(cksum_new, cksum_update);
 
@@ -216,7 +214,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum32) {
     old32 = buf[0];
     new32 = buf[0] = rd.Get();
     cksum_new = CalculateGenericChecksum(buf, 20);
-    cksum_update = CalculateChecksumIncremental32(cksum_old, old32, new32);
+    cksum_update = UpdateChecksum32(cksum_old, old32, new32);
     EXPECT_EQ(cksum_new, cksum_update);
   }
 }
@@ -260,14 +258,14 @@ TEST(ChecksumTest, IncrementalUpdateSrcIpPort) {
       tcp->src_port = be16_t(rd.Get() >> 16);
     }
 
-    ip->checksum = CalculateChecksumIncremental32(
-        ip_cksum_old, src_ip_old.raw_value(), ip->src.raw_value());
+    ip->checksum = UpdateChecksum32(ip_cksum_old, src_ip_old.raw_value(),
+                                    ip->src.raw_value());
     EXPECT_TRUE(VerifyIpv4NoOptChecksum(*ip));
 
-    tcp->checksum = CalculateChecksumIncremental32(
-        tcp_cksum_old, src_ip_old.raw_value(), ip->src.raw_value());
-    tcp->checksum = CalculateChecksumIncremental16(
-        tcp->checksum, src_port_old.raw_value(), tcp->src_port.raw_value());
+    tcp->checksum = UpdateChecksum32(tcp_cksum_old, src_ip_old.raw_value(),
+                                     ip->src.raw_value());
+    tcp->checksum = UpdateChecksum16(tcp->checksum, src_port_old.raw_value(),
+                                     tcp->src_port.raw_value());
     EXPECT_TRUE(VerifyIpv4TcpChecksum(*ip, *tcp));
   }
 }

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -90,11 +90,11 @@ class[[gnu::packed]] BigEndian final : public EndianBase<T> {
     return BigEndian(this->value() - o.value());
   }
 
-  constexpr BigEndian<T> operator<<(unsigned int shift) const {
+  constexpr BigEndian<T> operator<<(size_t shift) const {
     return BigEndian(this->value() << shift);
   }
 
-  constexpr BigEndian<T> operator>>(unsigned int shift) const {
+  constexpr BigEndian<T> operator>>(size_t shift) const {
     return BigEndian(this->value() >> shift);
   }
 

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -114,7 +114,7 @@ class[[gnu::packed]] BigEndian final : public EndianBase<T> {
 
   constexpr bool operator>=(const BigEndian &o) const { return !(*this < o); }
 
-  constexpr operator bool() const { return data_ != 0; }
+  explicit constexpr operator bool() const { return data_ != 0; }
 
   friend std::ostream &operator<<(std::ostream &os, const BigEndian &be) {
     os << "0x" << std::hex << std::setw(sizeof(be) * 2) << std::setfill('0')

--- a/core/utils/endian.h
+++ b/core/utils/endian.h
@@ -104,6 +104,18 @@ class[[gnu::packed]] BigEndian final : public EndianBase<T> {
 
   constexpr bool operator!=(const BigEndian &o) const { return !(*this == o); }
 
+  constexpr bool operator<(const BigEndian &o) const {
+    return this->value() < o.value();
+  }
+
+  constexpr bool operator>(const BigEndian &o) const { return o < *this; }
+
+  constexpr bool operator<=(const BigEndian &o) const { return !(*this > o); }
+
+  constexpr bool operator>=(const BigEndian &o) const { return !(*this < o); }
+
+  constexpr operator bool() const { return data_ != 0; }
+
   friend std::ostream &operator<<(std::ostream &os, const BigEndian &be) {
     os << "0x" << std::hex << std::setw(sizeof(be) * 2) << std::setfill('0')
        << be.value() << std::setfill(' ') << std::dec;

--- a/core/utils/ip.cc
+++ b/core/utils/ip.cc
@@ -20,6 +20,16 @@ bool ParseIpv4Address(const std::string &str, be32_t *addr) {
   return true;
 }
 
+std::string ToIpv4Address(be32_t addr) {
+  const union {
+    be32_t addr;
+    char bytes[4];
+  } &t = {.addr = addr};
+
+  return bess::utils::Format("%hhu.%hhu.%hhu.%hhu", t.bytes[0], t.bytes[1],
+                             t.bytes[2], t.bytes[3]);
+}
+
 Ipv4Prefix::Ipv4Prefix(const std::string &prefix) {
   size_t delim_pos = prefix.find('/');
 

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -11,6 +11,9 @@ namespace utils {
 // return false if string -> be32_t conversion failed (*addr is unmodified)
 bool ParseIpv4Address(const std::string &str, be32_t *addr);
 
+// be32 -> string
+std::string ToIpv4Address(be32_t addr);
+
 // An IPv4 header definition loosely based on the BSD version.
 struct[[gnu::packed]] Ipv4 {
   enum Flag : uint16_t {

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -8,6 +8,22 @@ namespace {
 
 using bess::utils::Ipv4Prefix;
 
+TEST(IPTest, AddressInStr) {
+  be32_t a(192 << 24 | 168 << 16 | 100 << 8 | 199);
+
+  std::string str = ToIpv4Address(a);
+  EXPECT_EQ(str, "192.168.100.199");
+
+  be32_t b;
+  bool ret = ParseIpv4Address(str, &b);
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(a, b);
+
+  EXPECT_FALSE(ParseIpv4Address("hello", &b));
+  EXPECT_FALSE(ParseIpv4Address("1.1.1", &b));
+  EXPECT_FALSE(ParseIpv4Address("1.1.256.1", &b));
+}
+
 // Check if Ipv4Prefix can be correctly constructed from strings
 TEST(IPTest, CIDRInStr) {
   Ipv4Prefix prefix_1("192.168.0.1/24");

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -25,7 +25,7 @@ TEST(IPTest, AddressInStr) {
 }
 
 // Check if Ipv4Prefix can be correctly constructed from strings
-TEST(IPTest, CIDRInStr) {
+TEST(IPTest, PrefixInStr) {
   Ipv4Prefix prefix_1("192.168.0.1/24");
   EXPECT_EQ((192 << 24) + (168 << 16) + 1, prefix_1.addr.value());
   EXPECT_EQ(0xffffff00, prefix_1.mask.value());
@@ -40,7 +40,7 @@ TEST(IPTest, CIDRInStr) {
 }
 
 // Check if Ipv4Prefix::Match() behaves correctly
-TEST(IPTest, CIDRMatch) {
+TEST(IPTest, PrefixMatch) {
   Ipv4Prefix prefix_1("192.168.0.1/24");
   EXPECT_TRUE(prefix_1.Match(be32_t((192 << 24) + (168 << 16) + 254)));
   EXPECT_FALSE(

--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -520,7 +520,7 @@ class BESS(object):
 
     # Deprecated alias for attach_task
     def attach_module(self, *args, **kwargs):
-        return attach_task(self, *args, **kwargs)
+        return self.attach_task(self, *args, **kwargs)
 
     def get_tc_stats(self, name):
         request = bess_msg.GetTcStatsRequest()

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -612,20 +612,18 @@ message MetadataTestArg {
 }
 
 /**
- * The NAT module implements address translation, rewriting packet source addresses
- * for a specified internal prefix with IPs according to a specified
- * external prefix. To see an example
- * of NAT in use, see [`bess/bessctl/conf/samples/nat.bess`](https://github.com/NetSys/bess/blob/master/bessctl/conf/samples/nat.bess)
+ * The NAT module implements IPv4 address/port translation, rewriting packet
+ * source addresses with external addresses as specified. Currently only
+ * supports TCP/UDP/ICMP. Note that address/port in packet payload
+ * (e.g., FTP, SIP, RTSP, etc.) are NOT translated.
+ * To see an example of NAT in use, see:
+ * [`bess/bessctl/conf/samples/nat.bess`](https://github.com/NetSys/bess/blob/master/bessctl/conf/samples/nat.bess)
  *
  * __Input Gates__: 2
  * __Output Gates__: 2
  */
 message NATArg {
-  message Rule {
-    string internal_addr_block = 1; /// Internal IP block in CIDR.
-    string external_addr_block = 2; /// External IP block in CIDR.
-  }
-  repeated Rule rules = 1; /// A list of rules for rewriting
+  repeated string ext_addrs = 1; /// list of external IP addresses
 }
 
 /**


### PR DESCRIPTION
This PR revamps the NAT module, with the following changes:
* More compliant to the standards. Most importantly, the new module performs [Endpoint-Independent Mapping](https://tools.ietf.org/html/rfc4787#section-4.1), which is required for NAT hole punching.
* The memory footprint has been reduced (total 64 bytes/entry; used to be 128 bytes/entry) and only proportional to the number of concurrent connections. It doesn't not maintain the list of free IP/port pairs any longer; using a large external IP address pool won't increase memory usage.
* The garbage collection phase has been eliminated. The module won't stop entirely even if IP/port pairs run out.
* Performance improvement (below)

### Local test (unidirectional)
All numbers are in Mpps.

Flows | New | Old
--------- | ----- | ----
1 | 43.8 | 27.2 |
16 | 29.2 | 20.2 |
256 | 30.1 | 20.7 |
4096 | 24.7 | 15.6 |
65536 | 19.4 | 13.2 |

### Local test (bidirectional)
For actual pps, multiple these numbers by 2

Flows | New | Old
--------- | ----- | ----
1 | 23.1 | 13.8 |
16 | 16.7 | 9.9 |
256 | 15.4 | 10.4 |
4096 | 12.6 | 7.7 |
65536 | 9.3 | 6.8 |

### With i40e NICs
Flows | New | Old
--------- | ----- | ----
1 | 16.2 | 12.9 |
16 | 13.8 | 11.3 |
256 | 13.0 | 10.0 |
4096 | 12.2 | 7.1 |
65536 | 11.6 | 6.6 |
1048576 | 6.2 | 3.8 |
