### PR TITLE
Allow module inheritance across shared objects

### DIFF
--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -427,12 +427,15 @@ bool LoadPlugins(const std::string &directory) {
       const std::string full_path = *it;
       LOG(INFO) << "Loading module (pass " << pass << "): " << full_path;
       if (!LoadPlugin(full_path)) {
-        LOG(WARNING) << "Error loading module " << full_path << ": "
-                     << dlerror();
+        LOG(INFO) << "Error loading module " << full_path << ": " << dlerror();
       } else {
         remaining.erase(it++);
       }
     }
+  }
+
+  for (auto it = remaining.begin(); it != remaining.end(); ++it) {
+    LOG(WARNING) << "Gave up on loading module " << *it;
   }
 
   return (remaining.size() == 0);

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -427,7 +427,7 @@ bool LoadPlugins(const std::string &directory) {
       const std::string full_path = *it;
       LOG(INFO) << "Loading module (pass " << pass << "): " << full_path;
       if (!LoadPlugin(full_path)) {
-        LOG(INFO) << "Error loading module " << full_path << ": " << dlerror();
+        VLOG(1) << "Error loading module " << full_path << ": " << dlerror();
       } else {
         remaining.erase(it++);
       }
@@ -435,7 +435,9 @@ bool LoadPlugins(const std::string &directory) {
   }
 
   for (auto it = remaining.begin(); it != remaining.end(); ++it) {
-    LOG(WARNING) << "Gave up on loading module " << *it;
+    LOG(ERROR)
+        << "Failed to load module " << *it
+        << ". Run daemon in verbose mode (--v=1) to see dlopen() attempts.";
   }
 
   return (remaining.size() == 0);

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -422,14 +422,14 @@ bool LoadPlugins(const std::string &directory) {
   closedir(dir);
 
   for (int pass = 1; pass <= kInheritanceLimit && remaining.size() > 0;
-       pass++) {
+       ++pass) {
     for (auto it = remaining.begin(); it != remaining.end(); ++it) {
       const std::string full_path = *it;
       LOG(INFO) << "Loading module (pass " << pass << "): " << full_path;
       if (!LoadPlugin(full_path)) {
         VLOG(1) << "Error loading module " << full_path << ": " << dlerror();
       } else {
-        remaining.erase(it++);
+        remaining.erase(it);
       }
     }
   }

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -40,6 +40,7 @@
 namespace bess {
 namespace bessd {
 
+const int kInheritanceLimit = 10;
 // Process command line arguments from gflags.
 void ProcessCommandLineArgs();
 

--- a/core/bessd.h
+++ b/core/bessd.h
@@ -40,6 +40,10 @@
 namespace bess {
 namespace bessd {
 
+// When Modules extend other Modules, they may reference a shared object
+// that has not yet been loaded by the BESS daemon. kInheritanceLimit is
+// the number of passes that will be made while loading Module shared objects,
+// and thus the maximum inheritance depth of any Module.
 const int kInheritanceLimit = 10;
 // Process command line arguments from gflags.
 void ProcessCommandLineArgs();


### PR DESCRIPTION
Previously, modules could not access (and therefore inherit from)
other modules because the RTLD_GLOBAL flag was not set. This patch
allows inheritance by dlopening module shared objects with the
RTLD_GLOBAL flag and by loading modules in multiple passes.