### PR TITLE
Fix metadata endianness

### DIFF
--- a/bessctl/conf/samples/generic_encap.bess
+++ b/bessctl/conf/samples/generic_encap.bess
@@ -10,7 +10,7 @@ payload = 'Hello World'
 test_packet = bytes(eth/ip/udp/payload)
 
 Source() \
-        -> SetMetadata(attrs=[{'name': 'ether_type', 'size': 2, 'value_int': 0x9999}]) \
+        -> SetMetadata(attrs=[{'name': 'ether_type', 'size': 2, 'value_int': 0x9876}]) \
         -> Rewrite(templates=[test_packet]) \
         -> GenericEncap(fields=[ \
             {'size': 6, 'value': 0x020000000001},

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -62,8 +62,7 @@ CommandResponse SetMetadata::AddAttrOne(
   // stored in memory). value_bin is a short stream of bytes, which means that
   // its data will never be reordered.
   if (attr.value_case() == bess::pb::SetMetadataArg_Attribute::kValueInt) {
-    if (!bess::utils::uint64_to_bin(&value, attr.value_int(), size,
-                                    bess::utils::is_be_system())) {
+    if (!bess::utils::uint64_to_bin(&value, attr.value_int(), size, true)) {
       return CommandFailure(EINVAL,
                             "'value_int' field has not a "
                             "correct %zu-byte value",

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -198,15 +198,11 @@ CommandResponse WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
     uint64_t v = 0;
     uint64_t m = 0;
 
-    bool force_be = (fields_[i].attr_id < 0);
-
-    if (!bess::utils::uint64_to_bin(&v, arg.values(i), field_size,
-                                    force_be || bess::utils::is_be_system())) {
+    if (!bess::utils::uint64_to_bin(&v, arg.values(i), field_size, true)) {
       return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte value", i,
                             field_size);
-    } else if (!bess::utils::uint64_to_bin(
-                   &m, arg.masks(i), field_size,
-                   force_be || bess::utils::is_be_system())) {
+    } else if (!bess::utils::uint64_to_bin(&m, arg.masks(i), field_size,
+                                           true)) {
       return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
                             field_size);
     }

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -366,11 +366,11 @@ CommandResponse WildcardMatch::CommandGetRules(const bess::pb::EmptyArg &) {
       for (auto &field : fields_) {
         uint64_t data = 0;
         bess::utils::bin_to_uint64(&data, entry_data + field.pos, field.size,
-                                   1);
+                                   true);
         rule->add_values(data);
         uint64_t mask_data = 0;
         bess::utils::bin_to_uint64(&mask_data, entry_mask + field.pos,
-                                   field.size, 1);
+                                   field.size, true);
         rule->add_masks(mask_data);
       }
     }


### PR DESCRIPTION
While all metadata attributes are supposed to be stored in big endian, `SetMetadata` and `WildcardMatch` modules were incorrectly assuming values are stored in host order.

(module tests will be added for a new test framework)