### PR TITLE
Standardized Field types

### DIFF
--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -24,7 +24,8 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
 # L4 protocol and source/destination IP addresses
 em::ExactMatch(fields=[{'offset':23, 'size':1},
                        {'offset':26, 'size':4},
-                       {'offset':30, 'size':4}])
+                       {'offset':30, 'size':4}],
+                masks=[{'value_int':0xff},{'value_int':0xff},{'value_int':0xff}])
 
 Source() -> Rewrite(templates=packets) -> em
 
@@ -33,12 +34,12 @@ em:1 -> Sink()
 em:2 -> Sink()
 em:5 -> Sink()   # used as default gate
 
-em.add(fields=[chr(17), aton('172.16.100.1'), aton('10.0.0.1')], gate=0)
-em.add(fields=[chr(6), aton('172.12.55.99'), aton('12.34.56.78')], gate=1)
-em.add(fields=[chr(17), aton('172.12.55.99'), aton('12.34.56.78')], gate=2)
+em.add(fields=[{'value_int':17}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
+em.add(fields=[{'value_int':6}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
+em.add(fields=[{'value_int':17}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
 
 # delete test
-em.add(fields=[chr(17), aton('192.168.1.123'), aton('12.34.56.78')], gate=3)
-em.delete(fields=[chr(17), aton('192.168.1.123'), aton('12.34.56.78')])
+em.add(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
+em.delete(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
 
 em.set_default_gate(gate=5)

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -22,13 +22,13 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
           ]
 
 # L4 protocol and source/destination IP addresses
-#em::ExactMatch(fields=[{'offset':23, 'size':1},
-#                       {'offset':26, 'size':4},
-#                       {'offset':30, 'size':4}])
+em::ExactMatch(fields=[{'offset':23, 'size':1},
+                       {'offset':26, 'size':4},
+                       {'offset':30, 'size':4}])
 
-em::ExactMatch(fields=[{'offset':23, 'size':1}])
-em.add(fields=[{'value_bin':b'\x11'}], gate=0)
-em.add(fields=[{'value_bin':b'\x06'}], gate=1)
+#em::ExactMatch(fields=[{'offset':23, 'size':1}])
+#em.add(fields=[{'value_bin':b'\x11'}], gate=0)
+#em.add(fields=[{'value_bin':b'\x06'}], gate=1)
 
 Source() -> Rewrite(templates=packets) -> em
 
@@ -37,12 +37,12 @@ em:1 -> Sink()
 em:2 -> Sink()
 em:5 -> Sink()   # used as default gate
 
-#em.add(fields=[{'value_int':17}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
-#em.add(fields=[{'value_int':6}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
-#em.add(fields=[{'value_int':17}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
+em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
+em.add(fields=[{'value_bin':chr(6)}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
+em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
 
 # delete test
-#em.add(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
-#em.delete(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
+em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
+em.delete(fields=[{'value_bin':chr(17)}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
 
 em.set_default_gate(gate=5)

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -22,10 +22,13 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
           ]
 
 # L4 protocol and source/destination IP addresses
-em::ExactMatch(fields=[{'offset':23, 'size':1},
-                       {'offset':26, 'size':4},
-                       {'offset':30, 'size':4}],
-                masks=[{'value_int':0xff},{'value_int':0xff},{'value_int':0xff}])
+#em::ExactMatch(fields=[{'offset':23, 'size':1},
+#                       {'offset':26, 'size':4},
+#                       {'offset':30, 'size':4}])
+
+em::ExactMatch(fields=[{'offset':23, 'size':1}])
+em.add(fields=[{'value_bin':b'\x11'}], gate=0)
+em.add(fields=[{'value_bin':b'\x06'}], gate=1)
 
 Source() -> Rewrite(templates=packets) -> em
 
@@ -34,12 +37,12 @@ em:1 -> Sink()
 em:2 -> Sink()
 em:5 -> Sink()   # used as default gate
 
-em.add(fields=[{'value_int':17}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
-em.add(fields=[{'value_int':6}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
-em.add(fields=[{'value_int':17}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
+#em.add(fields=[{'value_int':17}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
+#em.add(fields=[{'value_int':6}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
+#em.add(fields=[{'value_int':17}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
 
 # delete test
-em.add(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
-em.delete(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
+#em.add(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
+#em.delete(fields=[{'value_int':17}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
 
 em.set_default_gate(gate=5)

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -26,10 +26,6 @@ em::ExactMatch(fields=[{'offset':23, 'size':1},
                        {'offset':26, 'size':4},
                        {'offset':30, 'size':4}])
 
-#em::ExactMatch(fields=[{'offset':23, 'size':1}])
-#em.add(fields=[{'value_bin':b'\x11'}], gate=0)
-#em.add(fields=[{'value_bin':b'\x06'}], gate=1)
-
 Source() -> Rewrite(templates=packets) -> em
 
 em:0 -> Sink()

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -37,9 +37,9 @@ em:1 -> Sink()
 em:2 -> Sink()
 em:5 -> Sink()   # used as default gate
 
-em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
-em.add(fields=[{'value_bin':chr(6)}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
-em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
+em.add(fields=[{'value_int':17}, {'value_bin':aton('172.16.100.1')}, {'value_bin':aton('10.0.0.1')}], gate=0)
+em.add(fields=[{'value_int':6}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=1)
+em.add(fields=[{'value_int':17}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
 
 # delete test
 em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -22,9 +22,9 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
           ]
 
 # L4 protocol and source/destination IP addresses
-em::ExactMatch(fields=[{'offset':23, 'size':1},
-                       {'offset':26, 'size':4},
-                       {'offset':30, 'size':4}])
+em::ExactMatch(fields=[{'offset':23, 'num_bytes':1},
+                       {'offset':26, 'num_bytes':4},
+                       {'offset':30, 'num_bytes':4}])
 
 Source() -> Rewrite(templates=packets) -> em
 

--- a/bessctl/conf/samples/generic_encap.bess
+++ b/bessctl/conf/samples/generic_encap.bess
@@ -13,7 +13,7 @@ Source() \
         -> SetMetadata(attrs=[{'name': 'ether_type', 'size': 2, 'value_int': 0x9876}]) \
         -> Rewrite(templates=[test_packet]) \
         -> GenericEncap(fields=[ \
-        {'num_bytes': 6, 'value': {'value_int': 0x020000000001}},
-            {'num_bytes': 6, 'value': {'value_int': 0x0619deadbeef}},
-            {'num_bytes': 2, 'attribute': 'ether_type'}]) \
+        {'size': 6, 'value': {'value_int': 0x020000000001}},
+            {'size': 6, 'value': {'value_int': 0x0619deadbeef}},
+            {'size': 2, 'attribute': 'ether_type'}]) \
         -> Sink()

--- a/bessctl/conf/samples/generic_encap.bess
+++ b/bessctl/conf/samples/generic_encap.bess
@@ -13,7 +13,7 @@ Source() \
         -> SetMetadata(attrs=[{'name': 'ether_type', 'size': 2, 'value_int': 0x9876}]) \
         -> Rewrite(templates=[test_packet]) \
         -> GenericEncap(fields=[ \
-            {'size': 6, 'value': 0x020000000001},
-            {'size': 6, 'value': 0x0619deadbeef},
+        {'size': 6, 'value': {'value_int': 0x020000000001}},
+            {'size': 6, 'value': {'value_int': 0x0619deadbeef}},
             {'size': 2, 'attribute': 'ether_type'}]) \
         -> Sink()

--- a/bessctl/conf/samples/generic_encap.bess
+++ b/bessctl/conf/samples/generic_encap.bess
@@ -13,7 +13,7 @@ Source() \
         -> SetMetadata(attrs=[{'name': 'ether_type', 'size': 2, 'value_int': 0x9876}]) \
         -> Rewrite(templates=[test_packet]) \
         -> GenericEncap(fields=[ \
-        {'size': 6, 'value': {'value_int': 0x020000000001}},
-            {'size': 6, 'value': {'value_int': 0x0619deadbeef}},
-            {'size': 2, 'attribute': 'ether_type'}]) \
+        {'num_bytes': 6, 'value': {'value_int': 0x020000000001}},
+            {'num_bytes': 6, 'value': {'value_int': 0x0619deadbeef}},
+            {'num_bytes': 2, 'attribute': 'ether_type'}]) \
         -> Sink()

--- a/bessctl/conf/samples/wildcardmatch.bess
+++ b/bessctl/conf/samples/wildcardmatch.bess
@@ -3,7 +3,7 @@ import socket
 import struct
 
 def atoh(ip):
-    return struct.unpack("!L", socket.inet_aton(ip))[0]
+    return socket.inet_aton(ip)
 
 # Craft a packet with the specified IP address and port number
 def gen_packet(dst_ip, dst_port):
@@ -24,7 +24,7 @@ pkts = [gen_packet('172.16.100.1', 80),
 # destination IP address + destination port number + metadata 'in_port'
 wm::WildcardMatch(fields=[{'offset':30, 'size':4},
                           {'offset':36, 'size':2},
-                          {'attribute':'in_port', 'size':2}])
+                          {'attr_name':'in_port', 'size':2}])
 
 # locally emulate two input ports
 Source() -> SetMetadata(attrs=[{'name': 'in_port', 'size': 2, 'value_int': 1}]) -> Rewrite(templates=pkts) -> wm
@@ -39,27 +39,27 @@ wm:5 -> Sink()   # used as default gate
 wm.set_default_gate(gate=5)
 
 # 172.16.100.1/32, port 80, in_port 1
-wm.add(values=[atoh('172.16.100.1'),    80,         1       ], gate=0,
-        masks=[atoh('255.255.255.255'), 0xffff,     0xffff  ], priority=3)
+wm.add(values=[{'value_bin':atoh('172.16.100.1')},  {'value_int':80}, {'value_int': 1}], gate=0,
+        masks=[{'value_bin':atoh('255.255.255.255')}, {'value_int':0xffff}, {'value_int':0xffff}], priority=3)
 
 # 172.12.55.99/32, in_port 2
-wm.add(values=[atoh('172.12.55.99'),    0,          2       ], gate=1,
-        masks=[atoh('255.255.255.255'), 0x0000,     0xffff  ], priority=1)
+wm.add(values=[{'value_bin':atoh('172.12.55.99')}, {'value_int': 0}, {'value_int':  2}], gate=1,
+        masks=[{'value_bin':atoh('255.255.255.255')}, {'value_int': 0}, {'value_int':0xffff }], priority=1)
 
 # 172.12.55.3/32, in_port 1 (w/ the same wildcard pattern as the previous one)
-wm.add(values=[atoh('172.12.55.3'),     0,          1       ], gate=2,
-        masks=[atoh('255.255.255.255'), 0x0000,     0xffff  ], priority=0)
+wm.add(values=[{'value_bin':atoh('172.12.55.3')},{'value_int': 0},  {'value_int':1} ], gate=2,
+        masks=[{'value_bin':atoh('255.255.255.255')},{'value_int':0x0000},{'value_int': 0xffff}], priority=0)
 
 # 172.0.0.0/8, port <= 1023
-wm.add(values=[atoh('172.0.0.0'),       0,          0       ], gate=2,
-        masks=[atoh('255.0.0.0'),       0xfc00,     0x0000  ], priority=2)
+wm.add(values=[{'value_bin':atoh('172.0.0.0')},{'value_int':0},{'value_int':0}], gate=2,
+        masks=[{'value_bin':atoh('255.0.0.0')},{'value_int': 0xfc00},{'value_int':0x0000}], priority=2)
 
 # port 80
-wm.add(values=[atoh('0.0.0.0'),         80,         0       ], gate=3,
-        masks=[atoh('0.0.0.0'),         0xffff,     0x0000  ], priority=0)
+wm.add(values=[{'value_bin':atoh('0.0.0.0')}, {'value_int': 80}, {'value_int': 0}], gate=3,
+    masks=[{'value_bin':atoh('0.0.0.0')},{'value_int':0xffff},{'value_int':0x0000}], priority=0)
 
 # delete test
-wm.add(values=[atoh('172.12.55.0'),     0,          0       ], gate=0,
-        masks=[atoh('255.255.255.0'),   0x0000,     0x0000  ], priority=4)
-wm.delete(values=[atoh('172.12.55.0'),     0,          0       ],
-           masks=[atoh('255.255.255.0'),   0x0000,     0x0000  ])
+wm.add(values=[{'value_bin':atoh('172.12.55.0')},{'value_int':0},{'value_int':0}], gate=0,
+    masks=[{'value_bin':atoh('255.255.255.0')},{'value_int': 0x0000},{'value_int':0x0000}], priority=4)
+wm.delete(values=[{'value_bin':atoh('172.12.55.0')},{'value_int': 0},{'value_int':  0}],
+    masks=[{'value_bin':atoh('255.255.255.0')}, {'value_int':0x0000},{'value_int': 0x0000}  ])

--- a/bessctl/conf/samples/wildcardmatch.bess
+++ b/bessctl/conf/samples/wildcardmatch.bess
@@ -22,13 +22,13 @@ pkts = [gen_packet('172.16.100.1', 80),
         gen_packet('192.168.1.123', 80)]
 
 # destination IP address + destination port number + metadata 'in_port'
-wm::WildcardMatch(fields=[{'offset':30, 'size':4},
-                          {'offset':36, 'size':2},
-                          {'attr_name':'in_port', 'size':2}])
+wm::WildcardMatch(fields=[{'offset':30, 'num_bytes':4},
+                          {'offset':36, 'num_bytes':2},
+                          {'attr_name':'in_port', 'num_bytes':2}])
 
 # locally emulate two input ports
-Source() -> SetMetadata(attrs=[{'name': 'in_port', 'size': 2, 'value_int': 1}]) -> Rewrite(templates=pkts) -> wm
-Source() -> SetMetadata(attrs=[{'name': 'in_port', 'size': 2, 'value_int': 2}]) -> Rewrite(templates=pkts) -> wm
+Source() -> SetMetadata(attrs=[{'name': 'in_port', 'num_bytes': 2, 'value_int': 1}]) -> Rewrite(templates=pkts) -> wm
+Source() -> SetMetadata(attrs=[{'name': 'in_port', 'num_bytes': 2, 'value_int': 2}]) -> Rewrite(templates=pkts) -> wm
 
 wm:0 -> Sink()
 wm:1 -> Sink()

--- a/bessctl/conf/samples/wildcardmatch.bess
+++ b/bessctl/conf/samples/wildcardmatch.bess
@@ -27,8 +27,8 @@ wm::WildcardMatch(fields=[{'offset':30, 'num_bytes':4},
                           {'attr_name':'in_port', 'num_bytes':2}])
 
 # locally emulate two input ports
-Source() -> SetMetadata(attrs=[{'name': 'in_port', 'num_bytes': 2, 'value_int': 1}]) -> Rewrite(templates=pkts) -> wm
-Source() -> SetMetadata(attrs=[{'name': 'in_port', 'num_bytes': 2, 'value_int': 2}]) -> Rewrite(templates=pkts) -> wm
+Source() -> SetMetadata(attrs=[{'name': 'in_port', 'size': 2, 'value_int': 1}]) -> Rewrite(templates=pkts) -> wm
+Source() -> SetMetadata(attrs=[{'name': 'in_port', 'size': 2, 'value_int': 2}]) -> Rewrite(templates=pkts) -> wm
 
 wm:0 -> Sink()
 wm:1 -> Sink()

--- a/bessctl/conf/testing/module_tests/drr.py
+++ b/bessctl/conf/testing/module_tests/drr.py
@@ -1,10 +1,14 @@
 import scapy.all as scapy
 
-#ensures that given infinite input that the module does not crash.
+# ensures that given infinite input that the module does not crash.
+
+
 def crash_test():
     return [DRR(), 1, 1]
 
 # tests to make that inividual packets gets through the module
+
+
 def basic_output_test():
 
     # produces the number of duplicate packets specified by num_pkts and uses the provided
@@ -45,10 +49,12 @@ def fairness_test():
         err = bess.reset_all()
 
         packets = []
-        exm = ExactMatch(fields=[{'offset':26, 'size':4}])
-        for i in range(1, n+1):
-           packets.append(bytes(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i))))
-           exm.add(fields=[socket.inet_aton('22.11.11.' + str(i))], gate=i)
+        exm = ExactMatch(fields=[{'offset': 26, 'size': 4}])
+        for i in range(1, n + 1):
+            packets.append(
+                bytes(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i))))
+            exm.add(
+                fields=[{'value_bin': socket.inet_aton('22.11.11.' + str(i))}], gate=i)
 
         me_in = Measure()
         src = []
@@ -62,27 +68,28 @@ def fairness_test():
 
         me_out = Measure()
         snk = Sink()
-        q = DRR(num_flows= n+1, quantum=quantum)
+        q = DRR(num_flows=n + 1, quantum=quantum)
         me_in -> q -> me_out -> exm
 
         measure_out = []
-        for i in range(1, n+1):
+        for i in range(1, n + 1):
             measure_out.append(Measure())
-            exm:i -> measure_out[i-1] -> snk
+            exm:
+                i -> measure_out[i - 1] -> snk
 
         for i in range(0, n):
-            bess.add_tc('r'+ str(i) , policy='rate_limit', resource='packet',
-                    limit={'packet': rates[i]})
-            src[i].attach_task(parent='r'+ str(i))
+            bess.add_tc('r' + str(i), policy='rate_limit', resource='packet',
+                        limit={'packet': rates[i]})
+            src[i].attach_task(parent='r' + str(i))
 
         bess.add_tc('output', policy='rate_limit', resource='packet',
-                limit={'packet': module_rate})
+                    limit={'packet': module_rate})
         q.attach_task(parent='output')
 
         bess.resume_all()
         time.sleep(5)
         bess.pause_all()
-        f = lambda m : (float)((m.get_summary().packets)**2)
+        f = lambda m: (float)((m.get_summary().packets)**2)
         square_sum = 0
         for i in range(n):
             square_sum += f(measure_out[i])
@@ -91,14 +98,16 @@ def fairness_test():
         if square_sum == 0:
             fair = 0
         else:
-            fair = f(me_out)/square_sum
-        assert abs(.99 - fair) <=.05
+            fair = f(me_out) / square_sum
+        assert abs(.99 - fair) <= .05
 
     fairness_n_flow_test(2, 1000, [80000, 20000], 30000)
-    fairness_n_flow_test(5, 1000, [110000, 200000, 70000, 60000, 40000], 150000)
+    fairness_n_flow_test(
+        5, 1000, [110000, 200000, 70000, 60000, 40000], 150000)
 
-    ten_flows =  [210000, 120000, 130000, 160000, 100000, 105000, 90000, 70000, 60000, 40000]
-    fairness_n_flow_test(10, 1000, ten_flows , 300000)
+    ten_flows = [210000, 120000, 130000, 160000,
+                 100000, 105000, 90000, 70000, 60000, 40000]
+    fairness_n_flow_test(10, 1000, ten_flows, 300000)
 
     # hund_flows= []
     # cur = 200000

--- a/bessctl/conf/testing/module_tests/drr.py
+++ b/bessctl/conf/testing/module_tests/drr.py
@@ -49,7 +49,7 @@ def fairness_test():
         err = bess.reset_all()
 
         packets = []
-        exm = ExactMatch(fields=[{'offset': 26, 'size': 4}])
+        exm = ExactMatch(fields=[{'offset': 26, 'num_bytes': 4}])
         for i in range(1, n + 1):
             packets.append(
                 bytes(gen_packet(scapy.TCP, '22.11.11.' + str(i), '22.22.11.' + str(i))))

--- a/bessctl/conf/testing/module_tests/drr.py
+++ b/bessctl/conf/testing/module_tests/drr.py
@@ -74,8 +74,7 @@ def fairness_test():
         measure_out = []
         for i in range(1, n + 1):
             measure_out.append(Measure())
-            exm:
-                i -> measure_out[i - 1] -> snk
+            exm:i -> measure_out[i - 1] -> snk
 
         for i in range(0, n):
             bess.add_tc('r' + str(i), policy='rate_limit', resource='packet',

--- a/bessctl/conf/testing/module_tests/exact_match.py
+++ b/bessctl/conf/testing/module_tests/exact_match.py
@@ -1,7 +1,7 @@
 # Crash test -- generate a bunch of rules and stuff packets through
 em0 = ExactMatch(fields=[{'offset': 23, 'size': 1},  # random fields, I have no idea what these are
                          {'offset': 2, 'size': 2},
-                         {'offset': 29, 'size': 1}])
+                         {'offset': 29, 'size': 1}],
 
 em0.add(fields=[b'\xff', b'\x23\xba', b'\x34'], gate=0)
 em0.add(fields=[b'\xff', b'\x34\xaa', b'\x12'], gate=1)

--- a/bessctl/conf/testing/module_tests/exact_match.py
+++ b/bessctl/conf/testing/module_tests/exact_match.py
@@ -1,14 +1,14 @@
 # Crash test -- generate a bunch of rules and stuff packets through
 em0 = ExactMatch(fields=[{'offset': 23, 'size': 1},  # random fields, I have no idea what these are
                          {'offset': 2, 'size': 2},
-                         {'offset': 29, 'size': 1}],
+                         {'offset': 29, 'size': 1}])
 
-em0.add(fields=[b'\xff', b'\x23\xba', b'\x34'], gate=0)
-em0.add(fields=[b'\xff', b'\x34\xaa', b'\x12'], gate=1)
-em0.add(fields=[b'\xba', b'\x33\xaa', b'\x22'], gate=2)
-em0.add(fields=[b'\xaa', b'\x34\xba', b'\x32'], gate=3)
-em0.add(fields=[b'\x34', b'\x34\x7a', b'\x52'], gate=4)
-em0.add(fields=[b'\x12', b'\x34\x7a', b'\x72'], gate=5)
+em0.add(fields=[{'value_bin':b'\xff'}, {'value_bin':b'\x23\xba'}, {'value_bin':b'\x34'}], gate=0)
+em0.add(fields=[{'value_bin':b'\xff'}, {'value_bin':b'\x34\xaa'}, {'value_bin':b'\x12'}], gate=1)
+em0.add(fields=[{'value_bin':b'\xba'}, {'value_bin':b'\x33\xaa'}, {'value_bin':b'\x22'}], gate=2)
+em0.add(fields=[{'value_bin':b'\xaa'}, {'value_bin':b'\x34\xba'}, {'value_bin':b'\x32'}], gate=3)
+em0.add(fields=[{'value_bin':b'\x34'}, {'value_bin':b'\x34\x7a'}, {'value_bin':b'\x52'}], gate=4)
+em0.add(fields=[{'value_bin':b'\x12'}, {'value_bin':b'\x34\x7a'}, {'value_bin':b'\x72'}], gate=5)
 
 CRASH_TEST_INPUTS.append([em0, 1, 6])
 
@@ -17,8 +17,8 @@ CRASH_TEST_INPUTS.append([em0, 1, 6])
 em1 = ExactMatch(fields=[{'offset': 26, 'size': 4},
                          {'offset': 30, 'size': 4}])  # ip src and dst
 
-em1.add(fields=[aton('65.43.21.00'), aton('12.34.56.78')], gate=1)
-em1.add(fields=[aton('00.12.34.56'), aton('12.34.56.78')], gate=2)
+em1.add(fields=[{'value_bin':aton('65.43.21.00')}, {'value_bin':aton('12.34.56.78')}], gate=1)
+em1.add(fields=[{'value_bin':aton('00.12.34.56')}, {'value_bin':aton('12.34.56.78')}], gate=2)
 em1.set_default_gate(gate=3)
 
 test_packet1 = gen_packet(scapy.TCP, '65.43.21.00', '12.34.56.78')  # match 1
@@ -50,9 +50,9 @@ OUTPUT_TEST_INPUTS.append([em1, 1, 4,
 def exactmatch_test_with_metadata():
     # One exact match field
     em2 = ExactMatch(
-        fields=[{"attribute": "sangjin", "size": 2, "mask_bin": b'\xff\xf0'}])
-    em2.add(fields=[b'\x88\x80'], gate=1)
-    em2.add(fields=[b'\x77\x70'], gate=2)
+        fields=[{"attr_name": "sangjin", "size": 2}],masks=[{"value_bin": b'\xff\xf0'}])
+    em2.add(fields=[{'value_bin':b'\x88\x80'}], gate=1)
+    em2.add(fields=[{'value_bin':b'\x77\x70'}], gate=2)
     em2.set_default_gate(gate=0)
 
     # Only need one test packet

--- a/bessctl/conf/testing/module_tests/exact_match.py
+++ b/bessctl/conf/testing/module_tests/exact_match.py
@@ -1,7 +1,7 @@
 # Crash test -- generate a bunch of rules and stuff packets through
-em0 = ExactMatch(fields=[{'offset': 23, 'size': 1},  # random fields, I have no idea what these are
-                         {'offset': 2, 'size': 2},
-                         {'offset': 29, 'size': 1}])
+em0 = ExactMatch(fields=[{'offset': 23, 'num_bytes': 1},  # random fields, I have no idea what these are
+                         {'offset': 2, 'num_bytes': 2},
+                         {'offset': 29, 'num_bytes': 1}])
 
 em0.add(fields=[{'value_bin':b'\xff'}, {'value_bin':b'\x23\xba'}, {'value_bin':b'\x34'}], gate=0)
 em0.add(fields=[{'value_bin':b'\xff'}, {'value_bin':b'\x34\xaa'}, {'value_bin':b'\x12'}], gate=1)
@@ -14,8 +14,8 @@ CRASH_TEST_INPUTS.append([em0, 1, 6])
 
 
 # Output test over fields -- just make sure packets go out right ports
-em1 = ExactMatch(fields=[{'offset': 26, 'size': 4},
-                         {'offset': 30, 'size': 4}])  # ip src and dst
+em1 = ExactMatch(fields=[{'offset': 26, 'num_bytes': 4},
+                         {'offset': 30, 'num_bytes': 4}])  # ip src and dst
 
 em1.add(fields=[{'value_bin':aton('65.43.21.00')}, {'value_bin':aton('12.34.56.78')}], gate=1)
 em1.add(fields=[{'value_bin':aton('00.12.34.56')}, {'value_bin':aton('12.34.56.78')}], gate=2)
@@ -50,7 +50,7 @@ OUTPUT_TEST_INPUTS.append([em1, 1, 4,
 def exactmatch_test_with_metadata():
     # One exact match field
     em2 = ExactMatch(
-        fields=[{"attr_name": "sangjin", "size": 2}],masks=[{"value_bin": b'\xff\xf0'}])
+        fields=[{"attr_name": "sangjin", "num_bytes": 2}],masks=[{"value_bin": b'\xff\xf0'}])
     em2.add(fields=[{'value_bin':b'\x88\x80'}], gate=1)
     em2.add(fields=[{'value_bin':b'\x77\x70'}], gate=2)
     em2.set_default_gate(gate=0)

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -78,13 +78,19 @@ CommandResponse ExactMatch::AddFieldOne(
 CommandResponse ExactMatch::Init(const bess::pb::ExactMatchArg &arg) {
   int size_acc = 0;
 
-  for (auto i = 0; i < arg.fields_size(); ++i) {
+  RepeatedPtrField<bess::pb::Field> fields = arg.fields();
+  RepeatedPtrField<bess::pb::FieldData> masks = arg.masks();
+
+  for (auto i = 0; i < arg.fields().size(); ++i) {
     CommandResponse err;
     struct EmField *f = &fields_[i];
 
     f->pos = size_acc;
 
-    err = AddFieldOne(arg.fields(i), arg.masks(i), f, i);
+    bess::pb::Field fnm = arg.fields().Get(i);
+    bess::pb::FieldData fd = arg.masks().Get(i);
+
+    err = AddFieldOne(arg.fields().Get(i), arg.masks().Get(i), f, i);
     if (err.error().code() != 0) {
       return err;
     }

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -21,8 +21,9 @@ const Commands ExactMatch::cmds = {
     {"set_default_gate", "ExactMatchCommandSetDefaultGateArg",
      MODULE_CMD_FUNC(&ExactMatch::CommandSetDefaultGate), 1}};
 
-CommandResponse ExactMatch::AddFieldOne(
-    const bess::pb::Field &field, struct EmField *f, int idx) {
+CommandResponse ExactMatch::AddFieldOne(const bess::pb::Field &field,
+                                        const bess::pb::FieldData &mask,
+                                        struct EmField *f, int idx) {
   f->size = field.size();
   if (f->size < 1 || f->size > MAX_FIELD_SIZE) {
     return CommandFailure(EINVAL, "idx %d: 'size' must be 1-%d", idx,
@@ -48,23 +49,21 @@ CommandResponse ExactMatch::AddFieldOne(
                           idx);
   }
 
-  //bool force_be = (f->attr_id < 0);
-  /*
-  if (field.mask_case() == bess::pb::ExactMatchArg_Field::kMaskInt) {
-    if (!bess::utils::uint64_to_bin(&f->mask, field.mask_int(), f->size,
+  bool force_be = (f->attr_id < 0);
+
+  if (mask.encoding_case() == bess::pb::FieldData::kValueInt) {
+    if (!bess::utils::uint64_to_bin(&f->mask, mask.value_int(), f->size,
                                     bess::utils::is_be_system() || force_be)) {
       return CommandFailure(EINVAL, "idx %d: not a correct %d-byte mask", idx,
                             f->size);
     }
-  } else if (field.mask_case() == bess::pb::ExactMatchArg_Field::kMaskBin) {
-    if (field.mask_bin().size() != (size_t)f->size) {
+  } else if (mask.encoding_case() == bess::pb::FieldData::kValueBin) {
+    if (mask.value_bin().size() != (size_t)f->size) {
       return CommandFailure(EINVAL, "idx %d: not a correct %d-byte mask", idx,
                             f->size);
     }
     bess::utils::Copy(reinterpret_cast<uint8_t *>(&(f->mask)),
-                      field.mask_bin().c_str(), field.mask_bin().size());
-  }*/
-  if (false) {
+                      mask.value_bin().c_str(), mask.value_bin().size());
   } else {
     // by default all bits are considered
     f->mask =
@@ -81,13 +80,25 @@ CommandResponse ExactMatch::AddFieldOne(
 CommandResponse ExactMatch::Init(const bess::pb::ExactMatchArg &arg) {
   int size_acc = 0;
 
+  if (arg.fields_size() != arg.masks_size() && arg.masks_size() != 0) {
+    return CommandFailure(EINVAL,
+                          "must provide masks for all fields (or no masks for "
+                          "default match on all bits on all fields)");
+  }
+
   for (auto i = 0; i < arg.fields_size(); ++i) {
     CommandResponse err;
     struct EmField *f = &fields_[i];
 
     f->pos = size_acc;
 
-    err = AddFieldOne(arg.fields(i), f, i);
+    if (arg.masks_size() == 0) {
+      bess::pb::FieldData emptymask;
+      err = AddFieldOne(arg.fields(i), emptymask, f, i);
+    } else {
+      err = AddFieldOne(arg.fields(i), arg.masks(i), f, i);
+    }
+
     if (err.error().code() != 0) {
       return err;
     }
@@ -166,15 +177,14 @@ CommandResponse ExactMatch::GatherKey(
 
   memset(key, 0, sizeof(*key));
 
-
-  //bool force_be = (f->attr_id < 0);
+  // bool force_be = (f->attr_id < 0);
   for (auto i = 0; i < fields.size(); i++) {
     int field_size = fields_[i].size;
     int field_pos = fields_[i].pos;
 
     bess::pb::FieldData current = fields.Get(i);
 
-    if(current.encoding_case() == bess::pb::FieldData::kValueBin){
+    if (current.encoding_case() == bess::pb::FieldData::kValueBin) {
       const std::string &f_obj = fields.Get(i).value_bin();
 
       if (static_cast<size_t>(field_size) != f_obj.length()) {
@@ -182,11 +192,15 @@ CommandResponse ExactMatch::GatherKey(
                               field_size);
       }
 
-      bess::utils::Copy(reinterpret_cast<uint8_t *>(key) + field_pos, f_obj.c_str(), field_size);
-    }else{
-      //it's an int
-      if (!bess::utils::uint64_to_bin(reinterpret_cast<uint8_t *>(key), current.value_int(), field_size, bess::utils::is_be_system())) {
-        return CommandFailure(EINVAL, "value %d: not a correct %d-byte mask", (int) current.value_int(), (int) field_size);
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(key) + field_pos,
+                        f_obj.c_str(), field_size);
+    } else {
+      // it's an int
+      if (!bess::utils::uint64_to_bin(reinterpret_cast<uint8_t *>(key),
+                                      current.value_int(), field_size,
+                                      bess::utils::is_be_system())) {
+        return CommandFailure(EINVAL, "value %d: not a correct %d-byte mask",
+                              (int)current.value_int(), (int)field_size);
       }
     }
   }

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -24,7 +24,7 @@ const Commands ExactMatch::cmds = {
 CommandResponse ExactMatch::AddFieldOne(const bess::pb::Field &field,
                                         const bess::pb::FieldData &mask,
                                         struct EmField *f, int idx) {
-  f->size = field.size();
+  f->size = field.num_bytes();
   if (f->size < 1 || f->size > MAX_FIELD_SIZE) {
     return CommandFailure(EINVAL, "idx %d: 'size' must be 1-%d", idx,
                           MAX_FIELD_SIZE);
@@ -45,7 +45,7 @@ CommandResponse ExactMatch::AddFieldOne(const bess::pb::Field &field,
       return CommandFailure(EINVAL, "idx %d: invalid 'offset'", idx);
     }
   } else {
-    return CommandFailure(EINVAL, "idx %d: must specify 'offset' or 'attr'",
+    return CommandFailure(EINVAL, "idx %d: must specify 'offset' or 'attr_name'",
                           idx);
   }
 

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -118,7 +118,7 @@ class ExactMatch final : public Module {
 
  private:
   CommandResponse AddFieldOne(const bess::pb::Field &field,
-                              const bess::pb::FieldData &mask,
+                            //const bess::pb::FieldData &mask,
                               struct EmField *f, int idx);
   CommandResponse GatherKey(const RepeatedPtrField<bess::pb::FieldData> &fields,
                             em_hkey_t *key);

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -117,9 +117,10 @@ class ExactMatch final : public Module {
       const bess::pb::ExactMatchCommandSetDefaultGateArg &arg);
 
  private:
-  CommandResponse AddFieldOne(const bess::pb::ExactMatchArg_Field &field,
+  CommandResponse AddFieldOne(const bess::pb::Field &field,
+                              const bess::pb::FieldData &mask,
                               struct EmField *f, int idx);
-  CommandResponse GatherKey(const RepeatedPtrField<std::string> &fields,
+  CommandResponse GatherKey(const RepeatedPtrField<bess::pb::FieldData> &fields,
                             em_hkey_t *key);
 
   gate_idx_t default_gate_;

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -118,7 +118,7 @@ class ExactMatch final : public Module {
 
  private:
   CommandResponse AddFieldOne(const bess::pb::Field &field,
-                            //const bess::pb::FieldData &mask,
+                              const bess::pb::FieldData &mask,
                               struct EmField *f, int idx);
   CommandResponse GatherKey(const RepeatedPtrField<bess::pb::FieldData> &fields,
                             em_hkey_t *key);

--- a/core/modules/generic_encap.h
+++ b/core/modules/generic_encap.h
@@ -23,7 +23,7 @@ class GenericEncap final : public Module {
   void ProcessBatch(bess::PacketBatch *batch);
 
  private:
-  CommandResponse AddFieldOne(const bess::pb::GenericEncapArg_Field &field,
+  CommandResponse AddFieldOne(const bess::pb::GenericEncapArg_EncapField &field,
                               struct Field *f, int idx);
 
   int encap_size_;

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -38,7 +38,7 @@ const Commands WildcardMatch::cmds = {
 
 CommandResponse WildcardMatch::AddFieldOne(const bess::pb::Field &field,
                                            struct WmField *f) {
-  f->size = field.size();
+  f->size = field.num_bytes();
 
   if (f->size < 1 || f->size > MAX_FIELD_SIZE) {
     return CommandFailure(EINVAL, "'size' must be 1-%d", MAX_FIELD_SIZE);
@@ -363,7 +363,7 @@ CommandResponse WildcardMatch::CommandGetRules(const bess::pb::EmptyArg &) {
     } else {
       f->set_offset(field.offset);
     }
-    f->set_size(field.size);
+    f->set_num_bytes(field.size);
   }
 
   for (auto &tuple : tuples_) {

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -36,23 +36,22 @@ const Commands WildcardMatch::cmds = {
     {"set_default_gate", "WildcardMatchCommandSetDefaultGateArg",
      MODULE_CMD_FUNC(&WildcardMatch::CommandSetDefaultGate), 1}};
 
-CommandResponse WildcardMatch::AddFieldOne(
-    const bess::pb::WildcardMatchField &field, struct WmField *f) {
+CommandResponse WildcardMatch::AddFieldOne(const bess::pb::Field &field,
+                                           struct WmField *f) {
   f->size = field.size();
 
   if (f->size < 1 || f->size > MAX_FIELD_SIZE) {
     return CommandFailure(EINVAL, "'size' must be 1-%d", MAX_FIELD_SIZE);
   }
 
-  if (field.position_case() == bess::pb::WildcardMatchField::kOffset) {
+  if (field.position_case() == bess::pb::Field::kOffset) {
     f->attr_id = -1;
     f->offset = field.offset();
     if (f->offset < 0 || f->offset > 1024) {
       return CommandFailure(EINVAL, "too small 'offset'");
     }
-  } else if (field.position_case() ==
-             bess::pb::WildcardMatchField::kAttribute) {
-    const char *attr = field.attribute().c_str();
+  } else if (field.position_case() == bess::pb::Field::kAttrName) {
+    const char *attr = field.attr_name().c_str();
     f->attr_id = AddMetadataAttr(attr, f->size, Attribute::AccessMode::kRead);
     if (f->attr_id < 0) {
       return CommandFailure(-f->attr_id, "add_metadata_attr() failed");
@@ -198,13 +197,30 @@ CommandResponse WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
     uint64_t v = 0;
     uint64_t m = 0;
 
-    if (!bess::utils::uint64_to_bin(&v, arg.values(i), field_size, true)) {
-      return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte value", i,
-                            field_size);
-    } else if (!bess::utils::uint64_to_bin(&m, arg.masks(i), field_size,
-                                           true)) {
-      return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
-                            field_size);
+    bess::pb::FieldData valuedata = arg.values(i);
+    if (valuedata.encoding_case() == bess::pb::FieldData::kValueInt) {
+      if (!bess::utils::uint64_to_bin(&v, valuedata.value_int(), field_size,
+                                      true)) {
+        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte value", i,
+                              field_size);
+      }
+    } else if (valuedata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(&v),
+                        valuedata.value_bin().c_str(),
+                        valuedata.value_bin().size());
+    }
+
+    bess::pb::FieldData maskdata = arg.masks(i);
+    if (maskdata.encoding_case() == bess::pb::FieldData::kValueInt) {
+      if (!bess::utils::uint64_to_bin(&m, maskdata.value_int(), field_size,
+                                      true)) {
+        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
+                              field_size);
+      }
+    } else if (maskdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(&m),
+                        maskdata.value_bin().c_str(),
+                        maskdata.value_bin().size());
     }
 
     if (v & ~m) {
@@ -341,9 +357,9 @@ CommandResponse WildcardMatch::CommandGetRules(const bess::pb::EmptyArg &) {
   resp.set_default_gate(default_gate_);
 
   for (auto &field : fields_) {
-    bess::pb::WildcardMatchField *f = resp.add_fields();
+    bess::pb::Field *f = resp.add_fields();
     if (field.attr_id >= 0) {
-      f->set_attribute(all_attrs().at(field.attr_id).name);
+      f->set_attr_name(all_attrs().at(field.attr_id).name);
     } else {
       f->set_offset(field.offset);
     }

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -129,8 +129,7 @@ class WildcardMatch final : public Module {
 
   gate_idx_t LookupEntry(const wm_hkey_t &key, gate_idx_t def_gate);
 
-  CommandResponse AddFieldOne(const bess::pb::WildcardMatchField &field,
-                              struct WmField *f);
+  CommandResponse AddFieldOne(const bess::pb::Field &field, struct WmField *f);
 
   template <typename T>
   CommandResponse ExtractKeyMask(const T &arg, wm_hkey_t *key, wm_hkey_t *mask);

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package bess.pb;
+import "util_msg.proto";
 
 // Module-specific messages.
 // The header generated from this file should not be included in the BESS core
@@ -35,7 +36,7 @@ message BPFCommandClearArg {
  */
 message ExactMatchCommandAddArg {
   uint64 gate = 1; /// The gate to forward out packets that mach this rule.
-  repeated bytes fields = 2; /// The exact match values to check for
+  repeated FieldData fields = 2; /// The exact match values to check for
 }
 
 /**
@@ -43,7 +44,7 @@ message ExactMatchCommandAddArg {
  * Example use: `delete(fields=[aton('12.3.4.5'), aton('5.4.3.2')])`
  */
 message ExactMatchCommandDeleteArg {
-  repeated bytes fields = 2; /// The field values for the rule to be deleted.
+  repeated FieldData fields = 2; /// The field values for the rule to be deleted.
 }
 
 /**
@@ -438,21 +439,8 @@ message EtherEncapArg {
  * __Output Gates__: many (configurable)
  */
 message ExactMatchArg {
-  /**
-   * An ExactMatch Field specifies a field over which to check for ExactMatch rules. Field may be in EITHER the packet's data OR it's metadata attributes.
-   */
-  message Field {
-    uint64 size = 1; /// The length, in bytes, of the field to inspect
-    oneof mask {
-      uint64 mask_int = 4; /// A bitmask over the field to specify which bits to inspect (default 0xff).
-      bytes mask_bin = 5; // Same as mask_int, but in binary format.
-    }
-    oneof position {
-      string attribute = 2; ///Metadata attribute name, if field resides in metadata.
-      int64 offset = 3; /// The offset, in bytes, from the start of the packet that the field resides in (if field resides in packet data)..
-    }
-  }
   repeated Field fields = 1; ///A list of ExactMatch Fields
+  repeated FieldData masks = 2; /// mask(i) corresponds to the mask for field(i)
 }
 
 /**

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -496,16 +496,16 @@ message GenericDecapArg {
  */
 message GenericEncapArg {
   /**
-   * A GenericEncap field represents one field in the new packet header.
+   * An EncapField represents one field in the new packet header.
    */
-  message Field {
+  message EncapField {
     uint64 size = 1; /// The length of the field.
     oneof insertion {
       string attribute = 2; /// The metadata attribute name to pull the field value from
-      uint64 value = 3; /// Or, the fixed value to insert into the packet (max 8 bytes).
+      FieldData value = 3; /// Or, the fixed value to insert into the packet.
     }
   }
-  repeated Field fields = 1;
+  repeated EncapField fields = 1;
 }
 
 /**

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -289,16 +289,16 @@ message UpdateCommandClearArg {
 message WildcardMatchCommandAddArg {
   uint64 gate = 1; /// Traffic matching this new rule will be sent to this gate.
   int64 priority = 2; ///If a packet matches multiple rules, the rule with higher priority will be applied. If priorities are equal behavior is undefined.
-  repeated uint64 values = 3; /// The values to check for in each fieild.
-  repeated uint64 masks = 4; /// The bitmask for each field -- set 0x0 to ignore the field altogether.
+  repeated FieldData values = 3; /// The values to check for in each fieild.
+  repeated FieldData masks = 4; /// The bitmask for each field -- set 0x0 to ignore the field altogether.
 }
 
 /**
  * The module WildcardMatch has a command `delete(...)` which removes a rule -- simply specify the values and masks from the previously inserted rule to remove them.
  */
 message WildcardMatchCommandDeleteArg {
-  repeated uint64 values = 1; /// The values being checked for in the rule
-  repeated uint64 masks = 2; /// The bitmask from the rule.
+  repeated FieldData values = 1; /// The values being checked for in the rule
+  repeated FieldData masks = 2; /// The bitmask from the rule.
 }
 
 /**
@@ -327,23 +327,12 @@ message WildcardMatchRule {
 }
 
 /**
- * A field over which the WildcardMatch module should inspect.
- */
-message WildcardMatchField {
-  uint64 size = 1; /// The length in bytes of the field to inspect.
-  oneof position {
-    uint64 offset = 2; /// The field offset into the packet data, if the field lies in the packet itself.
-    string attribute = 3; /// The metadata attribute to inspect, if the field is a metadata attribute.
-  }
-}
-
-/**
  * The module WildcardMatch has a function `get_rules()` which
  * returns the current set of running rules.
  */
 message WildcardMatchCommandGetRulesResponse {
   uint64 default_gate = 1; /// The default gate
-  repeated WildcardMatchField fields = 2; /// The fields provided in initializing WCM
+  repeated Field fields = 2; /// The fields provided in initializing WCM
   repeated WildcardMatchRule rules = 3; /// All rules provided via calls to `WilcardMatch.add(...)`
 }
 
@@ -962,7 +951,7 @@ message VXLANEncapArg {
  * __Output Gates__: many (configurable)
  */
 message WildcardMatchArg {
-  repeated WildcardMatchField fields = 1; /// A list of WildcardMatch fields.
+  repeated Field fields = 1; /// A list of WildcardMatch fields.
 }
 
 /**

--- a/protobuf/util_msg.proto
+++ b/protobuf/util_msg.proto
@@ -1,0 +1,19 @@
+syntax="proto3";
+/// This file contains some standard "types" for messages to/from BESS
+
+package bess.pb;
+message Field {
+  oneof position {
+    string attr_name = 1;
+    uint32 offset = 2;
+  }
+  uint32 size = 3;
+}
+
+message FieldData {
+  oneof encoding {
+    bytes value_bin = 1;
+    uint64 value_int = 2;
+  }
+}
+

--- a/protobuf/util_msg.proto
+++ b/protobuf/util_msg.proto
@@ -2,6 +2,8 @@ syntax="proto3";
 /// This file contains some standard "types" for messages to/from BESS
 
 package bess.pb;
+
+/// The Field message represents one field in a packet -- either stored in metadata or in the packet body.
 message Field {
   oneof position {
     string attr_name = 1;

--- a/protobuf/util_msg.proto
+++ b/protobuf/util_msg.proto
@@ -6,16 +6,17 @@ package bess.pb;
 /// The Field message represents one field in a packet -- either stored in metadata or in the packet body.
 message Field {
   oneof position {
-    string attr_name = 1;
-    uint32 offset = 2;
+    string attr_name = 1; /// The metadata attribute assigned to store the data
+    uint32 offset = 2; /// The offset in bytes to store the data into
   }
-  uint32 size = 3;
+  uint32 size = 3; /// The size of the data in bytes
 }
 
+/// The FieldData message encodes a value to insert into a packet; the value can be supplied as either an int or a bytestring.
 message FieldData {
   oneof encoding {
-    bytes value_bin = 1;
-    uint64 value_int = 2;
+    bytes value_bin = 1; /// The value as a bytestring
+    uint64 value_int = 2; /// The value in integer format
   }
 }
 

--- a/protobuf/util_msg.proto
+++ b/protobuf/util_msg.proto
@@ -9,7 +9,7 @@ message Field {
     string attr_name = 1; /// The metadata attribute assigned to store the data
     uint32 offset = 2; /// The offset in bytes to store the data into
   }
-  uint32 size = 3; /// The size of the data in bytes
+  uint32 num_bytes = 3; /// The size of the data in bytes
 }
 
 /// The FieldData message encodes a value to insert into a packet; the value can be supplied as either an int or a bytestring.

--- a/pybess/test_bess.py
+++ b/pybess/test_bess.py
@@ -111,5 +111,5 @@ class TestBESS(unittest.TestCase):
                                              'add',
                                              'ExactMatchCommandAddArg',
                                              {'gate': 0,
-                                              'fields': [b'\x11', b'\x22']})
+                                                 'fields': [{'value_bin':b'\x11'}, {'value_bin':b'\x22'}]})
         self.assertEqual(0, response.error.code)


### PR DESCRIPTION
Creates generic "Field" and "FieldData" types to represent data to be written into packets. This addresses inconsistent naming and types across modules that essentially do the same thing (how many "Field" types do we need? :-) and also enables python scripts to supply either byte strings OR integers to insert into any fields (which was inconsistently supported previously). PR also amends WildcardMatch, GenericEncap, and ExactMatch to make use of these new standardized Field types.

RandomUpdate should be extended to do so as well, but also needs to be extended to randomly update metadata in addition to packet-data -- this can be addressed in a later PR.