### PR TITLE
env: Install clang-3.9

### DIFF
--- a/env/packages.yml
+++ b/env/packages.yml
@@ -17,6 +17,7 @@
         - g++-7
         - g++
         - clang-3.8
+        - clang-3.9
         - autoconf
         - automake
         - libtool

--- a/env/packages.yml
+++ b/env/packages.yml
@@ -73,8 +73,8 @@
     - name: Compile gRPC and its dependencies
       shell: make -j{{ ansible_processor_vcpus }} chdir=/tmp/grpc
       environment:
-        - CC: gcc-6
-        - CXX: g++-6
+        - CC: gcc-4.8
+        - CXX: g++-4.8
 
     - name: Install gRPC
       shell: make install chdir=/tmp/grpc


### PR DESCRIPTION
It's useful to have a more recent version.  For now travis still uses 3.8,
but that may change soon.