### PR TITLE
Python 2/3 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 install:
   - sudo apt-get install -y python2.7 python3 python3-pip
   - pip2 install grpcio scapy codecov
-  - pip3 install grpcio coverage
+  - pip3 install grpcio scapy-python3 coverage
   - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y g++-5"  # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"
@@ -53,7 +53,8 @@ script:
   - (cd core && ./all_test)  # TcpFlowReconstructTest requires working directory to be `core/`
   - coverage2 run -m unittest discover -v
   - coverage3 run -m unittest discover -v
-  - bessctl/bessctl -- daemon start -- run testing/run_module_tests
+  - python2 bessctl/bessctl -- daemon start -- run testing/run_module_tests
+  - python3 bessctl/bessctl -- daemon start -- run testing/run_module_tests
 
 after_success:
   - bessctl/bessctl daemon stop # flush out the coverage data

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ script:
   - ./container_build.py kmod_buildtest
   - (cd core && ./all_test)  # TcpFlowReconstructTest requires working directory to be `core/`
   - coverage2 run -m unittest discover -v
-  - coverage3 run -m unittest discover -v
+  - "[[ ${DEBUG:-0} == 0 ]] || coverage3 run -m unittest discover -v"
   - python2 bessctl/bessctl -- daemon start -- run testing/run_module_tests
-  - python3 bessctl/bessctl -- daemon start -- run testing/run_module_tests
+  - "[[ ${DEBUG:-0} == 0 ]] || python3 bessctl/bessctl -- daemon start -- run testing/run_module_tests"
 
 after_success:
   - bessctl/bessctl daemon stop # flush out the coverage data

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_install:
   - sudo apt-get -q update
 
 install:
-  - sudo apt-get install -y python python3 python3-pip
-  - pip install grpcio scapy codecov
+  - sudo apt-get install -y python2.7 python3 python3-pip
+  - pip2 install grpcio scapy codecov
   - pip3 install grpcio coverage
   - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y g++-5"  # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ before_install:
   - sudo apt-get -q update
 
 install:
-  - sudo apt-get install -y python
+  - sudo apt-get install -y python python3 python3-pip
   - pip install grpcio scapy codecov
+  - pip3 install grpcio coverage
   - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y g++-5"  # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"
@@ -50,7 +51,8 @@ script:
   - ./container_build.py bess
   - ./container_build.py kmod_buildtest
   - (cd core && ./all_test)  # TcpFlowReconstructTest requires working directory to be `core/`
-  - coverage run -m unittest discover -v
+  - coverage2 run -m unittest discover -v
+  - coverage3 run -m unittest discover -v
   - bessctl/bessctl -- daemon start -- run testing/run_module_tests
 
 after_success:

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 from __future__ import print_function
 from __future__ import absolute_import
 import sys

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -142,14 +142,13 @@ def main():
         line_buf = []
 
         for arg in sys.argv[1:]:
-            arg = arg.decode()
             if arg == '--':
                 cmds.append(' '.join(line_buf))
                 line_buf = []
             else:
                 line_buf.append(arg)
 
-        cmds.append(' '.join(line_buf))
+        cmds.append(u' '.join(line_buf))
         run_cli(io.StringIO('\n'.join(cmds)))
 
 if __name__ == '__main__':

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -1,24 +1,25 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 import os
 import os.path
-import cStringIO
+import io
 import tempfile
 import time
+import cli
+import commands
 
 # Suppress scapy IPv6 warning (must be done before importing scapy module)
 import logging
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-
-import cli
-import commands
 
 try:
     this_dir = os.path.dirname(os.path.realpath(__file__))
     sys.path.insert(1, os.path.join(this_dir, '..'))
     from pybess.bess import *
 except ImportError:
-    print >> sys.stderr, 'Cannot import the API module (pybess)'
+    print('Cannot import the API module (pybess)', file=sys.stderr)
     raise
 
 
@@ -141,6 +142,7 @@ def main():
         line_buf = []
 
         for arg in sys.argv[1:]:
+            arg = arg.decode()
             if arg == '--':
                 cmds.append(' '.join(line_buf))
                 line_buf = []
@@ -148,7 +150,7 @@ def main():
                 line_buf.append(arg)
 
         cmds.append(' '.join(line_buf))
-        run_cli(cStringIO.StringIO('\n'.join(cmds)))
+        run_cli(io.StringIO('\n'.join(cmds)))
 
 if __name__ == '__main__':
     main()

--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -69,7 +69,7 @@ class BESSCLI(cli.CLI):
 
         except self.bess.RPCError as e:
             self.err('RPC failed to {}:{} - {}'.format(
-                self.bess.peer[0], self.bess.peer[1], e.message))
+                self.bess.peer[0], self.bess.peer[1], str(e)))
 
             self._handle_broken_connection()
             raise self.HandledError()
@@ -121,7 +121,7 @@ def run_cli(instream=sys.stdin):
         s.connect()
     except BESS.APIError as e:
         if cli.interactive:
-            cli.ferr.write(e.message + '\n')
+            cli.ferr.write(str(e) + '\n')
             cli.ferr.write('Perhaps bessd daemon is not running locally? '
                            'Try "daemon start".\n')
 

--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -370,7 +370,7 @@ class CLI(object):
 
     def process_one_line(self):
         if self.interactive:
-            try:    # Hack for Python 2/3 compatibi
+            try:    # Hack for Python 2/3 compatibility
                 input = raw_input
             except NameError:
                 pass

--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -198,7 +198,7 @@ class CLI(object):
         if len(matched_list) == 0:
             return [], []
 
-        max_score = max(map(lambda x: x[1], matched_list))
+        max_score = max([x[1] for x in matched_list])
 
         ret = []
         ret_low = []
@@ -370,8 +370,12 @@ class CLI(object):
 
     def process_one_line(self):
         if self.interactive:
+            try:    # Hack for Python 2/3 compatibi
+                input = raw_input
+            except NameError:
+                pass
             try:
-                line = raw_input(self.get_prompt())
+                line = input(self.get_prompt())
             except KeyboardInterrupt:
                 self.fout.write('\n')
                 return

--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -370,12 +370,12 @@ class CLI(object):
 
     def process_one_line(self):
         if self.interactive:
-            try:    # Hack for Python 2/3 compatibility
-                input = raw_input
-            except NameError:
-                pass
             try:
-                line = input(self.get_prompt())
+                # Hack for Python 2/3 compatibility
+                if hasattr(__builtins__, 'raw_input'):
+                    line = raw_input(self.get_prompt())
+                else:
+                    line = input(self.get_prompt())
             except KeyboardInterrupt:
                 self.fout.write('\n')
                 return

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1692,7 +1692,7 @@ def tcpdump_module(cli, module_name, direction, gate, opts):
         direction = 'out'
 
     fifo = tempfile.mktemp()
-    os.mkfifo(fifo, 0600)   # random people should not see packets...
+    os.mkfifo(fifo, 0o600)   # random people should not see packets...
 
     fd = os.open(fifo, os.O_RDWR)
 

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -545,13 +545,13 @@ def warn(cli, msg, func, *args):
         if cli.rl:
             cli.rl.set_completer(cli.complete_dummy)
 
-        try:    # Hack for compatibility
-            input = raw_input
-        except NameError:
-            pass
-
         try:
-            resp = input('WARNING: %s Are you sure? (type "yes") ' % msg)
+            # Hack for Python 2/3 compatibility
+            if hasattr(__builtins__, 'raw_input'):
+                resp = raw_input(
+                    'WARNING: %s Are you sure? (type "yes") ' % msg)
+            else:
+                resp = input('WARNING: %s Are you sure? (type "yes") ' % msg)
 
             if resp.strip() == 'yes':
                 func(cli, *args)

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import os.path
 import sys
@@ -15,7 +17,6 @@ import traceback
 import tempfile
 import signal
 import collections
-
 import sugar
 
 try:
@@ -24,7 +25,7 @@ try:
     from pybess.module import *
     from pybess.port import *
 except ImportError:
-    print >> sys.stderr, 'Cannot import the API module (pybess)'
+    print('Cannot import the API module (pybess)', file=sys.stderr)
     raise
 
 
@@ -62,8 +63,8 @@ def __bess_env__(key, default=None):
         if default is None:
             raise ConfError('Environment variable "%s" must be set.')
 
-        print 'Environment variable "%s" is not set. \
-            Using default value "%s"' % (key, default)
+        print('Environment variable "%s" is not set. \
+              Using default value "%s"' % (key, default))
         return default
 
 
