### PR TITLE
Keep running python unittests after failure

### DIFF
--- a/bessctl/test_samples.py
+++ b/bessctl/test_samples.py
@@ -51,7 +51,12 @@ class TestSamples(unittest.TestCase):
 
 def generate_test_method(path):
     def template(self):
-        run_cmd('%s daemon reset -- run file %s' % (bessctl, path))
+        try:
+            run_cmd('%s daemon reset -- run file %s' % (bessctl, path))
+        except CommandError:
+            # bessd may have crashed. Relaunch for next tests.
+            run_cmd('%s daemon start' % bessctl)
+            raise
 
         # 0.5 seconds should be enough to detect packet leaks in the datapath
         time.sleep(0.5)


### PR DESCRIPTION
At the moment, one failure causes all subsequent test cases to fail. It should not. Example:
https://travis-ci.org/NetSys/bess/jobs/248679890#L1425