### PR TITLE
Use __attribute__ instead of square backets

### DIFF
--- a/core/kmod/llring.h
+++ b/core/kmod/llring.h
@@ -66,15 +66,22 @@
 #ifndef _LLRING_H_
 #define _LLRING_H_
 
-#if defined(__has_cpp_attribute)
+#if !defined(FALLTHROUGH) && defined(__has_attribute)
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH __attribute__((fallthrough))
+#endif
+#endif
+
+#if !defined(FALLTHROUGH) && defined(__has_cpp_attribute) &&                   \
+    defined(__cplusplus)
 #if __has_cpp_attribute(fallthrough)
 #define FALLTHROUGH [[fallthrough]]
 #elif __has_cpp_attribute(clang::fallthrough)
 #define FALLTHROUGH [[clang::fallthrough]]
-#else
-#define FALLTHROUGH
 #endif
-#else
+#endif
+
+#ifndef FALLTHROUGH
 #define FALLTHROUGH
 #endif
 

--- a/core/utils/copy.h
+++ b/core/utils/copy.h
@@ -1,15 +1,16 @@
 #ifndef BESS_UTILS_COPY_H_
 #define BESS_UTILS_COPY_H_
 
-#if defined(__has_cpp_attribute)
+#if !defined(FALLTHROUGH) && defined(__has_cpp_attribute) && \
+    defined(__cplusplus)
 #if __has_cpp_attribute(fallthrough)
 #define FALLTHROUGH [[fallthrough]]
 #elif __has_cpp_attribute(clang::fallthrough)
 #define FALLTHROUGH [[clang::fallthrough]]
-#else
-#define FALLTHROUGH
 #endif
-#else
+#endif
+
+#ifndef FALLTHROUGH
 #define FALLTHROUGH
 #endif
 


### PR DESCRIPTION
Unfortunately C does not support square bracket `[[ xxx ]]` for attributes, which
breaks kernel module builds. Falling back to the old `__attribute__` style.