### PR TITLE
Explicitly define kMaxBurst

### DIFF
--- a/core/packet.cc
+++ b/core/packet.cc
@@ -15,6 +15,8 @@
 
 namespace bess {
 
+const size_t PacketBatch::kMaxBurst;
+
 static struct rte_mempool *pframe_pool[RTE_MAX_NUMA_NODES];
 
 static void packet_init(struct rte_mempool *mp, void *opaque_arg, void *_m,


### PR DESCRIPTION
This is required for proper linking. Previously we were able to get away only with declaration (but without definition) of kMaxBurst, because a compiler optimization ignores this issue when kMaxBurst is used for array sizing.