### PR TITLE
Add virtio-user example for BESS<->container connection with kernel bypass

### DIFF
--- a/bessctl/conf/port/vhost/README.md
+++ b/bessctl/conf/port/vhost/README.md
@@ -1,12 +1,16 @@
+This example is to demonstrate how to connect BESS to VMs or containers.
+
 ### Requirements
 
 * Install these packages:
   * numactl
   * qemu-kvm
+  * Docker
 * Reserve at least 3GB of hugepages. 4GB if running on a NUMA machine
   * Each VM requires 2GB. BESS takes 1GB per socket.
   * On NUMA, check each socket has enough free hugepages.
   * It is recommended to use 1GB hugepages rather than 2MB ones.
+  * For container test, you MUST use 1GB pages
 
 
 ### vhost.bess
@@ -35,15 +39,28 @@ another. You must launch `vhost.bess` first, so that QEMU can connect to BESS
 vport sockets. Otherwise you will see an error like this:
 `qemu-system-x86_64: ... Failed to connect socket: No such file or directory`
 
-Environment variables:
+
+### launch\_container.py
+
+Same as launch\_vm.py, except it launches containers, not VMs (thus much faster
+to launch). No root permissions are required to run this script, but make sure
+that your account belongs to the "docker" group.
+
+
+### Environment variables
+
+The following environment variables are shared for both VM and container.
 * `VM_START_CPU`: Default: 1
-* `VM_VCPUS`: # of virtual cores per VM. Default: 2
+  * If set to X, VMs/containers will be placed on core X, X+1, X+2, so on.
+  * Run vSwitch on cores 0 through X-1 to avoid interference.
+* `VM_VCPUS`: # of virtual cores per VM/containers. Default: 2
   * One core is reserved for background processes.
-  * The other N-1 cores will be used for forwarding
+  * The other N-1 cores will be used for forwarding.
 * `VM_MEM_SOCKET`: Default: 0
 * `HUGEPAGES_PATH`: Default: /dev/hugepages
