### PR TITLE
Set default GCC version to 5 in the image

### DIFF
--- a/env/packages.yml
+++ b/env/packages.yml
@@ -14,7 +14,6 @@
         - g++-5
         - g++-6
         - g++-7
-        - g++
         - clang-3.8
         - clang-3.9
         - autoconf
@@ -44,6 +43,13 @@
         - linux-headers-generic
         - lcov
         - python-autopep8
+
+    - name: Set default gcc and g++ version
+      alternatives: name={{item}} link=/usr/bin/{{item}} path=/usr/bin/{{item}}-5
+      become: true
+      with_items:
+        - gcc
+        - g++
 
     - name: Install release-specific packages
       apt: name={{item}} state=latest update_cache=yes
@@ -81,9 +87,6 @@
 
     - name: Compile gRPC and its dependencies
       shell: make -j{{ ansible_processor_vcpus }} HAS_SYSTEM_PROTOBUF=false chdir=/tmp/grpc
-      environment:
-        - CC: gcc-5
-        - CXX: g++-5
 
     - name: Install gRPC
       shell: make install chdir=/tmp/grpc


### PR DESCRIPTION
`./container_build.py` was still using GCC 4 by default, but BESS rejects lower versions than 5. As a result, users had to manually export `CXX=g++-5` even with `./container_build.py`. This PR sets `g++-5` to be the default version, and the image on the Docker Hub is updated as well.