### PR TITLE
Compare output packets based on strings rather than scapy comparator

### DIFF
--- a/bessctl/conf/testing/module_tests/acl.py
+++ b/bessctl/conf/testing/module_tests/acl.py
@@ -82,14 +82,14 @@ def my_bonus_acl_test():
                       'drop': False}])
     src = Source()
     rwtemp = [
-        gen_packet(
+        str(gen_packet(
             scapy.UDP,
             "172.12.0.3",
-            "127.12.0.4"),
-        gen_packet(
+            "127.12.0.4")),
+        str(gen_packet(
             scapy.TCP,
             "192.168.32.4",
-            "1.2.3.4")]
+            "1.2.3.4"))]
     src -> Rewrite(templates=rwtemp) -> fw5 -> Sink()
     bess.resume_all()
     time.sleep(15)

--- a/bessctl/conf/testing/module_tests/drr.py
+++ b/bessctl/conf/testing/module_tests/drr.py
@@ -50,7 +50,7 @@ def fairness_test():
         packets = []
         exm = ExactMatch(fields=[{'offset':26, 'size':4}])
         for i in range(1, n+1):
-           packets.append(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i))) 
+           packets.append(str(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i)))) 
            exm.add(fields=[socket.inet_aton('22.11.11.' + str(i))], gate=i)
 
         me_in = Measure()

--- a/bessctl/conf/testing/module_tests/random_drop.py
+++ b/bessctl/conf/testing/module_tests/random_drop.py
@@ -23,14 +23,14 @@ def create_drop_test(rate):
         src = Source()
         rd2 = RandomDrop(drop_rate=rate)
         rwtemp = [
-            gen_packet(
+            str(gen_packet(
                 scapy.UDP,
                 "172.12.0.3",
-                "127.12.0.4"),
-            gen_packet(
+                "127.12.0.4")),
+            str(gen_packet(
                 scapy.TCP,
                 "192.168.32.4",
-                "1.2.3.4")]
+                "1.2.3.4"))]
         a = Measure()
         b = Measure()
         src -> b -> Rewrite(templates=rwtemp) -> rd2 -> a -> Sink()

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -43,9 +43,9 @@ def gen_packet(proto, src_ip, dst_ip, ip_ttl=64):
 
 
 def pkt_str(pkt):
-    if(pkt is None):
+    if pkt is None:
         return "None"
-    elif(issubclass(type(pkt), scapy.Packet)):
+    elif issubclass(type(pkt), scapy.Packet):
         return pkt.summary() + " " + str(pkt).encode("HEX")
     else:
         return str(pkt).encode("HEX")
@@ -139,9 +139,9 @@ def run_tests():
                     input_ports.append(PortInc(port=sockname))
                     output_ports.append(PortOut(port=sockname))
                     sockets.append(mysocket)
-                    if (port_num < input_port_cnt):
+                    if port_num < input_port_cnt:
                         input_ports[port_num] -> port_num:module
-                    if (port_num < output_port_cnt):
+                    if port_num < output_port_cnt:
                         module:port_num -> output_ports[port_num]
 
                 bess.resume_all()
@@ -151,7 +151,7 @@ def run_tests():
                     output_port = test_case["output_port"]
                     input_pkt = test_case["input_packet"]
                     output_pkt = test_case["output_packet"]
-                    if(input_pkt is not None):
+                    if input_pkt is not None:
                         sockets[input_port].send(str(input_pkt))
 
                     try:
@@ -163,7 +163,7 @@ def run_tests():
                     except socket.timeout:
                         return_pkt = "None"
 
-                    if(not (str(return_pkt) == str(output_pkt))):
+                    if not (str(return_pkt) == str(output_pkt)):
                         sys.stderr.write("Output test failed!\n")
                         sys.stderr.write("Input packet: %s" %
                                          pkt_str(input_pkt) + "\n")
@@ -212,6 +212,6 @@ def run_tests():
 
 
 # Call our big test function.