@@ -544,8 +545,13 @@ def warn(cli, msg, func, *args):
         if cli.rl:
             cli.rl.set_completer(cli.complete_dummy)
 
+        try:    # Hack for compatibility
+            input = raw_input
+        except NameError:
+            pass
+
         try:
-            resp = raw_input('WARNING: %s Are you sure? (type "yes") ' % msg)
+            resp = input('WARNING: %s Are you sure? (type "yes") ' % msg)
 
             if resp.strip() == 'yes':
                 func(cli, *args)
@@ -742,13 +748,13 @@ def _run_file(cli, conf_file, env_map):
         try:
             original_env = copy.copy(os.environ)
 
-            for k, v in env_map.iteritems():
+            for k, v in env_map.items():
                 os.environ[k] = str(v)
 
             _do_run_file(cli, conf_file)
         finally:
             os.environ.clear()
-            for k, v in original_env.iteritems():
+            for k, v in original_env.items():
                 os.environ[k] = v
     else:
         _do_run_file(cli, conf_file)
@@ -933,7 +939,7 @@ def _limit_to_str(limit):
 
 def _burst_to_str(burst):
     # no output if max_burst is not set
-    if len(burst.values()) == 0 or burst.values()[0] == 0:
+    if len(burst) == 0 or list(burst.values())[0] == 0:
         return ''
 
     if 'count' in burst:
@@ -1044,10 +1050,10 @@ def check_constraints(cli):
 
 
 def _show_tc_list(cli, tcs):
-    wids = sorted(list(set(map(lambda tc: getattr(tc, 'class').wid, tcs))))
+    wids = sorted(list(set([getattr(tc, 'class').wid for tc in tcs])))
 
     for wid in wids:
-        matched = filter(lambda tc: getattr(tc, 'class').wid == wid, tcs)
+        matched = [tc for tc in tcs if getattr(tc, 'class').wid == wid]
 
         root = _build_tcs_tree(matched)
         if wid == -1:
@@ -1151,7 +1157,7 @@ def _draw_pipeline(cli, field, units, last_stats=None):
                              stderr=subprocess.PIPE)
 
         for m in modules:
-            print >> f.stdin, '[%s]' % node_labels[m.name]
+            print('[%s]' % node_labels[m.name], file=f.stdin)
 
         for name in names:
             gates = cli.bess.get_module_info(name).ogates
@@ -1178,10 +1184,10 @@ def _draw_pipeline(cli, field, units, last_stats=None):
                 edge_attr = '{label::%d  %s %s %d:;}' % (
                     gate.ogate, label, units, gate.igate)
 
-                print >> f.stdin, '[%s] ->%s [%s]' % (
+                print('[%s] ->%s [%s]' % (
                     node_labels[name],
                     edge_attr,
-                    node_labels[gate.name])
+                    node_labels[gate.name]), file=f.stdin)
         output, error = f.communicate()
         f.wait()
         return output
@@ -1558,8 +1564,8 @@ def _monitor_ports(cli, *ports):
 
             if len(ports) > 1:
                 print_delta('Total', get_delta(
-                    get_total(last.values()),
-                    get_total(now.values())))
+                    get_total(list(last.values())),
+                    get_total(list(now.values()))))
 
             for port in ports:
                 last[port] = now[port]

--- a/bessctl/conf/metadata/attr_match.bess
+++ b/bessctl/conf/metadata/attr_match.bess
@@ -19,5 +19,5 @@ em:1 -> Sink()
 em:2 -> Sink()
 
 # NOTE: metadata attribute values are stored in host order (little endian)!
-em.add(fields=['\xcc', '\x22\x11'], gate=1)
-em.add(fields=['\x42', '\x33\x44'], gate=2)
+em.add(fields=[b'\xcc', b'\x22\x11'], gate=1)
+em.add(fields=[b'\x42', b'\x33\x44'], gate=2)

--- a/bessctl/conf/perftest/bpf.bess
+++ b/bessctl/conf/perftest/bpf.bess
@@ -10,7 +10,7 @@ bpf:2 -> Sink()      # for matched packets (by the second filter)
 
 def run_testcase(exps, test_pkts):
     rewrite.clear()
-    rewrite.add(templates=map(lambda x: str(x), test_pkts))
+    rewrite.add(templates=map(lambda x: bytes(x), test_pkts))
 
     # the higher number, the higher priority.
     bpf.clear()

--- a/bessctl/conf/perftest/bpf.bess
+++ b/bessctl/conf/perftest/bpf.bess
@@ -34,10 +34,10 @@ def run_testcase(exps, test_pkts):
 
     pps_total = pps_matched + pps_unmatched
 
-    print 'Total: %8.3fMpps   Matched: %8.3fMpps   Unmatched: %8.3fMpps' %  \
-            (pps_total / 1000000.0,
-             pps_matched / 1000000.0,
-             pps_unmatched / 1000000.0)
+    print('Total: %8.3fMpps   Matched: %8.3fMpps   Unmatched: %8.3fMpps' %
+          (pps_total / 1000000.0,
+           pps_matched / 1000000.0,
+           pps_unmatched / 1000000.0))
 
     bess.pause_all()
 
@@ -62,11 +62,11 @@ testcases = [
 ]
 
 for i, case in enumerate(testcases):
-    print
-    print 'Testcase %d: %s' % (i, ', '.join(case[0]))
+    print()
+    print('Testcase %d: %s' % (i, ', '.join(case[0])))
     pprint.pprint(case[1])
 
 print
 for i, case in enumerate(testcases):
-    print 'Testcase %d:\t\t' % i,
+    print('Testcase %d:\t\t' % i, end=' ')
     run_testcase(*case)

--- a/bessctl/conf/perftest/flowgen.bess
+++ b/bessctl/conf/perftest/flowgen.bess
@@ -23,7 +23,7 @@ ip = scapy.IP(src=src_ip, dst=dst_ip)
 src_port = int($BESS_SRC_PORT!'10001')
 tcp = scapy.TCP(sport=src_port, dport=12345, seq=12345)
 payload = "BESS is the Queen of Packet Processing."
-pkt_template = str(eth/ip/tcp/payload)
+pkt_template = bytes(eth/ip/tcp/payload)
 
 # This script is multi threaded but connects to a single port.
 myport = PMDPort(port_id=0, num_inc_q=num_cores, num_out_q=num_cores)
@@ -49,7 +49,7 @@ while True:
     portstats = myport.get_port_stats().inc.packets
     delta = portstats - prev_portstats
     nextround = max(1e6, 1.1 * delta / sleeptime)
-    print("Received " + str(delta / sleeptime) + " pps. Ramping up to: " + str(nextround))
+    print("Received " + bytes(delta / sleeptime) + " pps. Ramping up to: " + bytes(nextround))
     for wid, pkt_src in flowgens.items():
         bess.pause_worker(wid)
         pkt_src.update(pps = nextround / num_cores)

--- a/bessctl/conf/perftest/loopback_vport.bess
+++ b/bessctl/conf/perftest/loopback_vport.bess
@@ -39,32 +39,32 @@ def measure():
                     old_stats[i].inc.packets
         inc_mpps.append(pkts_diff / time_diff / 1000000.0)
 
-    print '%-15s' % 'CPU',
-    print '%7s' % '',
+    print('%-15s' % 'CPU', end=' ')
+    print('%7s' % '', end=' ')
     for i in range(len(ports)):
-        print '%7d' % cpu_set[i],
+        print('%7d' % cpu_set[i], end=' ')
     print
 
-    print '%-15s' % 'Ports',
-    print '%7s' % '(total)',
+    print('%-15s' % 'Ports', end=' ')
+    print('%7s' % '(total)', end=' ')
     for i in range(len(ports)):
-        print '%7s' % ports[i].name,
-    print
+        print('%7s' % ports[i].name, end=' ')
+    print()
 
-    print '-' * (8 * (len(ports) + 3))
+    print('-' * (8 * (len(ports) + 3)))
 
-    print '%-15s' % 'Outgoing (Mpps)',
-    print '%7.3f' % sum(out_mpps),
+    print('%-15s' % 'Outgoing (Mpps)', end=' ')
+    print('%7.3f' % sum(out_mpps), end=' ')
     for i in range(len(ports)):
-        print '%7.3f' % out_mpps[i],
-    print
+        print('%7.3f' % out_mpps[i], end=' ')
+    print()
 
