### PR TITLE
Check module exists before applying tcpdump

### DIFF
--- a/libbess-python/bess.py
+++ b/libbess-python/bess.py
@@ -398,6 +398,9 @@ class BESS(object):
         return self._request('ConfigureGateHook', request)
 
     def tcpdump(self, enable, m, direction='out', gate=0, fifo=None):
+        # Verify the module exists, otherwise raise exception
+        self.get_module_info(m)
+
         arg = bess_msg.TcpdumpArg()
         if fifo is not None:
             arg.fifo = fifo


### PR DESCRIPTION
#493 
This patch verify that the module name exists before
applying tcpdump command from python SDK.