### PR TITLE
Update docker repo for Ubuntu 17.04

### DIFF
--- a/env/docker.yml
+++ b/env/docker.yml
@@ -6,7 +6,7 @@
       apt_key: url=https://download.docker.com/linux/ubuntu/gpg
       become: true
 
-    - apt_repository: repo='deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ansible_distribution_release}} stable'
+    - apt_repository: repo='deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ansible_distribution_release}} edge'
       become: true
 
     - name: Install Docker


### PR DESCRIPTION
`docker-ce` package exists only in the `edge` branch.