### PR TITLE
Fix attr_match.bess to use correct arg

### DIFF
--- a/bessctl/conf/metadata/attr_match.bess
+++ b/bessctl/conf/metadata/attr_match.bess
@@ -1,8 +1,8 @@
 # For metadata attribute usage for wildcard matching,
 # also see samples/wildcardmatch.bess
 
-em::ExactMatch(fields=[{'name':'foo', 'size':1}, \
-                       {'name':'bar', 'size':2}])
+em::ExactMatch(fields=[{'attribute':'foo', 'size':1}, \
+                       {'attribute':'bar', 'size':2}])
 Source() \
         -> SetMetadata(attrs=[{'name': 'foo', 'size': 1, 'value_int': 0xcc}]) \
         -> SetMetadata(attrs=[{'name': 'bar', 'size': 2, 'value_int': 0x1122}]) \


### PR DESCRIPTION
side note: it's a bit confusing for ExactMatch to use `attribute` and Metadata to use `name`