### PR TITLE
Optimize RunModuleSplit() and reduce TLS usage

### DIFF
--- a/core/worker.h
+++ b/core/worker.h
@@ -91,8 +91,7 @@ class Worker {
   gate_idx_t current_igate() const { return current_igate_; }
   void set_current_igate(gate_idx_t idx) { current_igate_ = idx; }
 
-  /* better be the last field. it's huge */
-  bess::PacketBatch *splits() { return splits_; }
+  bess::PacketBatch **splits() { return splits_; }
 
  private:
   volatile worker_status_t status_;
@@ -115,8 +114,11 @@ class Worker {
    * Modules should use get_igate() for access */
   gate_idx_t current_igate_;
 
-  /* better be the last field. it's huge */
-  bess::PacketBatch splits_[MAX_GATES + 1];
+  // For each possible output gate contains a pointer to a batch, or nullptr,
+  // if no batch has been associated with the output gate yet.
+  //
+  // This should be the last field, since it's huge.
+  bess::PacketBatch *splits_[MAX_GATES + 1];
 };
 
 // NOTE: Do not use "thread_local" here. It requires a function call every time


### PR DESCRIPTION
My previous attempt at this caused random crashes inside gRPC on travis.

I haven't been able to understand why, or to reproduce the crash locally, but since then we changed some gRPC code.

I've run this on travis 10 times and it hasn't crashed.