### PR TITLE
Fix ignore wrong direction parameter to tcpdump

### DIFF
--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -397,6 +397,8 @@ class BESS(object):
             request.igate = gate
         elif direction == 'out':
             request.ogate = gate
+        else:
+            raise self.APIError('direction must be either "out" or "in"')
         request.arg.Pack(arg)
         return self._request('ConfigureGateHook', request)
 


### PR DESCRIPTION
tcpdump command doesnt recognize wrong parameter to the
direction which can result in unexpected behaivour, for example
'tcpdump <module> output 3'
This fix make sure the direction is either 'out' or 'in'