### PR TITLE
CI: Run unittests in an arbitrary order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 script:
   - ./container_build.py bess
   - ./container_build.py kmod_buildtest
-  - (cd core && ./all_test)  # TcpFlowReconstructTest requires working directory to be `core/`
+  - (cd core && ./all_test --gtest_shuffle)  # TcpFlowReconstructTest requires working directory to be `core/`
   - coverage2 run -m unittest discover -v
   - "[[ ${DEBUG:-0} == 0 ]] || coverage3 run -m unittest discover -v"
   - python2 bessctl/bessctl -- daemon start -- run testing/run_module_tests

--- a/core/port.h
+++ b/core/port.h
@@ -61,8 +61,7 @@ class PortBuilder {
  public:
   friend class PortTest;
   friend class ZeroCopyVPortTest;
-  FRIEND_TEST(PortBuilderTest, RegisterPortClassDirectCall);
-  FRIEND_TEST(PortBuilderTest, RegisterPortClassMacroCall);
+  friend class PortBuilderTest;
 
   PortBuilder(std::function<Port *()> port_generator,
               const std::string &class_name, const std::string &name_template,

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -69,6 +69,16 @@ class PortTest : public ::testing::Test {
   const PortBuilder *dummy_port_builder;
 };
 
+class PortBuilderTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    PortBuilder::all_port_builders_holder(true);
+    ASSERT_TRUE(PortBuilder::all_port_builders().empty());
+  }
+
+  virtual void TearDown() { PortBuilder::all_port_builders_holder(true); }
+};
+
 // Checks that when we create a port via the established PortBuilder, the right
 // Port object is returned.
 TEST_F(PortTest, CreatePort) {
@@ -246,9 +256,7 @@ TEST_F(PortTest, InitDrivers) {
 
 // Checks that when we register a portclass, the global table of PortBuilders
 // contains it.
-TEST(PortBuilderTest, RegisterPortClassDirectCall) {
-  ASSERT_TRUE(PortBuilder::all_port_builders().empty());
-
+TEST_F(PortBuilderTest, RegisterPortClassDirectCall) {
   PortBuilder::RegisterPortClass([]() { return new DummyPort(); }, "DummyPort",
                                  "dummy_port", "dummy help",
                                  PORT_INIT_FUNC(&DummyPort::Init));
@@ -261,15 +269,11 @@ TEST(PortBuilderTest, RegisterPortClassDirectCall) {
   EXPECT_EQ("DummyPort", b.class_name());
   EXPECT_EQ("dummy_port", b.name_template());
   EXPECT_EQ("dummy help", b.help_text());
-
-  PortBuilder::all_port_builders_holder(true);
 }
 
 // Checks that when we register a portclass via the ADD_DRIVER macro, the global
 // table of PortBuilders contains it.
-TEST(PortBuilderTest, RegisterPortClassMacroCall) {
-  ASSERT_TRUE(PortBuilder::all_port_builders().empty());
-
+TEST_F(PortBuilderTest, RegisterPortClassMacroCall) {
   ADD_DRIVER(DummyPort, "dummy_port", "dummy help");
   ASSERT_TRUE(__driver__DummyPort);
 
@@ -281,12 +285,10 @@ TEST(PortBuilderTest, RegisterPortClassMacroCall) {
   EXPECT_EQ("DummyPort", b.class_name());
   EXPECT_EQ("dummy_port", b.name_template());
   EXPECT_EQ("dummy help", b.help_text());
-
-  PortBuilder::all_port_builders_holder(true);
 }
 
 // Checks that we can generate a proper port name given a template or not.
-TEST(PortBuilderTest, GenerateDefaultPortNameTemplate) {
+TEST_F(PortBuilderTest, GenerateDefaultPortNameTemplate) {
   std::string name1 = PortBuilder::GenerateDefaultPortName("FooPort", "foo");
   EXPECT_EQ("foo0", name1);
 


### PR DESCRIPTION
... to add more randomness. Done with `--gtest_shuffle`

Some tests in `post_test.cc` were order-dependent and fixed.