### PR TITLE
Fix a bug that ixgbevf does not show any stats for show/monitor port

### DIFF
--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -335,8 +335,9 @@ void PMDPort::CollectStats(bool reset) {
 
   port_stats_.inc.dropped = stats.imissed;
 
-  // i40e PMD driver doesn't support per-queue stats
-  if (driver_ == "net_i40e" || driver_ == "net_i40e_vf") {
+  // i40e PMD driver and ixgbevf don't support per-queue stats
+  if (driver_ == "net_i40e" || driver_ == "net_i40e_vf" ||
+      driver_ == "net_ixgbe_vf") {
     // NOTE:
     // - if link is down, tx bytes won't increase
     // - if destination MAC address is incorrect, rx pkts won't increase


### PR DESCRIPTION
  ixgbevf does not support per queue stats.
  It is hard coded since I couldn't find a way to identify whether the driver supports queue-level or port-level stat functionality yet.
  (no flags, no driver-level supported functions, etc).

  BTW, in EC2 instances using ixgbevf, the stats are incorrect.
  EC2 limits pps per EC2 instance, (e.g., 75Kpps for c2.xlarge),
  the stats show more pps than rate limited performance and no drop count.

  It looks like rate limiting happens in host side and hidden from the EC2 instances.