### PR TITLE
Add L4Checksum module and add support for IP options to IPChecksum

### DIFF
--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -13,7 +13,8 @@ void IPChecksum::ProcessBatch(bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     Ethernet *eth = batch->pkts()[i]->head_data<Ethernet *>();
     Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
-    ip->checksum = CalculateIpv4NoOptChecksum(*ip);
+
+    ip->checksum = CalculateIpv4Checksum(*ip);
   }
 
   RunNextModule(batch);

--- a/core/modules/l4_checksum.cc
+++ b/core/modules/l4_checksum.cc
@@ -1,0 +1,46 @@
+#include "l4_checksum.h"
+
+#include "../utils/checksum.h"
+#include "../utils/ether.h"
+#include "../utils/ip.h"
+#include "../utils/tcp.h"
+#include "../utils/udp.h"
+
+void L4Checksum::ProcessBatch(bess::PacketBatch *batch) {
+  using bess::utils::Ethernet;
+  using bess::utils::Ipv4;
+  using bess::utils::Tcp;
+  using bess::utils::Udp;
+  using bess::utils::be16_t;
+
+  int cnt = batch->cnt();
+
+  for (int i = 0; i < cnt; i++) {
+    Ethernet *eth = batch->pkts()[i]->head_data<Ethernet *>();
+
+    // Calculate checksum only for IPv4 packets
+    if (eth->ether_type != be16_t(Ethernet::Type::kIpv4))
+      continue;
+
+    Ipv4 *ip = reinterpret_cast<Ipv4 *>(eth + 1);
+
+    if (ip->protocol == Ipv4::Proto::kUdp) {
+      size_t ip_bytes = (ip->header_length) << 2;
+      Udp *udp =
+          reinterpret_cast<Udp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
+      udp->checksum = CalculateIpv4UdpChecksum(*ip, *udp);
+    } else if (ip->protocol == Ipv4::Proto::kTcp) {
+      size_t ip_bytes = (ip->header_length) << 2;
+      Tcp *tcp =
+          reinterpret_cast<Tcp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
+      tcp->checksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+    }
+
+    continue;
+  }
+
+  RunNextModule(batch);
+}
+
+ADD_MODULE(L4Checksum, "l4_checksum",
+           "recomputes the TCP/Ipv4 and UDP/IPv4 checksum")

--- a/core/modules/l4_checksum.h
+++ b/core/modules/l4_checksum.h
@@ -1,0 +1,12 @@
+#ifndef BESS_MODULES_L4_CHECKSUM_H_
+#define BESS_MODULES_L4_CHECKSUM_H_
+
+#include "../module.h"
+
+// Compute L4 checksum on packet
+class L4Checksum final : public Module {
+ public:
+  void ProcessBatch(bess::PacketBatch *batch) override;
+};
+
+#endif  // BESS_MODULES_L4_CHECKSUM_H_

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -9,6 +9,7 @@
 #include "ip.h"
 #include "simd.h"
 #include "tcp.h"
