### PR TITLE
Fix removing unrelated packages in ansible script

### DIFF
--- a/env/packages.yml
+++ b/env/packages.yml
@@ -69,7 +69,7 @@
       become: true
 
     - name: Wipe prior protobuf installs to avoid conflicts
-      shell: apt-get remove -y -f libprotobuf* protobuf-*; rm -f `which protoc` warn=no
+      shell: apt-get remove -y -f libprotobuf-dev libprotobuf-java  ^protobuf-*; rm -f `which protoc` warn=no
       become: true
 
     - name: sudo ldconfig

--- a/env/packages.yml
+++ b/env/packages.yml
@@ -69,7 +69,7 @@
       become: true
 
     - name: Wipe prior protobuf installs to avoid conflicts
-      shell: apt-get remove -y -f libprotobuf-dev libprotobuf-java  ^protobuf-*; rm -f `which protoc` warn=no
+      shell: apt-get remove -y -f libprotobuf-dev libprotobuf-java ^protobuf-*; rm -f `which protoc` warn=no
       become: true
 
     - name: sudo ldconfig


### PR DESCRIPTION
If the expreation contains '*' then it is assumed to be
a POSIX-style regular expression, and it is applied to
all package names in the database.

It is recommanded to anchor the regular expression with
a ^ to avoid removing of unrelated packges.

The the reg expression  "libprotobuf*" include
"libprotobuf-lite9v5" which is needed in many pacakges that
will be removed by that in ubuntu 16.04 like  ubuntu-desktop
ubuntu-docs ubuntu-mono and other.