### PR TITLE
vagrant: provision VirtualBox VM with 5GB RAM

### DIFF
--- a/env/Vagrantfile
+++ b/env/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
 
     # Customize below. At least two or more vCPUs are recommended.
     vb.cpus = 2
-    vb.memory = 2048
+    vb.memory = 5120
 
     vb.customize ["modifyvm", :id, "--nic1", "nat"]
     vb.customize ["modifyvm", :id, "--nictype1", "virtio"]


### PR DESCRIPTION
The Wiki instructions say "5GB" but the Vagrantfile says "2GB".

When I built way back when, 2GB failed, 5GB worked.

(I've had this on my laptop for quite a while, it was when I rebuilt my vagrant-based VM yesterday I noticed it was time to send a pull request)