### PR TITLE
Remove invalid apt-get package in ansible-playbook

### DIFF
--- a/env/packages.yml
+++ b/env/packages.yml
@@ -70,7 +70,7 @@
       git: repo=https://github.com/google/grpc dest=/tmp/grpc accept_hostkey=yes version=v1.3.2
 
     - name: Compile gRPC and its dependencies
-      shell: make -j{{ ansible_processor_vcpus }} chdir=/tmp/grpc
+      shell: make -j{{ ansible_processor_vcpus }} HAS_SYSTEM_PROTOBUF=false chdir=/tmp/grpc
       environment:
         - CC: gcc-5
         - CXX: g++-5

--- a/env/packages.yml
+++ b/env/packages.yml
@@ -59,7 +59,7 @@
       become: true
 
     - name: Wipe prior protobuf installs to avoid conflicts
-      shell: apt-get remove -y -f libprotobuf* protobuf-*; sudo rm -f `which protoc` warn=no
+      shell: apt-get remove -y -f libprotobuf* protobuf-*; rm -f `which protoc` warn=no
       become: true
 
     - name: sudo ldconfig

--- a/env/packages.yml
+++ b/env/packages.yml
@@ -59,7 +59,7 @@
       become: true
 
     - name: Wipe prior protobuf installs to avoid conflicts
-      shell: apt-get remove -y -f libprotobuf* protobuf-* protoc; sudo rm -f `which protoc` warn=no
+      shell: apt-get remove -y -f libprotobuf* protobuf-*; sudo rm -f `which protoc` warn=no
       become: true
 
     - name: sudo ldconfig


### PR DESCRIPTION
The protoc package doesn't exist, and so the `apt-get remove`
operation that was supposed to wipe previous protobuf installs failed.