### PR TITLE
Fix raw_input and input confusion

### DIFF
--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -371,11 +371,11 @@ class CLI(object):
     def process_one_line(self):
         if self.interactive:
             try:
-                # Hack for Python 2/3 compatibility
-                if hasattr(__builtins__, 'raw_input'):
-                    line = raw_input(self.get_prompt())
-                else:
-                    line = input(self.get_prompt())
+                try:
+                    prompt = raw_input  # Python 2
+                except NameError:
+                    prompt = input      # Python 3
+                line = prompt(self.get_prompt())
             except KeyboardInterrupt:
                 self.fout.write('\n')
                 return

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -546,12 +546,12 @@ def warn(cli, msg, func, *args):
             cli.rl.set_completer(cli.complete_dummy)
 
         try:
-            # Hack for Python 2/3 compatibility
-            if hasattr(__builtins__, 'raw_input'):
-                resp = raw_input(
-                    'WARNING: %s Are you sure? (type "yes") ' % msg)
-            else:
-                resp = input('WARNING: %s Are you sure? (type "yes") ' % msg)
+            try:
+                prompt = raw_input  # Python 2
+            except NameError:
+                prompt = input      # Python 3
+
+            resp = prompt('WARNING: %s Are you sure? (type "yes") ' % msg)
 
             if resp.strip() == 'yes':
                 func(cli, *args)


### PR DESCRIPTION
Fix the `bessctl` crash in Python 2 introduced by the previous PR.