### PR TITLE
Remove Traverse() feature from TC trees

### DIFF
--- a/core/module.cc
+++ b/core/module.cc
@@ -712,17 +712,14 @@ void propagate_active_worker() {
     if (workers[i] == nullptr) {
       continue;
     }
-    int socket = 1ull << workers[i]->socket();
-    int core = workers[i]->core();
-    bess::TrafficClass *root = workers[i]->scheduler()->root();
-    if (root) {
-      root->Traverse([i, socket, core](bess::TCChildArgs *args) {
-        bess::TrafficClass *c = args->child();
-        if (c->policy() == bess::POLICY_LEAF) {
+    if (bess::TrafficClass *root = workers[i]->scheduler()->root()) {
+      for (const auto &tc_pair : bess::TrafficClassBuilder::all_tcs()) {
+        bess::TrafficClass *c = tc_pair.second;
+        if (c->policy() == bess::POLICY_LEAF && c->Root() == root) {
           auto leaf = static_cast<bess::LeafTrafficClass<Task> *>(c);
           leaf->Task().AddActiveWorker(i);
         }
-      });
+      }
     }
   }
 }

--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -115,20 +115,15 @@ class Scheduler {
       return;
     }
 
-    size_t n_children = 0;
-    TrafficClass *last_child = nullptr;
-    default_rr_class_->TraverseChildren(
-        [&last_child, &n_children](TCChildArgs *c) {
-          last_child = c->child();
-          n_children++;
-        });
-
-    if (n_children <= 1) {
-      root_ = last_child;
-      if (root_) {
-        default_rr_class_->RemoveChild(root_);
-      }
-      delete default_rr_class_;
+    const auto &children = default_rr_class_->Children();
+    if (children.size() == 0) {
+      delete root_;
+      root_ = nullptr;
+      default_rr_class_ = nullptr;
+    } else if (children.size() == 1) {
+      root_->RemoveChild(children[0]);
+      delete root_;
+      root_ = children[0];
       default_rr_class_ = nullptr;
     }
   }

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -25,6 +25,14 @@ PriorityTrafficClass::~PriorityTrafficClass() {
   TrafficClassBuilder::Clear(this);
 }
 
+std::vector<TrafficClass *> PriorityTrafficClass::Children() const {
+  std::vector<TrafficClass *> ret;
+  for (const auto &child : children_) {
+    ret.push_back(child.c_);
+  }
+  return ret;
+}
+
 bool PriorityTrafficClass::AddChild(TrafficClass *child, priority_t priority) {
   if (child->parent_) {
     return false;
@@ -130,6 +138,14 @@ WeightedFairTrafficClass::~WeightedFairTrafficClass() {
     delete c.c_;
   }
   TrafficClassBuilder::Clear(this);
+}
+
+std::vector<TrafficClass *> WeightedFairTrafficClass::Children() const {
+  std::vector<TrafficClass *> ret;
+  for (const auto &child : all_children_) {
+    ret.push_back(child.first);
+  }
+  return ret;
 }
 
 bool WeightedFairTrafficClass::AddChild(TrafficClass *child,
@@ -401,6 +417,10 @@ RateLimitTrafficClass::~RateLimitTrafficClass() {
   // there.
   delete child_;
   TrafficClassBuilder::Clear(this);
+}
+
+std::vector<TrafficClass *> RateLimitTrafficClass::Children() const {
+  return {child_};
 }
 
 bool RateLimitTrafficClass::AddChild(TrafficClass *child) {

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -12,9 +12,11 @@
 
 namespace bess {
 
-size_t TrafficClass::Size() {
-  size_t ret = 0;
-  Traverse([&ret](bess::TCChildArgs *) { ret += 1; });
+size_t TrafficClass::Size() const {
+  size_t ret = 1;  // itself
+  for (const auto *child : Children()) {
+    ret += child->Size();
+  };
   return ret;
 }
 
@@ -420,7 +422,11 @@ RateLimitTrafficClass::~RateLimitTrafficClass() {
 }
 
 std::vector<TrafficClass *> RateLimitTrafficClass::Children() const {
-  return {child_};
+  if (child_ == nullptr) {
+    return {};
+  } else {
+    return {child_};
+  }
 }
 
 bool RateLimitTrafficClass::AddChild(TrafficClass *child) {

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -123,14 +123,6 @@ void PriorityTrafficClass::FinishAndAccountTowardsRoot(
   parent_->FinishAndAccountTowardsRoot(wakeup_queue, this, usage, tsc);
 }
 
-void PriorityTrafficClass::TraverseChildren(
-    std::function<void(TCChildArgs *)> f) const {
-  for (const auto &child : children_) {
-    PriorityChildArgs args(child.priority_, child.c_);
-    f(&args);
-  }
-}
-
 WeightedFairTrafficClass::~WeightedFairTrafficClass() {
   while (!runnable_children_.empty()) {
     delete runnable_children_.top().c_;
@@ -267,14 +259,6 @@ void WeightedFairTrafficClass::FinishAndAccountTowardsRoot(
   parent_->FinishAndAccountTowardsRoot(wakeup_queue, this, usage, tsc);
 }
 
-void WeightedFairTrafficClass::TraverseChildren(
-    std::function<void(TCChildArgs *)> f) const {
-  for (const auto &child : all_children_) {
-    WeightedFairChildArgs args(child.second, child.first);
-    f(&args);
-  }
-}
-
 RoundRobinTrafficClass::~RoundRobinTrafficClass() {
   for (TrafficClass *c : runnable_children_) {
     delete c;
@@ -405,14 +389,6 @@ void RoundRobinTrafficClass::FinishAndAccountTowardsRoot(
   parent_->FinishAndAccountTowardsRoot(wakeup_queue, this, usage, tsc);
 }
 
-void RoundRobinTrafficClass::TraverseChildren(
-    std::function<void(TCChildArgs *)> f) const {
-  for (auto child : all_children_) {
-    RoundRobinChildArgs args(child);
-    f(&args);
-  }
-}
-
 RateLimitTrafficClass::~RateLimitTrafficClass() {
   // TODO(barath): Ensure that when this destructor is called this instance is
   // also cleared out of the wakeup_queue_ in Scheduler if it is present
@@ -504,14 +480,6 @@ void RateLimitTrafficClass::FinishAndAccountTowardsRoot(
     return;
   }
   parent_->FinishAndAccountTowardsRoot(wakeup_queue, this, usage, tsc);
-}
-
-void RateLimitTrafficClass::TraverseChildren(
-    std::function<void(TCChildArgs *)> f) const {
-  if (child_) {
-    RateLimitChildArgs args(child_);
-    f(&args);
-  }
 }
 
 std::unordered_map<std::string, TrafficClass *> TrafficClassBuilder::all_tcs_;

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -395,7 +395,7 @@ class RoundRobinTrafficClass final : public TrafficClass {
   explicit RoundRobinTrafficClass(const std::string &name)
       : TrafficClass(name, POLICY_ROUND_ROBIN),
         next_child_(),
-        children_(),
+        runnable_children_(),
         blocked_children_(),
         all_children_() {}
 
@@ -420,7 +420,9 @@ class RoundRobinTrafficClass final : public TrafficClass {
                                    TrafficClass *child, resource_arr_t usage,
                                    uint64_t tsc) override;
 
-  const std::vector<TrafficClass *> &children() const { return children_; }
+  const std::vector<TrafficClass *> &runnable_children() const {
+    return runnable_children_;
+  }
 
   const std::list<TrafficClass *> &blocked_children() const {
     return blocked_children_;
@@ -431,7 +433,7 @@ class RoundRobinTrafficClass final : public TrafficClass {
  private:
   size_t next_child_;
 
-  std::vector<TrafficClass *> children_;
+  std::vector<TrafficClass *> runnable_children_;
   std::list<TrafficClass *> blocked_children_;
 
   // This is a copy of the pointers to all children. It can be safely

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -164,6 +164,8 @@ class TrafficClass {
   // this TC.
   size_t Size();
 
+  virtual std::vector<TrafficClass *> Children() const = 0;
+
   // Returns the root of the tree this class belongs to.
   // Expensive in that it is recursive, so do not call from
   // performance-sensitive code.
@@ -295,6 +297,8 @@ class PriorityTrafficClass final : public TrafficClass {
 
   ~PriorityTrafficClass();
 
+  std::vector<TrafficClass *> Children() const override;
+
   // Returns true if child was added successfully.
   bool AddChild(TrafficClass *child, priority_t priority);
 
@@ -342,6 +346,8 @@ class WeightedFairTrafficClass final : public TrafficClass {
         all_children_() {}
 
   ~WeightedFairTrafficClass();
+
+  std::vector<TrafficClass *> Children() const override;
 
   // Returns true if child was added successfully.
   bool AddChild(TrafficClass *child, resource_share_t share);
@@ -394,6 +400,10 @@ class RoundRobinTrafficClass final : public TrafficClass {
         all_children_() {}
 
   ~RoundRobinTrafficClass();
+
+  std::vector<TrafficClass *> Children() const override {
+    return all_children_;
+  }
 
   // Returns true if child was added successfully.
   bool AddChild(TrafficClass *child);
@@ -450,6 +460,8 @@ class RateLimitTrafficClass final : public TrafficClass {
   }
 
   ~RateLimitTrafficClass();
+
+  std::vector<TrafficClass *> Children() const override;
 
   // Returns true if child was added successfully.
   bool AddChild(TrafficClass *child);
@@ -551,6 +563,8 @@ class LeafTrafficClass final : public TrafficClass {
   }
 
   ~LeafTrafficClass() override;
+
+  std::vector<TrafficClass *> Children() const override { return {}; }
 
   void TraverseChildren(std::function<void(TCChildArgs *)>) const override {}
 

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -162,7 +162,7 @@ class TrafficClass {
 
   // Returns the number of TCs in the TC subtree rooted at this, including
   // this TC.
-  size_t Size();
+  size_t Size() const;
 
   virtual std::vector<TrafficClass *> Children() const = 0;
 

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -337,7 +337,7 @@ class WeightedFairTrafficClass final : public TrafficClass {
   WeightedFairTrafficClass(const std::string &name, resource_t resource)
       : TrafficClass(name, POLICY_WEIGHTED_FAIR),
         resource_(resource),
-        children_(),
+        runnable_children_(),
         blocked_children_(),
         all_children_() {}
 
@@ -362,8 +362,8 @@ class WeightedFairTrafficClass final : public TrafficClass {
 
   void set_resource(resource_t res) { resource_ = res; }
 
-  const extended_priority_queue<ChildData> &children() const {
-    return children_;
+  const extended_priority_queue<ChildData> &runnable_children() const {
+    return runnable_children_;
   }
 
   const std::list<ChildData> &blocked_children() const {
@@ -376,7 +376,7 @@ class WeightedFairTrafficClass final : public TrafficClass {
   // The resource that we are sharing.
   resource_t resource_;
 
-  extended_priority_queue<ChildData> children_;
+  extended_priority_queue<ChildData> runnable_children_;
   std::list<ChildData> blocked_children_;
 
   // This is a copy of the pointers to (and shares of) all children. It can be

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -378,6 +378,11 @@ class WeightedFairTrafficClass final : public TrafficClass {
 
   void TraverseChildren(std::function<void(TCChildArgs *)>) const override;
 
+  const std::vector<std::pair<TrafficClass *, resource_share_t>> &children()
+      const {
+    return all_children_;
+  }
+
  private:
   // The resource that we are sharing.
   resource_t resource_;

--- a/core/traffic_class_test.cc
+++ b/core/traffic_class_test.cc
@@ -128,11 +128,11 @@ TEST(CreateTree, RoundRobinRootAndLeaf) {
 
   RoundRobinTrafficClass *c = static_cast<RoundRobinTrafficClass *>(tree.get());
   ASSERT_NE(nullptr, c);
-  ASSERT_EQ(1, c->children().size());
+  ASSERT_EQ(1, c->runnable_children().size());
   ASSERT_EQ(0, c->blocked_children().size());
 
   LeafTrafficClass<Task> *leaf =
-      static_cast<LeafTrafficClass<Task> *>(c->children().front());
+      static_cast<LeafTrafficClass<Task> *>(c->runnable_children().front());
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
@@ -248,7 +248,7 @@ TEST(DefaultSchedulerNext, BasicTreeRoundRobin) {
   ASSERT_EQ(0, c->blocked_children().size());
 
   LeafTrafficClass<Task> *leaf =
-      static_cast<LeafTrafficClass<Task> *>(c->children().front());
+      static_cast<LeafTrafficClass<Task> *>(c->runnable_children().front());
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
@@ -450,7 +450,7 @@ TEST(DefaultScheduleOnce, TwoLeavesRoundRobin) {
 
   RoundRobinTrafficClass *root =
       static_cast<RoundRobinTrafficClass *>(s.root());
-  ASSERT_EQ(2, root->children().size());
+  ASSERT_EQ(2, root->runnable_children().size());
 
   ASSERT_EQ(leaf_1, s.Next(rdtsc()));
   s.ScheduleOnce();
@@ -496,10 +496,10 @@ TEST(DefaultScheduleOnce, LeavesWeightedFairAndRoundRobin) {
   ASSERT_EQ(2, root->runnable_children().size());
   RoundRobinTrafficClass *rr_1 =
       static_cast<RoundRobinTrafficClass *>(TrafficClassBuilder::Find("rr_1"));
-  ASSERT_EQ(2, rr_1->children().size());
+  ASSERT_EQ(2, rr_1->runnable_children().size());
   RoundRobinTrafficClass *rr_2 =
       static_cast<RoundRobinTrafficClass *>(TrafficClassBuilder::Find("rr_2"));
-  ASSERT_EQ(2, rr_2->children().size());
+  ASSERT_EQ(2, rr_2->runnable_children().size());
 
   // There's no guarantee which will run first because they will tie, so this is
   // a guess based upon the heap's behavior.

--- a/core/traffic_class_test.cc
+++ b/core/traffic_class_test.cc
@@ -95,11 +95,11 @@ TEST(CreateTree, WeightedFairRootAndLeaf) {
       static_cast<WeightedFairTrafficClass *>(tree.get());
   ASSERT_NE(nullptr, c);
   EXPECT_EQ(RESOURCE_CYCLE, c->resource());
-  ASSERT_EQ(1, c->children().size());
+  ASSERT_EQ(1, c->runnable_children().size());
   ASSERT_EQ(0, c->blocked_children().size());
 
   LeafTrafficClass<Task> *leaf = static_cast<LeafTrafficClass<Task> *>(
-      c->children().container().front().c_);
+      c->runnable_children().container().front().c_);
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
@@ -217,11 +217,11 @@ TEST(DefaultSchedulerNext, BasicTreeWeightedFair) {
   WeightedFairTrafficClass *c =
       static_cast<WeightedFairTrafficClass *>(s.root());
   ASSERT_NE(nullptr, c);
-  ASSERT_EQ(1, c->children().size());
+  ASSERT_EQ(1, c->runnable_children().size());
   ASSERT_EQ(0, c->blocked_children().size());
 
   LeafTrafficClass<Task> *leaf = static_cast<LeafTrafficClass<Task> *>(
-      c->children().container().front().c_);
+      c->runnable_children().container().front().c_);
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
@@ -358,7 +358,7 @@ TEST(DefaultScheduleOnce, TwoLeavesWeightedFair) {
 
   WeightedFairTrafficClass *root =
       static_cast<WeightedFairTrafficClass *>(s.root());
-  ASSERT_EQ(2, root->children().size());
+  ASSERT_EQ(2, root->runnable_children().size());
 
   // There's no guarantee which will run first because they will tie, so this is
   // a guess based upon the heap's behavior.
@@ -493,7 +493,7 @@ TEST(DefaultScheduleOnce, LeavesWeightedFairAndRoundRobin) {
 
   WeightedFairTrafficClass *root =
       static_cast<WeightedFairTrafficClass *>(s.root());
-  ASSERT_EQ(2, root->children().size());
+  ASSERT_EQ(2, root->runnable_children().size());
   RoundRobinTrafficClass *rr_1 =
       static_cast<RoundRobinTrafficClass *>(TrafficClassBuilder::Find("rr_1"));
   ASSERT_EQ(2, rr_1->children().size());

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -127,7 +127,7 @@ void attach_orphans() {
     Worker *w;
 
     int wid = tc.first;
-    if (wid == -1 || workers[wid] == nullptr) {
+    if (wid == Worker::kAnyWorker || workers[wid] == nullptr) {
       w = get_next_active_worker();
     } else {
       w = workers[wid];

--- a/core/worker.h
+++ b/core/worker.h
@@ -47,6 +47,7 @@ class Task;
 class Worker {
  public:
   static const int kMaxWorkers = 64;
+  static const int kAnyWorker = -1;  // unspecified worker ID
 
   /* ----------------------------------------------------------------------
    * functions below are invoked by non-worker threads (the master)


### PR DESCRIPTION
It has been observed a couple of times on Travis that TrafficClass::Traverse() gets stuck in an infinite loop. While its cause is unknown yet, the tree traversal mechanism of Traverse() doesn't seem to be strictly necessary; all it use cases can be replaced with simple iteration over all TCs. I hope this simpler implementation makes the bug less likely to occur...