-* `FWD_MODE`: Default: "macswap retry"
-  * The forwarding mode of the 
+* `FWD_MODE`: testpmd forwarding mode. Default: "macswap retry"
+  * With "io retry", packet payload won't be touched by guests.
+  * If you skip "retry", guests will discard received packets if TXQ is full.
   * See [DPDK User guide](http://dpdk.org/doc/guides/testpmd_app_ug/index.html)
 * `BESS_PORTS`: # of virtio ports per VM. Default: 2
 * `BESS_QUEUES`: # of RX/TX queue pairs per port. Default: 1

--- a/bessctl/conf/port/vhost/launch_container.py
+++ b/bessctl/conf/port/vhost/launch_container.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import sys
+import subprocess
+import time
+import shlex
+
+# How many cores we reserve for vSwitches?
+# If set to 2, Containers will run on core 2, 3, 4, ..., skipping core 0-1.
+VM_START_CPU = int(os.getenv('VM_START_CPU', '1'))
+VM_MEM_SOCKET = int(os.getenv('VM_MEM_SOCKET', '0'))
+
+HUGEPAGES_PATH = os.getenv('HUGEPAGES_PATH', '/dev/hugepages')
+
+# "io retry" gives better throughput as the VM will not touch the packet
+# payload, but it is somewhat unrealistic...
+FWD_MODE = os.getenv('FWD_MODE', 'macswap retry')
+
+# per container configuration
+# NUM_CPUS cores are used for forwarding
+NUM_VCPUS = int(os.getenv('VM_VCPUS', '2'))
+NUM_VPORTS = int(os.getenv('BESS_PORTS', '2'))
+NUM_QUEUES = int(os.getenv('BESS_QUEUES', '1'))
+
+VERBOSE = int(os.getenv('VERBOSE', '0'))
+
+SOCKDIR = '/tmp/bessd'
+IMAGE = 'nefelinetworks/bess_build'
+
+
+def launch(cid):
+    print('Running container {} as a forwarder'.format(cid))
+    first_cpu = VM_START_CPU + cid * NUM_VCPUS
+    last_cpu = first_cpu + NUM_VCPUS - 1
+    eal_opts = '--file-prefix=vnf{} --no-pci -m 256 -l 0,{}-{}'.format(
+        cid, first_cpu, last_cpu)
+
+    for port_id in range(NUM_VPORTS):
+        sockpath = '{}/vhost_user{}_{}.sock'.format(SOCKDIR, cid, port_id)
+        eal_opts += ' --vdev=virtio_user{},path={}'.format(port_id, sockpath)
+
+    testpmd_opts = '-i --burst=64 --txd=1024 --rxd=1024 --disable-hw-vlan ' \
+        '--txqflags=0xf01 --txq={q} --rxq={q} --nb-cores={cores}'.format(
+            q=NUM_QUEUES, cores=NUM_VCPUS)
+
+    if subprocess.check_output(['numactl', '-H']).find(' 1 nodes') >= 0:
+        cmd = ''
+    else:
+        cmd = 'numactl -m %d ' % VM_MEM_SOCKET
+
+    cmd += 'docker run -i --rm -v {huge}:{huge} -v {sock}:{sock} ' \
+           '{image} {cmd} {eal_options} -- {testpmd_options}'.format(
+               huge=HUGEPAGES_PATH, sock=SOCKDIR, image=IMAGE,
+            cmd='/build/dpdk-17.05/build/app/testpmd', eal_options=eal_opts,
+            testpmd_options=testpmd_opts)
+
+    if VERBOSE:
+        out = None  # to screen
+        print(cmd)
+    else:
+        out = subprocess.PIPE
+
+    proc = subprocess.Popen(shlex.split(cmd), stdin=subprocess.PIPE,
+                            stdout=out, stderr=subprocess.STDOUT)
+    proc.stdin.write('set fwd {}\n'.format(FWD_MODE))
+    proc.stdin.write('start\n')
+    return proc
+
+
+def main(argv):
+    if len(argv) != 2:
+        print('Usage: %s <# of containers to launch>' %
+              argv[0], file=sys.stderr)
+        return 2
+
+    num_containers = int(argv[1])
+
+    try:
+        procs = [launch(i) for i in range(num_containers)]
+
+        print('Press Ctrl+C to terminate all containers')
+        while True:
+            time.sleep(100)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        for proc in procs:
+            print('Terminating container (pid=%d)' % proc.pid)
+            proc.kill()
+            proc.wait()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/bessctl/conf/port/vhost/vhost.bess
+++ b/bessctl/conf/port/vhost/vhost.bess
@@ -57,4 +57,4 @@ for i in range(NUM_VMS):
             qinc -> sink
             qinc.attach_task(parent='nf_to_host')
 
-print('Run launch_vm.py to launch VMs')
+print('Now you can run either launch_vm.py or launch_container.py')

--- a/bessctl/conf/port/vhost/vhost.bess
+++ b/bessctl/conf/port/vhost/vhost.bess
@@ -6,9 +6,9 @@ import string
 from socket import inet_aton as aton
 
 PKT_SIZE = int($BESS_PKT_SIZE!'60')
-NUM_VMS = int(os.getenv('BESS_VMS', '1'))
-NUM_VPORTS = int(os.getenv('BESS_PORTS', '2'))
-NUM_QUEUES = int(os.getenv('BESS_QUEUES', '1'))
+NUM_VMS = int($BESS_VMS!'1')
+NUM_VPORTS = int($BESS_PORTS!'2')
+NUM_QUEUES = int($BESS_QUEUES!'1')
 
 # QEMU 2.8 supports up to 1024, older versions are hardcoded with 256
 QSIZE = int($BESS_QSIZE!'2048')

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -98,13 +98,19 @@ static void init_eal(const char *prog_name, int mb_per_socket,
   rte_argv[rte_argc++] = opt_master_lcore;
   rte_argv[rte_argc++] = "--lcore";
   rte_argv[rte_argc++] = opt_lcore_bitmap;
-  rte_argv[rte_argc++] = "-n";
-  rte_argv[rte_argc++] = "4"; /* number of memory channels (Sandy Bridge) */
+
+  // Do not bother with /var/run/.rte_config and .rte_hugepage_info,
+  // since we don't want to interfere with other DPDK applications.
+  rte_argv[rte_argc++] = "--no-shconf";
   if (no_huge) {
     rte_argv[rte_argc++] = "--no-huge";
   } else {
     rte_argv[rte_argc++] = "--socket-mem";
     rte_argv[rte_argc++] = opt_socket_mem;
+
+    // Unlink mapped hugepage files so that memory can be reclaimed as soon as
+    // bessd terminates.
+    rte_argv[rte_argc++] = "--huge-unlink";
   }
   if (!no_huge && multi_instance) {
     snprintf(opt_file_prefix, sizeof(opt_file_prefix), "rte%lld",


### PR DESCRIPTION
Same as #529, but for containers this time.

To allow BESS and containers (both DPDK applications) to run in the same domain, `--no-shconf` and `--huge-unlink` options to the EAL options of BESS.