### PR TITLE
Do not generate per-packet log in non-verbose mode

### DIFF
--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -226,7 +226,7 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
     // No need to parse the headers if the reconstruct code tells us it failed.
     bool success = buffer.InsertPacket(pkt);
     if (!success) {
-      DLOG(WARNING) << "Reconstruction failure";
+      VLOG(1) << "Reconstruction failure";
       out_batches[0].add(pkt);
       continue;
     }

--- a/core/utils/tcp_flow_reconstruct.h
+++ b/core/utils/tcp_flow_reconstruct.h
@@ -63,15 +63,15 @@ class TcpFlowReconstruct {
     }
 
     if (!initialized_) {
-      DLOG(WARNING) << "Non-SYN received but not yet initialized.";
+      VLOG(1) << "Non-SYN received but not yet initialized.";
       return false;
     }
 
     // Check if the sequence number is greater or equal than SYN + 1. Wraparound
     // is possible.
     if ((int32_t)(seq - init_seq_) < 0) {
-      DLOG(WARNING) << "Sequence number not match. Initial seq: " << init_seq_
-                    << ", Seq: " << seq;
+      VLOG(1) << "Sequence number not match. Initial seq: " << init_seq_
+              << ", Seq: " << seq;
       return false;
     }
 


### PR DESCRIPTION
For TCP stream reconstruction, packet loss or out-of-order arrival is rather common. URLFilter module generates per-packet log messages in such cases, which is too verbose. DLOG(WARNING) messages were replaced with VLOG(1), so as to be printed only with --v=1 or higher.