+#include "udp.h"
 
 namespace bess {
 namespace utils {
@@ -16,7 +17,7 @@ namespace utils {
 // All input bytestreams for checksum should be network-order
 // Todo: strongly-typed endian for input/output paramters
 
-// Return 32-bit one's complement sum of 'len' bytes from 'buf' and 'sum16'.
+// Returns 32-bit one's complement sum of 'len' bytes from 'buf' and 'sum16'.
 static inline uint32_t CalculateSum(const void *buf, size_t len) {
   const uint64_t *buf64 = reinterpret_cast<const uint64_t *>(buf);
   uint64_t sum64 = 0;
@@ -156,26 +157,26 @@ static inline uint16_t FoldChecksum(uint32_t cksum) {
   return ~cksum;
 }
 
-// Return internet checksum (the negative of 16-bit one's complement sum)
+// Returns internet checksum (the negative of 16-bit one's complement sum)
 // of 'len' bytes from 'buf'
 static inline uint16_t CalculateGenericChecksum(const void *buf, size_t len) {
   return FoldChecksum(CalculateSum(buf, len));
 }
 
-// Return true if the 'cksum' is correct for the 'len' bytes from 'buf'
+// Returns true if the 'cksum' is correct for the 'len' bytes from 'buf'
 static inline bool VerifyGenericChecksum(const void *buf, size_t len,
                                          uint16_t cksum) {
   uint16_t ret = CalculateGenericChecksum(buf, len);
   return ret == cksum;
 }
 
-// Return true if the 'len' bytes from 'buf' is correct
+// Returns true if the 'len' bytes from 'buf' is correct
 // Assumption: 'buf' already includes 16-bit checksum (e.g., IP/TCP header)
 static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
   return VerifyGenericChecksum(buf, len, 0);
 }
 
-// Return true if the IP checksum is true
+// Returns true if the IP checksum is true
 static inline bool VerifyIpv4NoOptChecksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   uint32_t sum = buf32[0];
@@ -195,7 +196,7 @@ static inline bool VerifyIpv4NoOptChecksum(const Ipv4 &iph) {
   return FoldChecksum(sum) == 0;
 }
 
-// Return IP checksum of the ip header 'iph' without ip options
+// Returns IP checksum of the ip header 'iph' without ip options
 // It skips the checksum field into the calculation
 // It does not set the checksum field in ip header
 static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4 &iph) {
@@ -219,18 +220,87 @@ static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4 &iph) {
   return FoldChecksum(sum);
 }
 
-// Return true if the TCP checksum is true with the TCP header and
+// Returns true if the UDP checksum is true with the UDP header and
+// pseudo header info - source ip, destiniation ip, and UDP byte stream length
+// udp_len: UDP header + payload in bytes
+static inline bool VerifyIpv4UdpChecksum(const Udp &udph, be32_t src_ip,
+                                         be32_t dst_ip, uint16_t udp_len) {
+  const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&udph);
+
+  // UDP payload
+  uint32_t sum = CalculateSum(buf32 + 2, udp_len - sizeof(udph));
+  uint32_t len = static_cast<uint32_t>(be16_t::swap(udp_len));
+
+  // Calculate the checksum of UDP header and pseudo header
+  asm("addl %[u0], %[sum]      \n\t"
+      "adcl %[u1], %[sum]      \n\t"
+      "adcl %[src], %[sum]     \n\t"
+      "adcl %[dst], %[sum]     \n\t"
+      "adcl %[len], %[sum]     \n\t"
+      "adcl $0x1100, %[sum]    \n\t"  // 17 == IPPROTO_UDP
+      "adcl $0, %[sum]         \n\t"
+      : [sum] "+r"(sum)
+      : [u0] "m"(buf32[0]), [u1] "m"(buf32[1]), [src] "r"(src_ip.raw_value()),
+        [dst] "r"(dst_ip.raw_value()), [len] "r"(len));
+
+  return FoldChecksum(sum) == 0;
+}
+
+// Returns true if the UDP checksum is true
+static inline bool VerifyIpv4UdpChecksum(const Ipv4 &iph, const Udp &udph) {
+  return VerifyIpv4UdpChecksum(udph, iph.src, iph.dst,
+                               iph.length.value() - (iph.header_length << 2));
+}
+
+// Returns UDP (on IPv4) checksum of the UDP header 'udph' with pseudo header
+// informations - source ip ('src'), destiniation ip ('dst'),
+// and UDP byte stream length ('udp_len', udp_header + payload len)
+// 'udp_len' is in host-order, and the others are in network-order
+// It skips the checksum field into the calculation
+// It does not set the checksum field in UDP header
+static inline uint16_t CalculateIpv4UdpChecksum(const Udp &udph, be32_t src,
+                                                be32_t dst, uint16_t udp_len) {
+  const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&udph);
+  // UDP payload
+  uint32_t sum = CalculateSum(buf32 + 2, udp_len - sizeof(udph));
+  uint32_t len = static_cast<uint32_t>(be16_t::swap(udp_len));
+
+  // Calculate the checksum of UDP header and pseudo header
+  asm("addl %[u0], %[sum]      \n\t"
+      "adcl %[u1], %[sum]      \n\t"
+      "adcl %[src], %[sum]     \n\t"
+      "adcl %[dst], %[sum]     \n\t"
+      "adcl %[len], %[sum]     \n\t"
+      "adcl $0x1100, %[sum]    \n\t"  // 17 == IPPROTO_UDP
+      "adcl $0, %[sum]         \n\t"
+      : [sum] "+r"(sum)
+      : [u0] "m"(buf32[0]), [u1] "g"(buf32[1] & 0xFFFF),  // skip checksum field
+        [src] "r"(src.raw_value()), [dst] "r"(dst.raw_value()), [len] "r"(len));
+
+  return FoldChecksum(sum);
+}
+
+// Returns UDP (on IPv4) checksum of the UDP header 'udph' with ip header 'iph'
+// It skips the checksum field into the calculation
+// It does not set the checksum field in UDP header
+static inline uint16_t CalculateIpv4UdpChecksum(const Ipv4 &iph,
+                                                const Udp &udph) {
+  return CalculateIpv4UdpChecksum(
+      udph, iph.src, iph.dst, iph.length.value() - (iph.header_length << 2));
+}
+
+// Returns true if the TCP checksum is true with the TCP header and
 // pseudo header info - source ip, destiniation ip, and tcp byte stream length
 // tcp_len: TCP header + payload in bytes
 static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
                                          be32_t dst_ip, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
 
-  // tcp options and data
+  // TCP options and payload
   uint32_t sum = CalculateSum(buf32 + 5, tcp_len - sizeof(tcph));
   uint32_t len = static_cast<uint32_t>(be16_t::swap(tcp_len));
 