-if(not run_tests()):
+if not run_tests():
     print("Some tests failed. :(")
     sys.exit(1)

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -37,7 +37,7 @@ def gen_packet(proto, src_ip, dst_ip, ip_ttl=64):
     udp = proto(sport=10001, dport=10002)
     payload = 'helloworld'
     pkt = eth / ip / udp / payload
-    return str(pkt)
+    return pkt
 
 # Quick turn a packet into a string even if it is None
 
@@ -52,12 +52,12 @@ def pkt_str(pkt):
 
 # These are just for the crash test
 crash_test_packets = [
-    gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
-    gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78'),
-    gen_packet(scapy.UDP, '172.12.55.99', '10.0.0.1'),
-    gen_packet(scapy.UDP, '172.16.100.1', '12.34.56.78'),
-    gen_packet(scapy.TCP, '172.12.55.99', '12.34.56.78'),
-    gen_packet(scapy.UDP, '192.168.1.123', '12.34.56.78')
+    str(gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1')),
+    str(gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78')),
+    str(gen_packet(scapy.UDP, '172.12.55.99', '10.0.0.1')),
+    str(gen_packet(scapy.UDP, '172.16.100.1', '12.34.56.78')),
+    str(gen_packet(scapy.TCP, '172.12.55.99', '12.34.56.78')),
+    str(gen_packet(scapy.UDP, '192.168.1.123', '12.34.56.78'))
 ]
 
 ## TEST FUNCTIONS ##
@@ -155,24 +155,21 @@ def run_tests():
 
                     try:
                         return_data = sockets[output_port].recv(2048)
+                        try:
+                            return_pkt = scapy.Ether(return_data)
+                        except:
+                            return_pkt = return_data
                     except socket.timeout:
-                        return_data = None
+                        return_pkt = "None"
 
-                    try:
-                        return_pkt = scapy.Ether(return_data)
-                    except:
-                        return_pkt = return_data
-
-                    if(not str(return_pkt) == str(output_pkt)):
-                        sys.stderr.write("Test failed!\n")
+                    if(not (str(return_pkt) == str(output_pkt))):
+                        sys.stderr.write("Output test failed!\n")
                         sys.stderr.write("Input packet: %s" %
                                          pkt_str(input_pkt) + "\n")
                         sys.stderr.write(
                             "Expected: %s" %
                             pkt_str(output_pkt) + "\n")
-                        sys.stderr.write("Received: %s" % pkt_str(return_pkt) + "\n")
-                        for sock in sockets:
-                            sock.close()
+                        sys.stderr.write("Received: %s" % pkt_str(return_pkt) + " " + str(output_pkt) + "\n")
                         DID_TESTS_FAIL = True
                         print("   %s output test %s: FAIL" %
                             (str(module), str(output_testid)))

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -50,6 +50,7 @@ def pkt_str(pkt):
     else:
         return str(pkt).encode("HEX")
 
+
 # These are just for the crash test
 crash_test_packets = [
     str(gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1')),
@@ -97,7 +98,7 @@ def monitor_task(module, wid):
 ## RUN TEST LOOP ##
 def run_tests():
     DID_TESTS_FAIL = False
- 
+
     path = os.path.dirname(os.path.realpath(sys.argv[0]))
     for filename in glob.glob(path + "/conf/testing/module_tests/*.py"):
         bess.reset_all()
@@ -169,13 +170,14 @@ def run_tests():
                         sys.stderr.write(
                             "Expected: %s" %
                             pkt_str(output_pkt) + "\n")
-                        sys.stderr.write("Received: %s" % pkt_str(return_pkt) + " " + str(output_pkt) + "\n")
+                        sys.stderr.write("Received: %s" % pkt_str(
+                            return_pkt) + " " + str(output_pkt) + "\n")
                         DID_TESTS_FAIL = True
                         print("   %s output test %s: FAIL" %
-                            (str(module), str(output_testid)))
+                              (str(module), str(output_testid)))
                     else:
                         print("   %s output test %s: PASS" %
-                            (str(module), str(output_testid)))
+                              (str(module), str(output_testid)))
                     output_testid += 1
             except BaseException:
                 print("   %s output test %s: FAIL" %
@@ -208,7 +210,8 @@ def run_tests():
     bess.reset_all()
     return not DID_TESTS_FAIL
 
-#Call our big test function.
+
+# Call our big test function.
 if(not run_tests()):
     print("Some tests failed. :(")
     sys.exit(1)

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -45,6 +45,8 @@ def gen_packet(proto, src_ip, dst_ip, ip_ttl=64):
 def pkt_str(pkt):
     if(pkt is None):
         return "None"
+    elif(type(pkt) is scapy.Packet):
+        return pkt.summary() + " " + str(pkt).encode("HEX")
     else:
         return str(pkt).encode("HEX")
 

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -45,7 +45,7 @@ def gen_packet(proto, src_ip, dst_ip, ip_ttl=64):
 def pkt_str(pkt):
     if(pkt is None):
         return "None"
-    elif(type(pkt) is scapy.Packet):
+    elif(issubclass(type(pkt), scapy.Packet)):
         return pkt.summary() + " " + str(pkt).encode("HEX")
     else:
         return str(pkt).encode("HEX")
@@ -152,12 +152,18 @@ def run_tests():
                     output_pkt = test_case["output_packet"]
                     if(input_pkt is not None):
                         sockets[input_port].send(str(input_pkt))
+
                     try:
-                        return_pkt = scapy.Ether(sockets[output_port].recv(2048))
+                        return_data = sockets[output_port].recv(2048)
                     except socket.timeout:
-                        return_pkt = None
-                    if(not ((return_pkt is None and output_pkt is None) or
-                            (str(return_pkt) == str(output_pkt)))):
+                        return_data = None
+
+                    try:
+                        return_pkt = scapy.Ether(return_data)
+                    except:
+                        return_pkt = return_data
+
+                    if(not str(return_pkt) == str(output_pkt)):
                         sys.stderr.write("Test failed!\n")
                         sys.stderr.write("Input packet: %s" %
                                          pkt_str(input_pkt) + "\n")

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -46,7 +46,7 @@ def pkt_str(pkt):
     if(pkt is None):
         return "None"
     else:
-        return pkt.summary()
+        return str(pkt).encode("HEX")
 
 # These are just for the crash test
 crash_test_packets = [
@@ -156,14 +156,13 @@ def run_tests():
                         return_pkt = None
                     if(not ((return_pkt is None and output_pkt is None) or
                             (str(return_pkt) == str(output_pkt)))):
-                        sys.stderr.write("Test failed!")
+                        sys.stderr.write("Test failed!\n")
                         sys.stderr.write("Input packet: %s" %
-                                         pkt_str(scapy.Ether(input_pkt)))
+                                         pkt_str(input_pkt) + "\n")
                         sys.stderr.write(
                             "Expected: %s" %
-                            pkt_str(
-                                scapy.Ether(output_pkt)))
-                        sys.stderr.write("Received: %s" % pkt_str(return_pkt))
+                            pkt_str(output_pkt) + "\n")
+                        sys.stderr.write("Received: %s" % pkt_str(return_pkt) + "\n")
                         for sock in sockets:
                             sock.close()
                         DID_TESTS_FAIL = True

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -155,7 +155,7 @@ def run_tests():
                     except socket.timeout:
                         return_pkt = None
                     if(not ((return_pkt is None and output_pkt is None) or
-                            (return_pkt == scapy.Ether(output_pkt)))):
+                            (str(return_pkt) == str(output_pkt)))):
                         sys.stderr.write("Test failed!")
                         sys.stderr.write("Input packet: %s" %
                                          pkt_str(scapy.Ether(input_pkt)))


### PR DESCRIPTION
Not all packets coming out of the Unix socket will be Ethernet, and (for research and experimental uses) may not even be protocols scapy knows how to parse! Better to compare based on bytestrings to avoid the dependency on scapy knowing what protocol it's looking at.