-    print '%-15s' % 'Incoming (Mpps)',
-    print '%7.3f' % sum(inc_mpps),
+    print('%-15s' % 'Incoming (Mpps)', end=' ')
+    print('%7.3f' % sum(inc_mpps), end=' ')
     for i in range(len(ports)):
-        print '%7.3f' % inc_mpps[i],
-    print
-    print
+        print('%7.3f' % inc_mpps[i], end=' ')
+    print()
+    print()
 
 for cpu in range(CORE_START, CORE_END, CORE_STEP):
     v = VPort(loopback=1, rxq_cpus=[cpu])

--- a/bessctl/conf/perftest/nat.bess
+++ b/bessctl/conf/perftest/nat.bess
@@ -10,7 +10,7 @@ eth = scapy.Ether(src='02:1e:67:9f:4d:ac', dst='06:16:3e:1b:72:32')
 ip = scapy.IP(src='10.0.0.1', dst='192.168.1.1')
 udp = scapy.UDP(sport=10001, dport=10002)
 payload = 'helloworld'
-pkt_bytes = str(eth/ip/udp/payload)
+pkt_bytes = bytes(eth/ip/udp/payload)
 
 Source() \
     -> Rewrite(templates=[pkt_bytes]) \

--- a/bessctl/conf/perftest/pktgen.bess
+++ b/bessctl/conf/perftest/pktgen.bess
@@ -21,7 +21,7 @@ def build_pkt(size):
     payload = ('hello' + '0123456789' * 200)[:size-len(eth/ip/udp)]
     pkt = eth/ip/udp/payload
     pkt.show()
-    return str(pkt)
+    return bytes(pkt)
 
 if imix:
     # https://en.wikipedia.org/wiki/Internet_Mix
@@ -45,7 +45,7 @@ ports = [PMDPort(port_id=i, num_inc_q=num_cores, num_out_q=num_cores) \
          for i in range(num_ports)]
 
 for i in range(num_cores):
-    print("starting up worker: " + str(i))
+    print("starting up worker: " + bytes(i))
     bess.add_worker(wid=i, core=i)
 
     src = Source()

--- a/bessctl/conf/perftest/vport_scaling.bess
+++ b/bessctl/conf/perftest/vport_scaling.bess
@@ -7,7 +7,7 @@ for i in xrange(1, NUM_PORTS + 1):
     try:
         vport = VPort(loopback=1)
     except:
-        print 'FAILURE: %d vports has been initialized' % (i - 1)
+        print('FAILURE: %d vports has been initialized' % (i - 1))
         raise
 
     sys.stdout.write('.')
@@ -18,4 +18,4 @@ for i in xrange(1, NUM_PORTS + 1):
 
     time.sleep(1.0 / i)
 else:
-    print 'SUCCESS: %d vports has been successfully initialized' % NUM_PORTS
+    print('SUCCESS: %d vports has been successfully initialized' % NUM_PORTS)

--- a/bessctl/conf/port/latency.bess
+++ b/bessctl/conf/port/latency.bess
@@ -27,7 +27,7 @@ while True:
     else:
         ns_per_packet = 0
 
-    print '%s: %.3f Mpps, %.3f Mbps, rtt_avg: %.3f us, rtt_med: %.3f us, '\
+    print('%s: %.3f Mpps, %.3f Mbps, rtt_avg: %.3f us, rtt_med: %.3f us, '\
           'rtt_99th: %.3f us, jitter_med: %.3f us, jitter_99th: %.3f us' % \
             (time.ctime(now.timestamp),
              diff_pkts / 1e6,
@@ -36,4 +36,4 @@ while True:
              last.latency_50_ns / 1e3,
              last.latency_99_ns / 1e3,
              last.jitter_50_ns / 1e3,
-             last.jitter_99_ns / 1e3)
+             last.jitter_99_ns / 1e3))

--- a/bessctl/conf/port/loopback.bess
+++ b/bessctl/conf/port/loopback.bess
@@ -1,9 +1,9 @@
 dpdk_ports = int($BESS_PORTS!'1')
 qsize = int($BESS_QSIZE!'128')
 
-print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
-print 'RX/TX queue size: %d packets per queue' % qsize
-print 'NOTE: not all DPDK ports support lookback mode'
+print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
+print('RX/TX queue size: %d packets per queue' % qsize)
+print('NOTE: not all DPDK ports support lookback mode')
 
 for i in range(dpdk_ports):
 		p = PMDPort(port_id=i, loopback=1, size_inc_q=qsize, size_out_q=qsize)

--- a/bessctl/conf/port/loopback_vport.bess
+++ b/bessctl/conf/port/loopback_vport.bess
@@ -1,6 +1,6 @@
 num_ports = int($BESS_PORTS!'1')
 
-print 'Using %d virtual ports... (envvar "BESS_PORTS")' % num_ports
+print('Using %d virtual ports... (envvar "BESS_PORTS")' % num_ports)
 
 for i in range(num_ports):
 	v = VPort(loopback=True)

