### PR TITLE
Fix ratelimit overflow

### DIFF
--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -497,12 +497,10 @@ class RateLimitTrafficClass final : public TrafficClass {
 
   void TraverseChildren(std::function<void(TCChildArgs *)>) const override;
 
-  // Convert resource units to work units per cycle
+  // Convert resource units to work units per cycle.
+  // Not meant to be used in the datapath: slow due to 128bit operations
   static uint64_t to_work_units_per_cycle(uint64_t x) {
-    // We sacrifice 10 least significant bits of tsc_hz to avoid overflow.
-    // (it should be less than measurement error anyway)
-    // x (resource units / second) should be less than 2^42 (~4.4 Tbps)
-    return (x << (kUsageAmplifierPow - 10)) / (tsc_hz >> 10);
+    return (static_cast<unsigned __int128>(x) << kUsageAmplifierPow) / tsc_hz;
   }
 
   // Convert resource units to work units

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -23,8 +23,6 @@ namespace bess {
 // A large default priority.
 #define DEFAULT_PRIORITY 0xFFFFFFFFu
 
-#define USAGE_AMPLIFIER_POW 32
-
 // Share is defined relatively, so 1024 should be large enough
 #define STRIDE1 (1 << 20)
 
@@ -504,20 +502,22 @@ class RateLimitTrafficClass final : public TrafficClass {
     // We sacrifice 10 least significant bits of tsc_hz to avoid overflow.
     // (it should be less than measurement error anyway)
     // x (resource units / second) should be less than 2^42 (~4.4 Tbps)
-    return (x << (USAGE_AMPLIFIER_POW - 10)) / (tsc_hz >> 10);
+    return (x << (kUsageAmplifierPow - 10)) / (tsc_hz >> 10);
   }
 
   // Convert resource units to work units
-  static uint64_t to_work_units(uint64_t x) { return x << USAGE_AMPLIFIER_POW; }
+  static uint64_t to_work_units(uint64_t x) { return x << kUsageAmplifierPow; }
 
  private:
   template <typename CallableTask>
   friend class Scheduler;
 
+  static const int kUsageAmplifierPow = 32;
+
   // The resource that we are limiting.
   resource_t resource_;
 
-  // 1 work unit = 2 ^ USAGE_AMPLIFIER_POW resource usage.
+  // 1 work unit = 2 ^ kUsageAmplifierPow resource usage.
   // (for better precision without using floating point numbers)
   uint64_t limit_;          // In work units per cycle (0 if unlimited).
   uint64_t limit_arg_;      // In resource units per second.


### PR DESCRIPTION
#534 is caused by `uint64_t` overflow while converting resource limit in resource/s to work/cycle, if the input is greater than 2^36/s. This PR is a hot fix to increase the threshold to 2^42/s (e.g., 4.4 Tbps), which should be practically good for now.