### PR TITLE
Remove GCC 4.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - GCOV_PREFIX=$TRAVIS_BUILD_DIR             # /build/bess/core/xx becomes $TRAVIS_BUILD_DIR/core/xx
   matrix:
     - VER_CXX=clang++-3.8 SANITIZE=1
-    - VER_CXX=g++-4.8
     - VER_CXX=g++-5
     - VER_CXX=g++-5 DEBUG=1
     - VER_CXX=g++-5 TAG_SUFFIX=_32              # 32bit build

--- a/core/Makefile
+++ b/core/Makefile
@@ -21,8 +21,8 @@ CXXCOMPILER := $(shell expr $(word 1, $(shell $(CXX) --version)) : '\(clang\|g++
 CXXVERSION := $(shell $(CXX) -dumpversion)
 
 ifeq "$(CXXCOMPILER)" "g++"
-ifneq "$(shell printf '$(CXXVERSION)\n4.7' | sort -V | head -n1)" "4.7"
-    $(error g++ 4.8 or higher is required)
+ifneq "$(shell printf '$(CXXVERSION)\n5' | sort -V | head -n1)" "5"
+    $(error g++ 5 or higher is required. Use container_build.py if newer g++ is not available.)
 endif
 endif
 

--- a/core/kmod/llring.h
+++ b/core/kmod/llring.h
@@ -66,23 +66,14 @@
 #ifndef _LLRING_H_
 #define _LLRING_H_
 
-#if !defined(FALLTHROUGH) && defined(__has_attribute)
-#if __has_attribute(fallthrough)
+#if !defined(__cplusplus) // C
 #define FALLTHROUGH __attribute__((fallthrough))
-#endif
-#endif
-
-#if !defined(FALLTHROUGH) && defined(__has_cpp_attribute) &&                   \
-    defined(__cplusplus)
-#if __has_cpp_attribute(fallthrough)
-#define FALLTHROUGH [[fallthrough]]
-#elif __has_cpp_attribute(clang::fallthrough)
+#elif __cplusplus <= 201402L && defined(__clang__) // C++14 or older, Clang
 #define FALLTHROUGH [[clang::fallthrough]]
-#endif
-#endif
-
-#ifndef FALLTHROUGH
+#elif __cplusplus <= 201402L && __GNUC__ < 7 // C++14 or older, pre-GCC 7
 #define FALLTHROUGH
+#else
+#define FALLTHROUGH [[fallthrough]]
 #endif
 
 /**

--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -19,6 +19,16 @@
 #define maybe_unused gnu::unused
 #endif
 
+#if !defined(__cplusplus)  // C
+#define FALLTHROUGH __attribute__((fallthrough))
+#elif __cplusplus <= 201402L && defined(__clang__)  // C++14 or older, Clang
+#define FALLTHROUGH [[clang::fallthrough]]
+#elif __cplusplus <= 201402L && __GNUC__ < 7  // C++14 or older, pre-GCC 7
+#define FALLTHROUGH
+#else
+#define FALLTHROUGH [[fallthrough]]
+#endif
+
 /* Hint for performance optimization. Same as _nDCHECK() of TI compilers */
 #define promise(cond)          \
   ({                           \
@@ -151,8 +161,8 @@ template <typename T, typename U>
 inline void InsertSorted(T &container, U &item) {
   container.push_back(item);
 
-  for (size_t i = container.size()-1; i > 0; --i) {
-    auto &prev = container[i-1];
+  for (size_t i = container.size() - 1; i > 0; --i) {
+    auto &prev = container[i - 1];
     auto &cur = container[i];
     if (cur < prev) {
       std::swap(prev, cur);

--- a/core/utils/copy.h
+++ b/core/utils/copy.h
@@ -1,19 +1,6 @@
 #ifndef BESS_UTILS_COPY_H_
 #define BESS_UTILS_COPY_H_
 
-#if !defined(FALLTHROUGH) && defined(__has_cpp_attribute) && \
-    defined(__cplusplus)
-#if __has_cpp_attribute(fallthrough)
-#define FALLTHROUGH [[fallthrough]]
-#elif __has_cpp_attribute(clang::fallthrough)
-#define FALLTHROUGH [[clang::fallthrough]]
-#endif
-#endif
-
-#ifndef FALLTHROUGH
-#define FALLTHROUGH
-#endif
-
 #include <glog/logging.h>
 #include <x86intrin.h>
 

--- a/env/packages.yml
+++ b/env/packages.yml
@@ -11,7 +11,6 @@
         - apt-transport-https
         - ca-certificates
         - build-essential
-        - g++-4.8
         - g++-5
         - g++-6
         - g++-7
@@ -73,8 +72,8 @@
     - name: Compile gRPC and its dependencies
       shell: make -j{{ ansible_processor_vcpus }} chdir=/tmp/grpc
       environment:
-        - CC: gcc-4.8
-        - CXX: g++-4.8
+        - CC: gcc-5
+        - CXX: g++-5
 
     - name: Install gRPC
       shell: make install chdir=/tmp/grpc


### PR DESCRIPTION
GCC 4.8 uses a different ABI. As a result, gRPC built by GCC 4.8 doesn't work in any case (#532). In addition, if gRPC is built by GCC 5+, BESS cannot be built by GCC 4.8. This PR ditches the support for GCC 4.8.