--- a/bessctl/conf/port/macswap.bess
+++ b/bessctl/conf/port/macswap.bess
@@ -1,5 +1,5 @@
 dpdk_ports = int($BESS_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
+print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/port/p2s.bess
+++ b/bessctl/conf/port/p2s.bess
@@ -1,5 +1,5 @@
 dpdk_ports = int($BESS_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
+print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/port/s2p.bess
+++ b/bessctl/conf/port/s2p.bess
@@ -1,5 +1,5 @@
 dpdk_ports = int($BESS_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
+print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/port/s2p2s.bess
+++ b/bessctl/conf/port/s2p2s.bess
@@ -1,5 +1,5 @@
 dpdk_ports = int($BESS_PORTS!'1')
-print 'Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports
+print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
 
 for i in range(dpdk_ports):
     p = PMDPort(port_id=i)

--- a/bessctl/conf/port/unix_port.bess
+++ b/bessctl/conf/port/unix_port.bess
@@ -38,8 +38,8 @@ else:
     s.connect(SOCKET_PATH)
 
 for i in range(ITERATION):
-    original = gen_packet('10.0.0.1', '192.168.1.10' + str(i))
-    s.send(str(original))
+    original = gen_packet('10.0.0.1', '192.168.1.10' + bytes(i))
+    s.send(bytes(original))
 
     modified = s.recv(2048)
     pkt = scapy.Ether(modified)

--- a/bessctl/conf/port/unix_port.bess
+++ b/bessctl/conf/port/unix_port.bess
@@ -46,7 +46,7 @@ for i in range(ITERATION):
     assert len(original) == len(modified)
 
     print('%2d/%2d\tOriginal: %s' % (i + 1, ITERATION, original.summary()))
-    print '\tModified: %s' % pkt.summary()
+    print('\tModified: %s' % pkt.summary())
 
     time.sleep(1)
 

--- a/bessctl/conf/port/vport.bess
+++ b/bessctl/conf/port/vport.bess
@@ -7,4 +7,4 @@ p = PMDPort(port_id=0)
 PortInc(port=p.name) -> PortOut(port=v.name)
 PortInc(port=v.name) -> PortOut(port=p.name)
 
-print 'Two ports have been spliced: {} <-> {}'.format(p, v)
+print('Two ports have been spliced: {} <-> {}'.format(p, v))

--- a/bessctl/conf/samples/acl.bess
+++ b/bessctl/conf/samples/acl.bess
@@ -7,7 +7,7 @@ def gen_packet(proto, src_ip, dst_ip):
     udp = proto(sport=10001, dport=10002)
     payload = 'helloworld'
     pkt = eth/ip/udp/payload
-    return str(pkt)
+    return bytes(pkt)
 
 packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
            gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78'),

--- a/bessctl/conf/samples/drr.bess
+++ b/bessctl/conf/samples/drr.bess
@@ -5,8 +5,8 @@ ip1 = scapy.IP(src='192.168.1.1', dst='10.0.0.1')
 ip2 = scapy.IP(src='192.168.2.2', dst= '10.0.0.2')
 udp = scapy.UDP(sport=10001, dport=10002)
 payload = 'helloworld'
-pkt_bytes1 = str(eth/ip1/udp/payload)
-pkt_bytes2 = str(eth/ip2/udp/payload)
+pkt_bytes1 = bytes(eth/ip1/udp/payload)
+pkt_bytes2 = bytes(eth/ip2/udp/payload)
 
 # Create the pipeline from two sources rewriting each to have their own 
 # source port and destination port respectively, the pushing them into

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -11,7 +11,7 @@ def gen_packet(proto, src_ip, dst_ip):
     udp = proto(sport=10001, dport=10002)
     payload = 'helloworld'
     pkt = eth/ip/udp/payload
-    return str(pkt)
+    return bytes(pkt)
 
 packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
            gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78'),

--- a/bessctl/conf/samples/flowgen.bess
+++ b/bessctl/conf/samples/flowgen.bess
@@ -10,7 +10,7 @@ ip = scapy.IP(src='10.0.0.1', dst='10.0.0.2')   # dst IP is overwritten
 tcp = scapy.TCP(sport=10001, dport=10002)
 payload = ('hello' + '0123456789' * 200)[:pkt_size-len(eth/ip/tcp)]
 pkt = eth/ip/tcp/payload
-pkt_data = str(pkt)
+pkt_data = bytes(pkt)
 
 # NOTE: without quick_rampup=1, it takes a while to converge to
 # the desied load level, especially when flow duration is pareto distribution

--- a/bessctl/conf/samples/generic_encap.bess
+++ b/bessctl/conf/samples/generic_encap.bess
@@ -7,7 +7,7 @@ ip = scapy.IP()
 udp = scapy.UDP()
 payload = 'Hello World'
 
-test_packet = str(eth/ip/udp/payload)
+test_packet = bytes(eth/ip/udp/payload)
 
 Source() \
         -> SetMetadata(attrs=[{'name': 'ether_type', 'size': 2, 'value_int': 0x9999}]) \

--- a/bessctl/conf/samples/hash_lb.bess
+++ b/bessctl/conf/samples/hash_lb.bess
@@ -4,7 +4,7 @@ eth = scapy.Ether(src='02:1e:67:9f:4d:ac', dst='06:16:3e:1b:72:32')
 ip = scapy.IP(src='192.168.1.1', dst='10.0.0.1')
 udp = scapy.UDP(sport=10001, dport=10002)
 payload = 'helloworld'
-pkt_bytes = str(eth/ip/udp/payload)
+pkt_bytes = bytes(eth/ip/udp/payload)
 
 # randomize destination port
 Source() \

--- a/bessctl/conf/samples/iplookup.bess
+++ b/bessctl/conf/samples/iplookup.bess
@@ -13,7 +13,7 @@ def gen_packet(dst_ip):
     udp = scapy.UDP(sport=10001, dport=10002)
     payload = ('hello' + '0123456789' * 200)[:pkt_size-len(eth/ip/udp)]
     pkt = eth/ip/udp/payload
-    return str(pkt)
+    return bytes(pkt)
 
 packets = [gen_packet('172.16.100.1'),
            gen_packet('172.12.55.99'),

--- a/bessctl/conf/samples/l2forward.bess
+++ b/bessctl/conf/samples/l2forward.bess
@@ -21,7 +21,7 @@ else:
                      for i in range(num_entries)])
 
 pkt = scapy.Ether(src='02:00:00:00:00:01', dst='00:00:00:00:00:01')
-pkt_bytes = str(pkt)
+pkt_bytes = bytes(pkt)
 
 Source() -> \
         Rewrite(templates=[pkt_bytes]) -> \

--- a/bessctl/conf/samples/nat.bess
+++ b/bessctl/conf/samples/nat.bess
@@ -10,7 +10,7 @@ def gen_packet(proto, src_ip, dst_ip):
     udp = proto(sport=10001, dport=10002)
     payload = 'helloworld'
     pkt = eth/ip/udp/payload
-    return str(pkt)
+    return bytes(pkt)
 
 packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
            gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78'),

--- a/bessctl/conf/samples/queue.bess
+++ b/bessctl/conf/samples/queue.bess
@@ -5,7 +5,7 @@ ip = scapy.IP()
 udp = scapy.UDP()
 payload = 'Hello World'
 
-test_packet = str(eth/ip/udp/payload)
+test_packet = bytes(eth/ip/udp/payload)
 
 src::Source() \
         -> Rewrite(templates=[test_packet]) \

--- a/bessctl/conf/samples/s2s.bess
+++ b/bessctl/conf/samples/s2s.bess
@@ -1,4 +1,4 @@
 psize = int($BESS_PKT_SIZE!'60')
-print 'Using packet size %d (envvar "BESS_PKT_SIZE")' % psize
+print('Using packet size %d (envvar "BESS_PKT_SIZE")' % psize)
 
 Source(pkt_size=psize) -> Sink()

--- a/bessctl/conf/samples/update.bess
+++ b/bessctl/conf/samples/update.bess
@@ -4,7 +4,7 @@ eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
 ip = scapy.IP(src='192.168.1.1', dst='10.0.0.1')
 udp = scapy.UDP(sport=10001, dport=10002)
 payload = 'helloworld'
-pkt_bytes = str(eth/ip/udp/payload)
+pkt_bytes = bytes(eth/ip/udp/payload)
 
 Source() -> Rewrite(templates=[pkt_bytes]) -> rr::RoundRobin(gates=[1, 2])
 

--- a/bessctl/conf/samples/update_ttl.bess
+++ b/bessctl/conf/samples/update_ttl.bess
@@ -4,7 +4,7 @@ eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
 ip = scapy.IP(src='192.168.1.1', dst='10.0.0.1', ttl=2)
 udp = scapy.UDP(sport=10001, dport=10002)
 payload = 'helloworld'
-pkt_bytes = str(eth/ip/udp/payload)
+pkt_bytes = bytes(eth/ip/udp/payload)
 
 Source() -> Rewrite(templates=[pkt_bytes]) -> rr::RoundRobin(gates=[1, 2, 3])
 

--- a/bessctl/conf/samples/url_filter.bess
+++ b/bessctl/conf/samples/url_filter.bess
@@ -6,7 +6,7 @@ eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
 ip = scapy.IP(src='192.168.0.1', dst='10.0.0.1')
 tcp = scapy.TCP(sport=10001, dport=80, seq=12345)
 payload = 'GET /pub/WWW/TheProject.html HTTP/1.1\r\nHost: www.google.com\r\n\r\n'
-pkt = str(eth/ip/tcp/payload)
+pkt = bytes(eth/ip/tcp/payload)
 
 src::FlowGen(template=pkt, pps=2.2e6, flow_rate=800, flow_duration=5.0, \
     arrival='uniform', duration='uniform', quick_rampup=False)

--- a/bessctl/conf/samples/vlantest.bess
+++ b/bessctl/conf/samples/vlantest.bess
@@ -5,7 +5,7 @@ ip = scapy.IP()
 udp = scapy.UDP()
 payload = 'Hello World'
 
-test_packet = str(eth/ip/udp/payload)
+test_packet = bytes(eth/ip/udp/payload)
 
 Source() -> Rewrite(templates=[test_packet]) -> VLANPush(tci=2) -> VLANPop() -> Sink()
 Source() -> Rewrite(templates=[test_packet]) -> VLANPush(tci=2) -> VLANPush(tci=3) -> VLANPop() -> VLANPop() -> Sink()

--- a/bessctl/conf/samples/wildcardmatch.bess
+++ b/bessctl/conf/samples/wildcardmatch.bess
@@ -12,7 +12,7 @@ def gen_packet(dst_ip, dst_port):
     udp = scapy.UDP(sport=1234, dport=dst_port)
     payload = 'helloworld'
     pkt = eth/ip/udp/payload
-    return str(pkt)
+    return bytes(pkt)
 
 pkts = [gen_packet('172.16.100.1', 80),
         gen_packet('172.12.55.99', 54321),

--- a/bessctl/conf/testing/module_tests/acl.py
+++ b/bessctl/conf/testing/module_tests/acl.py
@@ -78,11 +78,11 @@ def my_bonus_acl_test():
                       'drop': False}])
     src = Source()
     rwtemp = [
-        str(gen_packet(
+        bytes(gen_packet(
             scapy.UDP,
             "172.12.0.3",
             "127.12.0.4")),
-        str(gen_packet(
+        bytes(gen_packet(
             scapy.TCP,
             "192.168.32.4",
             "1.2.3.4"))]
@@ -90,5 +90,6 @@ def my_bonus_acl_test():
     bess.resume_all()
     time.sleep(15)
     bess.pause_all()
+
 
 CUSTOM_TEST_FUNCTIONS.append(my_bonus_acl_test)

--- a/bessctl/conf/testing/module_tests/drr.py
+++ b/bessctl/conf/testing/module_tests/drr.py
@@ -14,32 +14,32 @@ def basic_output_test():
         for i in range(num_pkts):
             cur_pkt = gen_packet(protocol, input_ip, output_ip)
             packet_list.append({'input_port': 0, 'input_packet': cur_pkt,
-                                    'output_port': 0, "output_packet": cur_pkt})
+                                'output_port': 0, "output_packet": cur_pkt})
         return packet_list
 
-    single_basic = DRR(num_flows=2, max_flow_queue_size= 100)
+    single_basic = DRR(num_flows=2, max_flow_queue_size=100)
     monitor_task(single_basic, 0)
 
     out = []
-    single_packet= gen_packet_list(scapy.TCP, '22.22.22.22', '22.22.22.22', 1)
+    single_packet = gen_packet_list(scapy.TCP, '22.22.22.22', '22.22.22.22', 1)
     out.append([single_basic,  # test this module
-                               1, 1,  # it has one input port and one output port
-                               single_packet])
-    batch_basic = DRR(num_flows=4, max_flow_queue_size= 100)
+                1, 1,  # it has one input port and one output port
+                single_packet])
+    batch_basic = DRR(num_flows=4, max_flow_queue_size=100)
     monitor_task(batch_basic, 0)
     packet_list = gen_packet_list(scapy.TCP, '22.22.22.1', '22.22.22.1', 2)
     packet_list += gen_packet_list(scapy.TCP, '22.22.11.1', '22.22.11.1', 2)
     packet_list += gen_packet_list(scapy.TCP, '22.11.11.1', '22.11.11.1', 1)
     out.append([batch_basic,  # test this module
-                               1, 1,  # it has one input port and one output port
-                               packet_list])
+                1, 1,  # it has one input port and one output port
+                packet_list])
     return out
 