-  // Calculate the checksum of TCP pseudo header
+  // Calculate the checksum of TCP header and pseudo header
   asm("addl %[u0], %[sum]      \n\t"
       "adcl %[u1], %[sum]      \n\t"
       "adcl %[u2], %[sum]      \n\t"
@@ -249,26 +319,26 @@ static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
   return FoldChecksum(sum) == 0;
 }
 
-// Return true if the TCP checksum is true
+// Returns true if the TCP checksum is true
 static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph, const Tcp &tcph) {
   return VerifyIpv4TcpChecksum(tcph, iph.src, iph.dst,
                                iph.length.value() - (iph.header_length << 2));
 }
 
-// Return TCP (on IPv4) checksum of the tcp header 'tcph' with pseudo header
+// Returns TCP (on IPv4) checksum of the tcp header 'tcph' with pseudo header
 // informations - source ip ('src'), destiniation ip ('dst'),
-// and tcp byte stream length ('tcp_len', tcp_header + data len)
+// and tcp byte stream length ('tcp_len', tcp_header + payload len)
 // 'tcp_len' is in host-order, and the others are in network-order
 // It skips the checksum field into the calculation
 // It does not set the checksum field in TCP header
 static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph, be32_t src,
                                                 be32_t dst, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
-  // tcp options and data
+  // tcp options and payload
   uint32_t sum = CalculateSum(buf32 + 5, tcp_len - sizeof(tcph));
   uint32_t len = static_cast<uint32_t>(be16_t::swap(tcp_len));
 
-  // Calculate the checksum of TCP pseudo header
+  // Calculate the checksum of TCP header and pseudo header
   asm("addl %[u0], %[sum]      \n\t"
       "adcl %[u1], %[sum]      \n\t"
       "adcl %[u2], %[sum]      \n\t"
@@ -288,7 +358,9 @@ static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph, be32_t src,
   return FoldChecksum(sum);
 }
 
-// Return true if the TCP (on IPv4) checksum is true
+// Returns TCP (on IPv4) checksum of the tcp header 'tcph' with ip header 'iph'
+// It skips the checksum field into the calculation
+// It does not set the checksum field in TCP header
 static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4 &iph,
                                                 const Tcp &tcph) {
   return CalculateIpv4TcpChecksum(
@@ -329,7 +401,7 @@ static inline uint16_t UpdateChecksumWithIncrement(uint16_t old_checksum,
   return FoldChecksum((~old_checksum & 0xFFFF) + increment);
 }
 
-// Return incrementally updated checksum from old_checksum
+// Returns incrementally updated checksum from old_checksum
 // when 32-bit 'old_value' changes to 'new_value' e.g., changed IPv4 address
 static inline uint16_t UpdateChecksum32(uint16_t old_checksum,
                                         uint32_t old_value,
@@ -340,7 +412,7 @@ static inline uint16_t UpdateChecksum32(uint16_t old_checksum,
   return UpdateChecksumWithIncrement(old_checksum, inc);
 }
 
-// Return incrementally updated checksum from old_checksum
+// Returns incrementally updated checksum from old_checksum
 // when 16-bit 'old_value' changes to 'new_value' e.g., changed port number
 static inline uint16_t UpdateChecksum16(uint16_t old_checksum,
                                         uint16_t old_value,

--- a/core/utils/checksum_bench.cc
+++ b/core/utils/checksum_bench.cc
@@ -79,7 +79,7 @@ BENCHMARK_REGISTER_F(ChecksumFixture, BmGenericChecksumBess)
 // Benchmarks DPDK IP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
 (benchmark::State &state) {
-  char pkt[20] = {0};  // ipv4 header w/o options
+  char pkt[60] = {0};  // ipv4 header w/o options
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
@@ -106,7 +106,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumDpdk)
 // Benchmarks BESS IP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
 (benchmark::State &state) {
-  char pkt[20] = {0};  // ipv4 header w/o options
+  char pkt[60] = {0};  // ipv4 header w/o options
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
@@ -132,7 +132,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4NoOptChecksumBess)
 // Benchmarks BESS IP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmIpv4ChecksumBess)
 (benchmark::State &state) {
-  char pkt[20] = {0};  // ipv4 header w/o options
+  char pkt[60] = {0};  // ipv4 header w/o options
 
   bess::utils::Ipv4 *ip = reinterpret_cast<bess::utils::Ipv4 *>(pkt);
 
@@ -185,7 +185,7 @@ BENCHMARK_DEFINE_F(ChecksumFixture, BmUdpChecksumDpdk)
   state.SetBytesProcessed(buf_len * state.iterations());
 }
 
-// Benchmarks BESS TCP checksum
+// Benchmarks BESS UCP checksum
 BENCHMARK_DEFINE_F(ChecksumFixture, BmUdpChecksumBess)
 (benchmark::State &state) {
   void *pkt;


### PR DESCRIPTION
Adding functionality to calculate checksums for IPv4 header with options, UDP.
Adding a module to calculate L4 (UDP/TCP) over IPv4.