### PR TITLE
Fix segmentation on gate hook configure for invalid module name

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1326,8 +1326,8 @@ class BESSControlImpl final : public BESSControl::Service {
     // Install this hook on the specified module
     const auto& it = ModuleBuilder::all_modules().find(request->module_name());
     if (it == ModuleBuilder::all_modules().end()) {
-      *response = CommandFailure(ENOENT, "No module '%s' found",
-                                 request->module_name().c_str());
+      return return_with_error(response, ENOENT, "No module '%s' found",
+                               request->module_name().c_str());
     }
     if (request->enable()) {
       *response =


### PR DESCRIPTION
Since there was no return in the code, the method would continue
to the next line and segment as the module doesnt exists.
This change return the error in case the module is not found.
#493  
