### PR TITLE
ip_lookup: work around DPDK out-of-memory bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ after_success:
 after_failure:
   - more /tmp/bessd.*.INFO.* | cat      # dump all bessd log files
   - more /tmp/sanitizer* | cat          # dump all sanitizer results
+  - fgrep Huge /proc/meminfo /sys/devices/system/node/node*/meminfo
 
 before_deploy:
   - for arch in core2 sandybridge haswell; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - sudo apt-get -q update
 
 install:
+  - sudo sysctl -w vm.nr_hugepages=512
   - sudo apt-get install -y python2.7 python3 python3-pip ruby-dev
   - sudo gem install fpm
   - pip2 install grpcio scapy codecov
@@ -43,7 +44,6 @@ install:
   - "docker pull nefelinetworks/bess_build:latest${TAG_SUFFIX} | cat"  # cat suppresses progress bars
 
 before_script:
-  - sudo sysctl -w vm.nr_hugepages=512
   - sudo mkdir -p /mnt/huge
   - sudo mount -t hugetlbfs nodev /mnt/huge
   - export CXX=$VER_CXX
@@ -59,6 +59,7 @@ script:
   - "[[ ${DEBUG:-0} == 0 ]] || python3 bessctl/bessctl -- daemon start -- run testing/run_module_tests"
 
 after_success:
+  - fgrep Huge /proc/meminfo /sys/devices/system/node/node*/meminfo
   - bessctl/bessctl daemon stop # flush out the coverage data
   - "[[ ${DEBUG:-0} == 0 ]] || codecov --gcov-exec gcov-5"
 

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -129,6 +129,9 @@ CommandResponse IPLookup::Init(const bess::pb::IPLookupArg &arg) {
 
   default_gate_ = DROP_GATE;
 
+  // XXX rte_lpm_create sometimes fails without setting rte_errno.
+  // This occurs for memory-allocation failure only, so pre-set it.
+  rte_errno = ENOMEM;
   lpm_ = rte_lpm_create(name().c_str(), /* socket_id = */ 0, &conf);
 
   if (!lpm_) {


### PR DESCRIPTION
This is just a small hack to try to help diagnose whatever is going wrong
with Travis CI builds (seems to disproportionally affect the _32 builds,
though this does seem to happen randomly with other builds as well).

---

When we call rte_lpm_create() it returns NULL if the
parameters are invalid or if it runs out of memory.
For all but the "out of memory" case it sets rte_errno,
but when it runs out of memory, it fails to set rte_errno
at all.  This leaves whatever per-thread value it had
in it, which can often be zero.  This causes the subsequent
"return CommandFailure(rte_errno, ...)" to return a
failure with a zero error code, which pybess interprets
as success, so that it goes on to use the invalid data
and crashes bess.

While we probably should not crash, and perhaps should
have CommandFailure guarantee a nonzero return code or
otherwise arrange for failures to show up as failures,
we can work around this easily enough for now by pre-setting
ENOMEM as the error.