### PR TITLE
Make names pytest-friendly

### DIFF
--- a/bessctl/test_samples.py
+++ b/bessctl/test_samples.py
@@ -15,6 +15,7 @@ sample_dir = os.path.join(this_dir, 'conf/samples')
 
 
 class CommandError(subprocess.CalledProcessError):
+
     '''Identical to CalledProcessError, except it also shows the output'''
 
     def __str__(self):
@@ -30,6 +31,7 @@ def run_cmd(cmd):
 
 
 class TestSamples(unittest.TestCase):
+
     """
     All scripts in conf/samples will be dynamically added here as individual
     tests (e.g., test_path_to_conf_samples_exactmatch_bess) in this class.
@@ -47,22 +49,22 @@ class TestSamples(unittest.TestCase):
         run_cmd('%s daemon stop' % bessctl)
 
 
-def test_generator(path):
-    def test(self):
+def generate_test_method(path):
+    def template(self):
         run_cmd('%s daemon reset -- run file %s' % (bessctl, path))
 
         # 0.5 seconds should be enough to detect packet leaks in the datapath
         time.sleep(0.5)
 
-    return test
+    return template
 
 
 for root, _, file_names in os.walk(sample_dir):
     for file_name in fnmatch.filter(file_names, "*.bess"):
         path = os.path.join(root, file_name)
-        test_name = 'test' + path.replace('/', '_').replace('.', '_')
-        test_method = test_generator(path)
-        setattr(TestSamples, test_name, test_method)
+        name = 'test' + path.replace('/', '_').replace('.', '_')
+        method = generate_test_method(path)
+        setattr(TestSamples, name, method)
 
 if __name__ == '__main__':
     unittest.main()

--- a/bessctl/test_sugar.py
+++ b/bessctl/test_sugar.py
@@ -12,6 +12,7 @@ script_dir = os.path.join(this_dir, 'conf')
 
 
 class TestSugar(unittest.TestCase):
+
     """
     All scripts in conf/ will be dynamically added here as individual
     tests (e.g., test_path_to_conf_samples_exactmatch_bess) in this class.
@@ -44,8 +45,10 @@ class TestSugar(unittest.TestCase):
 
     def test_module(self):
         mod_suite = [
-            ('a::SomeModule()',         "__bess_module__('a', 'SomeModule', )"),
-            ('a::SomeModule(b, c, d)',  "__bess_module__('a', 'SomeModule', b, c, d)"),
+            ('a::SomeModule()',
+             "__bess_module__('a', 'SomeModule', )"),
+            ('a::SomeModule(b, c, d)',
+             "__bess_module__('a', 'SomeModule', b, c, d)"),
             ('a > b',                   "a > b"),
             ('a >- b',                  "a >- b"),
             ('a -> b',                  "a + b"),
@@ -88,20 +91,20 @@ class TestSugar(unittest.TestCase):
         self.run_suite(mod_suite)
 
 
-def test_generator(path):
-    def test(self):
+def generate_test_method(path):
+    def template(self):
         xformed = sugar.xform_file(path)
         code = compile(xformed, path, 'exec')
 
-    return test
+    return template
 
 
 for root, dir_names, file_names in os.walk(script_dir):
     for file_name in fnmatch.filter(file_names, "*.bess"):
         path = os.path.join(root, file_name)
-        test_name = 'test' + path.replace('/', '_').replace('.', '_')
-        test_method = test_generator(path)
-        setattr(TestSugar, test_name, test_method)
+        name = 'test' + path.replace('/', '_').replace('.', '_')
+        method = generate_test_method(path)
+        setattr(TestSugar, name, method)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pybess/test_bess.py
+++ b/pybess/test_bess.py
@@ -9,7 +9,7 @@ from . import bess_msg_pb2 as bess_msg
 from . import service_pb2
 
 
-class TestServiceImpl(service_pb2.BESSControlServicer):
+class DummyServiceImpl(service_pb2.BESSControlServicer):
 
     def __init__(self):
         pass
@@ -39,7 +39,7 @@ class TestBESS(unittest.TestCase):
     def setUp(self):
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
         service_pb2.add_BESSControlServicer_to_server(
-            TestServiceImpl(),
+            DummyServiceImpl(),
             self.server)
         self.server.add_insecure_port('[::]:%d' % self.PORT)
         self.server.start()


### PR DESCRIPTION
In [`pytest`](https://pytest.org), which is compatible with `unittest.py` that we currently use, names with `Test...` and `test_...` have special meanings. This PR renames such names to avoid interference.