-# tests the fairness of 2 and 5 flows setup using the inner helper function. 
-def fairness_test():
 
-    # Takes the number of flows n, the quantum to give drr, the list packet rates for each flow 
-    # and the packet rate for the module. runs this setup for five seconds and tests that 
+# tests the fairness of 2 and 5 flows setup using the inner helper function.
+def fairness_test():
+    # Takes the number of flows n, the quantum to give drr, the list packet rates for each flow
+    # and the packet rate for the module. runs this setup for five seconds and tests that
     # throughput for each flow had a jaine fairness of atleast .95.
     def fairness_n_flow_test(n, quantum, rates, module_rate):
         err = bess.reset_all()
@@ -47,7 +47,7 @@ def fairness_test():
         packets = []
         exm = ExactMatch(fields=[{'offset':26, 'size':4}])
         for i in range(1, n+1):
-           packets.append(str(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i)))) 
+           packets.append(bytes(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i))))
            exm.add(fields=[socket.inet_aton('22.11.11.' + str(i))], gate=i)
 
         me_in = Measure()
@@ -60,9 +60,9 @@ def fairness_test():
             rewrites.append(Rewrite(templates=[packets[i]]))
             src[i] -> rewrites[i] -> measure_in[i] -> me_in
 
-        me_out = Measure() 
+        me_out = Measure()
         snk = Sink()
-        q = DRR(num_flows= n+1, quantum=quantum) 
+        q = DRR(num_flows= n+1, quantum=quantum)
         me_in -> q -> me_out -> exm
 
         measure_out = []

--- a/bessctl/conf/testing/module_tests/nat.py
+++ b/bessctl/conf/testing/module_tests/nat.py
@@ -31,7 +31,7 @@ def my_nat_simple_rule_test():
 
         orig = eth / ip_orig / l4_orig / l7
 
-        s0.send(str(orig))
+        s0.send(bytes(orig))
         natted_str = s1.recv(2048)
         natted = scapy.Ether(natted_str)
         # The NAT module can choose an arbitrary port/id.  We cannot test it,
@@ -41,14 +41,14 @@ def my_nat_simple_rule_test():
             l4_natted.id = natted.payload.payload.id
         else:
             l4_natted.sport = natted.payload.payload.sport
-        assert str(eth / ip_natted / l4_natted / l7) == natted_str
+        assert bytes(eth / ip_natted / l4_natted / l7) == natted_str
 
         l4_reply = swap_l4(natted.payload.payload)
         reply = eth / ip_reply / l4_reply / l7
 
-        s1.send(str(reply))
+        s1.send(bytes(reply))
         unnatted_str = s0.recv(2048)
-        assert str(eth / ip_unnatted / swap_l4(l4_orig) / l7) == unnatted_str
+        assert bytes(eth / ip_unnatted / swap_l4(l4_orig) / l7) == unnatted_str
 
     nat0::NAT(ext_addrs=['192.168.1.1'])
 

--- a/bessctl/conf/testing/module_tests/random_drop.py
+++ b/bessctl/conf/testing/module_tests/random_drop.py
@@ -19,11 +19,11 @@ def create_drop_test(rate):
         src = Source()
         rd2 = RandomDrop(drop_rate=rate)
         rwtemp = [
-            str(gen_packet(
+            bytes(gen_packet(
                 scapy.UDP,
                 "172.12.0.3",
                 "127.12.0.4")),
-            str(gen_packet(
+            bytes(gen_packet(
                 scapy.TCP,
                 "192.168.32.4",
                 "1.2.3.4"))]

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -53,12 +53,12 @@ def pkt_str(pkt):
 
 # These are just for the crash test
 crash_test_packets = [
-    str(gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1')),
-    str(gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78')),
-    str(gen_packet(scapy.UDP, '172.12.55.99', '10.0.0.1')),
-    str(gen_packet(scapy.UDP, '172.16.100.1', '12.34.56.78')),
-    str(gen_packet(scapy.TCP, '172.12.55.99', '12.34.56.78')),
-    str(gen_packet(scapy.UDP, '192.168.1.123', '12.34.56.78'))
+    bytes(gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1')),
+    bytes(gen_packet(scapy.UDP, '172.12.55.99', '12.34.56.78')),
+    bytes(gen_packet(scapy.UDP, '172.12.55.99', '10.0.0.1')),
+    bytes(gen_packet(scapy.UDP, '172.16.100.1', '12.34.56.78')),
+    bytes(gen_packet(scapy.TCP, '172.12.55.99', '12.34.56.78')),
+    bytes(gen_packet(scapy.UDP, '192.168.1.123', '12.34.56.78'))
 ]
 
 ## TEST FUNCTIONS ##
@@ -115,13 +115,9 @@ def run_tests():
         for module, input_port_cnt, output_port_cnt in CRASH_TEST_INPUTS:
             try:
                 crash_test(module, input_port_cnt, output_port_cnt)
-                print(
-                    "   %s crash test %s: PASS" %
-                    (str(module), str(crash_testid)))
+                print("   %s crash test %d: PASS" % (str(module), crash_testid))
             except BaseException:
-                print(
-                    "   %s crash test %s: FAIL" %
-                    (str(module), str(crash_testid)))
+                print("   %s crash test %d: FAIL" % (str(module), crash_testid))
                 DID_TESTS_FAIL = True
                 print("\n")
                 traceback.print_exc()
@@ -154,7 +150,7 @@ def run_tests():
                     input_pkt = test_case["input_packet"]
                     output_pkt = test_case["output_packet"]
                     if input_pkt is not None:
-                        sockets[input_port].send(str(input_pkt))
+                        sockets[input_port].send(bytes(input_pkt))
 
                     try:
                         return_data = sockets[output_port].recv(2048)
@@ -175,15 +171,15 @@ def run_tests():
                         sys.stderr.write("Received: %s" % pkt_str(
                             return_pkt) + " " + str(output_pkt) + "\n")
                         DID_TESTS_FAIL = True
-                        print("   %s output test %s: FAIL" %
-                              (str(module), str(output_testid)))
+                        print("   %s output test %d: FAIL" %
+                              (str(module), output_testid))
                     else:
-                        print("   %s output test %s: PASS" %
-                              (str(module), str(output_testid)))
+                        print("   %s output test %d: PASS" %
+                              (str(module), output_testid))
                     output_testid += 1
             except BaseException:
-                print("   %s output test %s: FAIL" %
-                      (str(module), str(output_testid)))
+                print("   %s output test %d: FAIL" %
+                      (str(module), output_testid))
                 DID_TESTS_FAIL = True
                 print("\n")
                 traceback.print_exc()

--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -123,9 +123,9 @@ def run_tests():
                     "   %s crash test %s: FAIL" %
                     (str(module), str(crash_testid)))
                 DID_TESTS_FAIL = True
-                print "\n"
+                print("\n")
                 traceback.print_exc()
-                print "\n"
+                print("\n")
             crash_testid += 1
 
         output_testid = 1
@@ -185,9 +185,9 @@ def run_tests():
                 print("   %s output test %s: FAIL" %
                       (str(module), str(output_testid)))
                 DID_TESTS_FAIL = True
-                print "\n"
+                print("\n")
                 traceback.print_exc()
-                print "\n"
+                print("\n")
 
             # tests passed!
             for sock in sockets:
@@ -203,9 +203,9 @@ def run_tests():
             except BaseException:
                 print("   %s  custom test: FAIL" % str(test))
                 DID_TESTS_FAIL = True
-                print "\n"
+                print("\n")
                 traceback.print_exc()
-                print "\n"
+                print("\n")
         # All done!
 
     bess.pause_all()

--- a/bessctl/test_samples.py
+++ b/bessctl/test_samples.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import fnmatch
 import glob
 import os
@@ -6,6 +7,7 @@ import subprocess
 import sys
 import time
 import unittest
+
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 bessctl = os.path.join(this_dir, 'bessctl')

--- a/bessctl/test_sugar.py
+++ b/bessctl/test_sugar.py
@@ -1,7 +1,11 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import fnmatch
 import os
-import sugar
 import unittest
+
+from . import sugar
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 script_dir = os.path.join(this_dir, 'conf')

--- a/bin/dpdk-devbind.py
+++ b/bin/dpdk-devbind.py
@@ -32,6 +32,10 @@
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+from __future__ import print_function
+from builtins import map
+from builtins import str
+from builtins import range
 import sys
 import os
 import getopt
@@ -182,8 +186,7 @@ def check_modules():
 
         # special case for vfio_pci (module is named vfio-pci,
         # but its .ko is named vfio_pci)
-        sysfs_mods = map(lambda a:
-                         a if a != 'vfio_pci' else 'vfio-pci', sysfs_mods)
+        sysfs_mods = [a if a != 'vfio_pci' else 'vfio-pci' for a in sysfs_mods]
 
         for mod in mods:
             if mod["Name"] in sysfs_mods:
@@ -265,12 +268,12 @@ def get_nic_details():
     ssh_if = []
     route = check_output(["ip", "-o", "route"])
     # filter out all lines for 169.254 routes
-    route = "\n".join(filter(lambda ln: not ln.startswith("169.254"),
-                             route.decode().splitlines()))
+    route = "\n".join([ln for ln in route.decode().splitlines()
+                       if not ln.startswith("169.254")])
     rt_info = route.split()
     for i in range(len(rt_info) - 1):
         if rt_info[i] == "dev":
-            ssh_if.append(rt_info[i+1])
+            ssh_if.append(rt_info[i + 1])
 
     # based on the basic info, get extended text details
     for d in devices.keys():
@@ -509,7 +512,7 @@ def display_devices(title, dev_list, extra_params=None):
      device's dictionary.'''
     strings = []  # this holds the strings to print. We sort before printing
     print("\n%s" % title)
-    print("="*len(title))
+    print("=" * len(title))
     if len(dev_list) == 0:
         strings.append("<none>")
     else:

--- a/build.py
+++ b/build.py
@@ -111,22 +111,23 @@ def check_c_lib(lib):
 
 def required(header_file, lib_name, compiler):
     if not check_header(header_file, compiler):
-        print >> sys.stderr, 'Error - #include <%s> failed. ' \
-            'Did you install "%s" package?' % (header_file, lib_name)
+        print('Error - #include <%s> failed. '
+              'Did you install "%s" package?'
+              % (header_file, lib_name), file=sys.stderr)
         sys.exit(1)
 
 
 def check_essential():
     if not cmd_success('gcc -v'):
-        print >> sys.stderr, 'Error - "gcc" is not available'
+        print('Error - "gcc" is not available', file=sys.stderr)
         sys.exit(1)
 
     if not cmd_success('g++ -v'):
-        print >> sys.stderr, 'Error - "g++" is not available'
+        print('Error - "g++" is not available', file=sys.stderr)
         sys.exit(1)
 
     if not cmd_success('make -v'):
-        print >> sys.stderr, 'Error - "make" is not available'
+        print('Error - "make" is not available', file=sys.stderr)
         sys.exit(1)
 
     required('pcap/pcap.h', 'libpcap-dev', 'gcc')

--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 import os
 import os.path
@@ -45,8 +46,8 @@ def cmd(cmd):
     out, err = proc.communicate()
 
     if proc.returncode:
-        print >> sys.stderr, 'Log:\n', out
-        print >> sys.stderr, 'Error has occured running command: %s' % cmd
+        print('Log:\n', out, file=sys.stderr)
+        print('Error has occured running command: %s' % cmd, file=sys.stderr)
         sys.exit(proc.returncode)
 
 
@@ -111,7 +112,7 @@ def check_c_lib(lib):
 def required(header_file, lib_name, compiler):
     if not check_header(header_file, compiler):
         print >> sys.stderr, 'Error - #include <%s> failed. ' \
-                'Did you install "%s" package?' % (header_file, lib_name)
+            'Did you install "%s" package?' % (header_file, lib_name)
         sys.exit(1)
 
 
@@ -153,8 +154,8 @@ def check_bnx():
         global extra_libs
         extra_libs.add('z')
     else:
-        print ' - "zlib1g-dev" is not available. ' \
-                'Disabling BNX2X PMD...'
+        print(' - "zlib1g-dev" is not available. '
+              'Disabling BNX2X PMD...')
         set_config(DPDK_FINAL_CONFIG, 'CONFIG_RTE_LIBRTE_BNX2X_PMD', 'n')
 
 
@@ -164,12 +165,12 @@ def check_mlx():
         extra_libs.add('ibverbs')
         # extra_libs.add('mlx5')
     else:
-        print ' - "Mellanox OFED" is not available. ' \
-                'Disabling MLX4 and MLX5 PMDs...'
+        print(' - "Mellanox OFED" is not available. '
+              'Disabling MLX4 and MLX5 PMDs...')
         if check_header('infiniband/verbs.h', 'gcc'):
-            print '   NOTE: "libibverbs-dev" does exist, but it does not ' \
-                    'work with MLX PMDs. Instead download OFED from ' \
-                    'http://www.melloanox.com'
+            print('   NOTE: "libibverbs-dev" does exist, but it does not '
+                  'work with MLX PMDs. Instead download OFED from '
+                  'http://www.melloanox.com')
         set_config(DPDK_FINAL_CONFIG, 'CONFIG_RTE_LIBRTE_MLX4_PMD', 'n')
         set_config(DPDK_FINAL_CONFIG, 'CONFIG_RTE_LIBRTE_MLX5_PMD', 'n')
 
@@ -192,7 +193,7 @@ def generate_extra_mk():
 
 def download_dpdk():
     try:
-        print 'Downloading %s ...  ' % DPDK_URL
+        print('Downloading %s ...  ' % DPDK_URL)
         cmd('curl -s -L %s -o %s' % (DPDK_URL, DPDK_FILE))
 
     except:
@@ -202,7 +203,7 @@ def download_dpdk():
 
 def configure_dpdk():
     try:
-        print 'Configuring DPDK...'
+        print('Configuring DPDK...')
         cmd('cp -f %s %s' % (DPDK_BASE_CONFIG, DPDK_FINAL_CONFIG))
 
         check_mlx()
@@ -223,7 +224,7 @@ def build_dpdk():
             download_dpdk()
 
         try:
-            print 'Decompressing DPDK...'
+            print('Decompressing DPDK...')
             cmd('mkdir -p %s' % DPDK_DIR)
             cmd('tar zxf %s -C %s --strip-components 1' %
                 (DPDK_FILE, DPDK_DIR))
@@ -237,7 +238,7 @@ def build_dpdk():
     if not os.path.exists('%s/build' % DPDK_DIR):
         configure_dpdk()
 
-    print 'Building DPDK...'
+    print('Building DPDK...')
     nproc = int(subprocess.check_output('nproc'))
     cmd('make -j%d -C %s EXTRA_CFLAGS=%s' % (nproc, DPDK_DIR, DPDK_CFLAGS))
 
@@ -250,13 +251,14 @@ def build_bess():
 
     generate_extra_mk()
 
-    print 'Generating protobuf codes for pybess...'
+    print('Generating protobuf codes for pybess...')
     cmd('protoc protobuf/*.proto \
         --proto_path=protobuf --python_out=pybess \
         --grpc_out=pybess \
         --plugin=protoc-gen-grpc=`which grpc_python_plugin`')
+    cmd('2to3 -wn pybess/*_pb2.py')
 
-    print 'Building BESS daemon...'
+    print('Building BESS daemon...')
     cmd('bin/bessctl daemon stop 2> /dev/null || true')
     cmd('rm -f core/bessd')     # force relink as DPDK might have been rebuilt
     cmd('make -C core -j`nproc`')
@@ -267,17 +269,17 @@ def build_kmod():
     check_essential()
 
     if os.getenv('KERNELDIR'):
-        print 'Building BESS kernel module (%s) ...' % \
-                os.getenv('KERNELDIR')
+        print('Building BESS kernel module (%s) ...' %
+              os.getenv('KERNELDIR'))
     else:
-        print 'Building BESS kernel module (%s - running kernel) ...' % \
-                subprocess.check_output('uname -r', shell=True).strip()
+        print('Building BESS kernel module (%s - running kernel) ...' %
+              subprocess.check_output('uname -r', shell=True).strip())
 
     cmd('sudo -n rmmod bess 2> /dev/null || true')
     try:
         cmd('make -C core/kmod')
     except SystemExit:
-        print >> sys.stderr, '*** module build has failed.'
+        print('*** module build has failed.', file=sys.stderr)
         sys.exit(1)
 
 
@@ -285,11 +287,11 @@ def build_all():
     build_dpdk()
     build_bess()
     build_kmod()
-    print 'Done.'
+    print('Done.')
 
 
 def do_clean():
-    print 'Cleaning up...'
+    print('Cleaning up...')
     cmd('make -C core clean')
     cmd('rm -f bin/bessd')
     cmd('make -C core/kmod clean')
@@ -298,7 +300,7 @@ def do_clean():
 
 def do_dist_clean():
     do_clean()
-    print 'Removing 3rd-party libraries...'
+    print('Removing 3rd-party libraries...')
     cmd('rm -rf %s %s' % (DPDK_FILE, DPDK_DIR))
 
 
@@ -308,7 +310,7 @@ def print_usage(parser):
 
 
 def update_benchmark_path(path):
-    print 'Specified benchmark path %s' % path
+    print('Specified benchmark path %s' % path)
     cxx_flags.extend(['-I%s/include' % (path)])
     ld_flags.extend(['-L%s/lib' % (path)])
 
@@ -341,8 +343,9 @@ def main():
     elif args.action == 'help':
         print_usage(parser)
     else:
-        print >> sys.stderr, 'Error - unknown command "%s".' % sys.argv[1]
+        print('Error - unknown command "%s".' % sys.argv[1], file=sys.stderr)
         print_usage(parser)
+
 
 if __name__ == '__main__':
     main()

--- a/container_build.py
+++ b/container_build.py
@@ -18,7 +18,8 @@ def run_cmd(cmd):
     proc.communicate()
 
     if proc.returncode:
-        print >> sys.stderr, 'Error has occured running host command: %s' % cmd
+        print('Error has occured running host command: %s' % cmd,
+              file=sys.stderr)
         sys.exit(proc.returncode)
 
 
@@ -48,7 +49,7 @@ def build_kmod():
     try:
         run_docker_cmd('%s kmod' % BUILD_SCRIPT)
     except:
-        print >> sys.stderr, '*** module build has failed.'
+        print('*** module build has failed.', file=sys.stderr)
 
 
 def build_kmod_buildtest():
@@ -73,10 +74,9 @@ def do_dist_clean():
 
 
 def print_usage():
-    print >> sys.stderr, \
-        'Usage: %s ' \
-        '[all|bess|kmod|kmod_buildtest|clean|dist_clean|shell||help]' % \
-        sys.argv[0]
+    print('Usage: %s '
+          '[all|bess|kmod|kmod_buildtest|clean|dist_clean|shell||help]'
+          % sys.argv[0], file=sys.stderr)
 
 
 def main():
@@ -104,7 +104,8 @@ def main():
             print_usage()
             sys.exit(0)
         else:
-            print >> sys.stderr, 'Error - unknown command "%s".' % sys.argv[1]
+            print('Error - unknown command "%s".' % sys.argv[1],
+                  file=sys.stderr)
             print_usage()
             sys.exit(2)
     else:

--- a/container_build.py
+++ b/container_build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 import subprocess
 import os
@@ -22,11 +23,11 @@ def run_cmd(cmd):
 
 
 def shell_quote(cmd):
-        return "'" + cmd.replace("'", "'\\''") + "'"
+    return "'" + cmd.replace("'", "'\\''") + "'"
 
 
 def run_docker_cmd(cmd):
-    run_cmd('docker run -e CXX -e DEBUG -e SANITIZE --rm -t ' \
+    run_cmd('docker run -e CXX -e DEBUG -e SANITIZE --rm -t '
             '-u %d:%d -v %s:%s %s sh -c %s' %
             (os.getuid(), os.getgid(), BESS_DIR_HOST, BESS_DIR_CONTAINER,
              IMAGE, shell_quote(cmd)))
@@ -73,9 +74,9 @@ def do_dist_clean():
 
 def print_usage():
     print >> sys.stderr, \
-            'Usage: %s ' \
-            '[all|bess|kmod|kmod_buildtest|clean|dist_clean|shell||help]' % \
-            sys.argv[0]
+        'Usage: %s ' \
+        '[all|bess|kmod|kmod_buildtest|clean|dist_clean|shell||help]' % \
+        sys.argv[0]
 
 
 def main():
@@ -113,4 +114,4 @@ def main():
 
 if __name__ == '__main__':
     main()
-    print 'Done.'
+    print('Done.')

--- a/env/rebuild_images.py
+++ b/env/rebuild_images.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import os
 import shlex
 import subprocess
@@ -11,16 +11,19 @@ TARGET_REPO = 'nefelinetworks/bess_build'
 imgs = {'trusty64': {'arch': 'x86_64', 'base': 'ubuntu:trusty',
                      'tag_suffix': ''},
         'trusty32': {'arch': 'i386', 'base': 'ioft/i386-ubuntu:trusty',
-                     'tag_suffix': '_32'},}
+                     'tag_suffix': '_32'}, }
+
 
 def print_usage(prog):
     print('Usage - {} [{}]'.format(prog, '|'.join(imgs.keys())))
+
 
 def run_cmd(cmd, shell=False):
     if shell:
         subprocess.check_call(cmd, shell=True)
     else:
         subprocess.check_call(shlex.split(cmd))
+
 
 def build(env):
     arch = imgs[env]['arch']
@@ -31,9 +34,9 @@ def build(env):
 
     run_cmd('m4 -DBASE_IMAGE={} Dockerfile.m4 > Dockerfile'.format(base),
             shell=True)
-    run_cmd('docker build --build-arg BESS_DPDK_BRANCH={branch} ' \
-            '--build-arg DPDK_ARCH={arch} ' \
-            '-t {target}:latest{suffix} -t {target}:{version}{suffix} ' \
+    run_cmd('docker build --build-arg BESS_DPDK_BRANCH={branch} '
+            '--build-arg DPDK_ARCH={arch} '
+            '-t {target}:latest{suffix} -t {target}:{version}{suffix} '
             '.'.format(branch=bess_dpdk_branch, arch=arch, target=TARGET_REPO,
                        version=version, suffix=tag_suffix))
 
@@ -42,10 +45,12 @@ def build(env):
 
     return version, tag_suffix
 
+
 def push(version, tag_suffix):
     run_cmd('docker login')
     run_cmd('docker push {}:latest{}'.format(TARGET_REPO, tag_suffix))
     run_cmd('docker push {}:{}{}'.format(TARGET_REPO, version, tag_suffix))
+
 
 def main(argv):
     if len(argv) != 2 or argv[1] not in imgs.keys():

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -1,15 +1,18 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import errno
 import grpc
 import os
 import pprint
 import time
 
-import service_pb2
-import protobuf_to_dict as pb_conv
+from . import service_pb2
+from . import protobuf_to_dict as pb_conv
 
-import module_msg
-import bess_msg_pb2 as bess_msg
-import port_msg_pb2 as port_msg
+from . import module_msg
+from . import bess_msg_pb2 as bess_msg
+from . import port_msg_pb2 as port_msg
 
 
 def _constraints_to_list(constraint):
@@ -73,7 +76,7 @@ class BESS(object):
 
     def _update_status(self, connectivity):
         if self.debug:
-            print "Channel status: {} -> {}".format(self.status, connectivity)
+            print("Channel status: {} -> {}".format(self.status, connectivity))
 
         # do not update status if previous disconnection is not reported yet
         if self.is_connection_broken():
@@ -133,8 +136,8 @@ class BESS(object):
         req_dict = pb_conv.protobuf_to_dict(req_pb)
 
         if self.debug:
-            print '====',  req_fn._method
-            print '--->', type(req_pb).__name__
+            print('====',  req_fn._method)
+            print('--->', type(req_pb).__name__)
             if req_dict:
                 pprint.pprint(req_dict)
 
@@ -144,7 +147,7 @@ class BESS(object):
             raise self.RPCError(str(e))
 
         if self.debug:
-            print '<---', type(response).__name__
+            print('<---', type(response).__name__)
             res = pb_conv.protobuf_to_dict(response)
             if res:
                 pprint.pprint(res)
@@ -187,25 +190,25 @@ class BESS(object):
         response = self.check_scheduling_constraints()
         error = False
         if len(response.violations) != 0 or len(response.modules) != 0:
-            print 'Placement violations found'
+            print('Placement violations found')
             for violation in response.violations:
                 if violation.constraint != 0:
                     valid = ' '.join(
                         map(str, _constraints_to_list(violation.constraint)))
-                    print 'name %s allowed_sockets [%s] worker_socket %d '\
-                        'worker_core %d' % (violation.name,
-                                            valid,
-                                            violation.assigned_node,
-                                            violation.assigned_core)
+                    print('name %s allowed_sockets [%s] worker_socket %d '
+                          'worker_core %d' % (violation.name,
+                                              valid,
+                                              violation.assigned_node,
+                                              violation.assigned_core))
                 else:
-                    print 'name %s has no valid '\
-                        'placements worker_socket %d '\
-                        'worker_core %d' % (violation.name,
-                                            violation.assigned_node,
-                                            violation.assigned_core)
+                    print('name %s has no valid '
+                          'placements worker_socket %d '
+                          'worker_core %d' % (violation.name,
+                                              violation.assigned_node,
+                                              violation.assigned_core))
             for module in response.modules:
-                print 'constraints violated for module %s --'\
-                    ' please check bessd log' % module.name
+                print('constraints violated for module %s --'
+                      ' please check bessd log' % module.name)
             error = True
         if response.fatal:
             raise self.ConstraintError("Fatal violation of "

--- a/pybess/module.py
+++ b/pybess/module.py
@@ -29,7 +29,7 @@ class Module(object):
             self.name = ret.name
         else:
             # bind to a pre-existing object, check if it's real
-            assert name != None, "Module should not be None"
+            assert name is not None, "Module should not be None"
             info = self.bess.get_module_info(name)
             assert self.mclass == info.mclass, "Module %s is not of % type" % (
                 name, self.mclass)

--- a/pybess/module_msg.py
+++ b/pybess/module_msg.py
@@ -23,8 +23,8 @@ def load_symbols(mod_name):
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 mod_files = glob.glob(dir_path + '/*_msg_pb2.py')
-mods = filter(lambda m: m not in exclude_list,
-              [os.path.basename(m)[:-3] for m in mod_files])
+mods = [m for m in [os.path.basename(m)[:-3] for m in mod_files]
+        if m not in exclude_list]
 
 for mod_name in mods:
     load_symbols(mod_name)

--- a/pybess/protobuf_to_dict.py
+++ b/pybess/protobuf_to_dict.py
@@ -26,7 +26,7 @@ TYPE_CALLABLE_MAP = {
     FieldDescriptor.TYPE_SFIXED64: int,
     FieldDescriptor.TYPE_BOOL: bool,
     FieldDescriptor.TYPE_STRING: str,
-    FieldDescriptor.TYPE_BYTES: str,
+    FieldDescriptor.TYPE_BYTES: bytes,
     FieldDescriptor.TYPE_ENUM: int,
 }
 

--- a/pybess/protobuf_to_dict.py
+++ b/pybess/protobuf_to_dict.py
@@ -1,6 +1,5 @@
 # Copied from https://github.com/benhodgson/protobuf-to-dict (cd98280)
 # written by Ben Hodgson, with additional fixes
-
 from google.protobuf.message import Message
 from google.protobuf.descriptor import FieldDescriptor
 
@@ -16,17 +15,17 @@ TYPE_CALLABLE_MAP = {
     FieldDescriptor.TYPE_DOUBLE: float,
     FieldDescriptor.TYPE_FLOAT: float,
     FieldDescriptor.TYPE_INT32: int,
-    FieldDescriptor.TYPE_INT64: long,
+    FieldDescriptor.TYPE_INT64: int,
     FieldDescriptor.TYPE_UINT32: int,
-    FieldDescriptor.TYPE_UINT64: long,
+    FieldDescriptor.TYPE_UINT64: int,
     FieldDescriptor.TYPE_SINT32: int,
-    FieldDescriptor.TYPE_SINT64: long,
+    FieldDescriptor.TYPE_SINT64: int,
     FieldDescriptor.TYPE_FIXED32: int,
-    FieldDescriptor.TYPE_FIXED64: long,
+    FieldDescriptor.TYPE_FIXED64: int,
     FieldDescriptor.TYPE_SFIXED32: int,
-    FieldDescriptor.TYPE_SFIXED64: long,
+    FieldDescriptor.TYPE_SFIXED64: int,
     FieldDescriptor.TYPE_BOOL: bool,
-    FieldDescriptor.TYPE_STRING: unicode,
+    FieldDescriptor.TYPE_STRING: str,
     FieldDescriptor.TYPE_BYTES: str,
     FieldDescriptor.TYPE_ENUM: int,
 }
@@ -34,8 +33,7 @@ TYPE_CALLABLE_MAP = {
 
 def repeated_map(type_k_callable, type_v_callable):
     return lambda values: {type_k_callable(k): type_v_callable(v)
-                           for k, v in values.items()
-                           }
+                           for k, v in values.items()}
 
 
 def repeated(type_callable):

--- a/pybess/test_bess.py
+++ b/pybess/test_bess.py
@@ -1,15 +1,12 @@
+from __future__ import absolute_import
 import unittest
 import grpc
 import time
 from concurrent import futures
 
-import bess
-import bess_msg_pb2 as bess_msg
-import service_pb2
-
-import bess
-import bess_msg_pb2 as bess_msg
-import service_pb2
+from . import bess
+from . import bess_msg_pb2 as bess_msg
+from . import service_pb2
 
 
 class TestServiceImpl(service_pb2.BESSControlServicer):
@@ -114,5 +111,5 @@ class TestBESS(unittest.TestCase):
                                              'add',
                                              'ExactMatchCommandAddArg',
                                              {'gate': 0,
-                                              'fields': ['\x11', '\x22']})
+                                              'fields': [b'\x11', b'\x22']})
         self.assertEqual(0, response.error.code)

--- a/pybess/test_protobuf_to_dict.py
+++ b/pybess/test_protobuf_to_dict.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import unittest
-import bess_msg_pb2 as bess_msg
-import protobuf_to_dict as pb_conv
+from . import bess_msg_pb2 as bess_msg
+from . import protobuf_to_dict as pb_conv
 
 
 class TestProtobufConvert(unittest.TestCase):


### PR DESCRIPTION
This should fix #488.

- Modified Python code to be 2/3 compatible 
  - Use Python 3 style `print()` with `from __future__ import print_function`;
  - Use list comprehension instead of `map` and `filter`;
  - Use `items()` instead of `iteritems()` (Yeah, it would become less efficient in Python 2);
  - Use `io` package to `read()` from files, so that the resulting string is Unicode-encoded;
  - Use `raw_input` for Python 2 and `input` for Python 3;
  - Disable implicit relative import and use absolute import instead;
  - Fix the discrepancy of `tokenizer`  between Python 2/3 (`->` is an `OP` token in Python 3);
  - Run `2to3` over `protoc` generated scripts, since those scripts still use implicit relative import;
  - Use raw bytes for non-Unicode literals (e.g `b'\x01'`).
- Add unit test for both Python 2/3.