### PR TITLE
Trie: Add support for values and prefix nodes

### DIFF
--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -142,8 +142,7 @@ CommandResponse UrlFilter::Init(const bess::pb::UrlFilterArg &arg) {
                          std::forward_as_tuple(url.host()),
                          std::forward_as_tuple());
     }
-    Trie<std::tuple<>> &trie = blacklist_.at(url.host());
-    trie.Insert(url.path(), {});
+    blacklist_[url.host()].Insert(url.path(), {});
   }
   return CommandSuccess();
 }

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -1,6 +1,7 @@
 #include "url_filter.h"
 
 #include <algorithm>
+#include <tuple>
 
 #include "../utils/checksum.h"
 #include "../utils/ether.h"
@@ -141,8 +142,8 @@ CommandResponse UrlFilter::Init(const bess::pb::UrlFilterArg &arg) {
                          std::forward_as_tuple(url.host()),
                          std::forward_as_tuple());
     }
-    Trie &trie = blacklist_.at(url.host());
-    trie.Insert(url.path());
+    Trie<std::tuple<>> &trie = blacklist_.at(url.host());
+    trie.Insert(url.path(), {});
   }
   return CommandSuccess();
 }
@@ -253,7 +254,7 @@ void UrlFilter::ProcessBatch(bess::PacketBatch *batch) {
           const std::string host(headers[j].value, headers[j].value_len);
           const auto rule_iterator = blacklist_.find(host);
           matched = rule_iterator != blacklist_.end() &&
-                    rule_iterator->second.LookupKey(path_str);
+                    rule_iterator->second.Match(path_str);
         }
       }
     }

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -92,7 +93,7 @@ class UrlFilter final : public Module {
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
 
  private:
-  std::unordered_map<std::string, Trie> blacklist_;
+  std::unordered_map<std::string, Trie<std::tuple<>>> blacklist_;
   std::unordered_map<Flow, FlowRecord, FlowHash> flow_cache_;
 };
 

--- a/core/utils/trie.h
+++ b/core/utils/trie.h
@@ -3,19 +3,23 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace bess {
 namespace utils {
 
 // A utility Trie class that supports prefix lookups
+template <typename T>
 class Trie {
  public:
   // Node definition
   struct Node {
-    Node() : leaf(), children() {}
+    Node() : leaf(), prefix(), val(), children() {}
 
     Node(const Node& other) {
       leaf = other.leaf;
+      prefix = other.prefix;
+      val = other.val;
       for (int i = 0; i < 256; i++) {
         if (other.children[i] != nullptr) {
           children[i].reset(new Node(*(other.children[i])));
@@ -25,6 +29,8 @@ class Trie {
 
     Node& operator=(const Node& other) {
       leaf = other.leaf;
+      prefix = other.prefix;
+      val = other.val;
       for (int i = 0; i < 256; i++) {
         if (other.children[i] != nullptr) {
           children[i].reset(new Node(*(other.children[i])));
@@ -34,26 +40,47 @@ class Trie {
     }
 
     bool leaf;
+    bool prefix;
+    T val;
     std::unique_ptr<Node> children[256];
   };
 
   Trie() : root_() {}
-  Trie(const Trie& t) : root_(t.root_) { }
+  Trie(const Trie& t) : root_(t.root_) {}
 
-  // Inserts a string into the trie
-  void Insert(const std::string& key);
+  // Inserts a string into the trie, associating the key
+  // with the value.
+  void Insert(const std::string& key, const T val);
 
-  // Returns true if prefix matches the stored keys
-  bool Lookup(const std::string& prefix);
+  // Inserts a string into the trie, associating the key with
+  // the value. If prefix is true, then any key that begins with
+  // this key will also be a match, unless the trie contains a match
+  // of greater specificity.
+  void Insert(const std::string& key, const T val, bool prefix);
 
-  // View stored keys as prefixes. Returns true if any prefix match the key.
-  bool LookupKey(const std::string& key);
+  // Returns true if the key is in the trie.
+  bool Match(const std::string& key);
+
+  // Returns true if there is a key in the trie that begins with the given
+  // prefix.
+  bool MatchPrefix(const std::string& prefix);
+
+  // Look up the value associated with the given key.
+  // Returns the pair {true, <value>} if the key is in the trie.
+  // Returns a pair whose first element is false if the key is not found.
+  std::pair<bool, T> Lookup(const std::string& key);
 
  private:
   Node root_;
 };
 
-inline void Trie::Insert(const std::string& key) {
+template <typename T>
+inline void Trie<T>::Insert(const std::string& key, const T val) {
+  return Insert(key, val, false);
+}
+
+template <typename T>
+inline void Trie<T>::Insert(const std::string& key, const T val, bool prefix) {
   Node* cur = &root_;
   for (const char& c : key) {
     size_t idx = c;
@@ -63,30 +90,78 @@ inline void Trie::Insert(const std::string& key) {
     cur = cur->children[idx].get();
   }
   cur->leaf = true;
+  cur->prefix = prefix;
+  cur->val = val;
 }
 
-inline bool Trie::Lookup(const std::string& prefix) {
+template <typename T>
+inline bool Trie<T>::Match(const std::string& key) {
   Node* cur = &root_;
+  if (cur->prefix) {
+    return true;
+  }
+
+  for (const char& c : key) {
+    size_t idx = c;
+    if (cur->children[idx] == nullptr) {
+      return false;
+    }
+    cur = cur->children[idx].get();
+    if (cur->prefix) {
+      return true;
+    }
+  }
+  return cur->leaf;
+}
+
+template <typename T>
+inline bool Trie<T>::MatchPrefix(const std::string& prefix) {
+  Node* cur = &root_;
+  if (cur->prefix) {
+    return true;
+  }
+
   for (const char& c : prefix) {
     size_t idx = c;
     if (cur->children[idx] == nullptr) {
       return false;
     }
     cur = cur->children[idx].get();
+    if (cur->prefix) {
+      return true;
+    }
   }
   return true;
 }
 
-inline bool Trie::LookupKey(const std::string& key) {
+template <typename T>
+inline std::pair<bool, T> Trie<T>::Lookup(const std::string& key) {
   Node* cur = &root_;
+  Node* prefix_match = nullptr;
+  if (cur->prefix) {
+    prefix_match = cur;
+  }
+
   for (const char& c : key) {
     size_t idx = c;
     if (cur->children[idx] == nullptr) {
-      break;
+      if (prefix_match != nullptr) {
+        return {true, prefix_match->val};
+      }
+      return {false, T()};
     }
     cur = cur->children[idx].get();
+    if (cur->prefix) {
+      prefix_match = cur;
+    }
   }
-  return cur->leaf;
+  if (cur->leaf) {
+    return {true, cur->val};
+  } else if (prefix_match != nullptr) {
+    return {true, prefix_match->val};
+  } else {
+    return {false, T()};
+  }
 }
 
 }  // namespace utils

--- a/core/utils/trie.h
+++ b/core/utils/trie.h
@@ -50,13 +50,13 @@ class Trie {
 
   // Inserts a string into the trie, associating the key
   // with the value.
-  void Insert(const std::string& key, const T val);
+  void Insert(const std::string& key, const T& val);
 
   // Inserts a string into the trie, associating the key with
   // the value. If prefix is true, then any key that begins with
   // this key will also be a match, unless the trie contains a match
   // of greater specificity.
-  void Insert(const std::string& key, const T val, bool prefix);
+  void Insert(const std::string& key, const T& val, bool prefix);
 
   // Returns true if the key is in the trie.
   bool Match(const std::string& key);
@@ -75,12 +75,12 @@ class Trie {
 };
 
 template <typename T>
-inline void Trie<T>::Insert(const std::string& key, const T val) {
+inline void Trie<T>::Insert(const std::string& key, const T& val) {
   return Insert(key, val, false);
 }
 
 template <typename T>
-inline void Trie<T>::Insert(const std::string& key, const T val, bool prefix) {
+inline void Trie<T>::Insert(const std::string& key, const T& val, bool prefix) {
   Node* cur = &root_;
   for (const char& c : key) {
     size_t idx = c;

--- a/core/utils/trie_test.cc
+++ b/core/utils/trie_test.cc
@@ -1,91 +1,190 @@
 #include "trie.h"
 
 #include <gtest/gtest.h>
+#include <tuple>
 
 using bess::utils::Trie;
 
 namespace {
 
-// Whether Lookup function matches the prefix correctly
+TEST(TrieTest, Match) {
+  Trie<int32_t> trie;
+
+  trie.Insert("Hello world!", 5);
+  trie.Insert("123456", 10);
+
+  EXPECT_FALSE(trie.Match("234"));
+  EXPECT_FALSE(trie.Match("ello"));
+  EXPECT_FALSE(trie.Match("H"));
+  EXPECT_FALSE(trie.Match(""));
+
+  EXPECT_TRUE(trie.Match("Hello world!"));
+  EXPECT_TRUE(trie.Match("123456"));
+}
+
+TEST(TrieTest, MatchPrefix) {
+  Trie<int32_t> trie;
+
+  trie.Insert("Hello world!", 5);
+  trie.Insert("123456", 10);
+
+  EXPECT_FALSE(trie.MatchPrefix("234"));
+  EXPECT_FALSE(trie.MatchPrefix("ello"));
+
+  EXPECT_TRUE(trie.MatchPrefix("H"));
+  EXPECT_TRUE(trie.MatchPrefix(""));
+  EXPECT_TRUE(trie.MatchPrefix("Hello"));
+  EXPECT_TRUE(trie.MatchPrefix("123456"));
+}
+
 TEST(TrieTest, Lookup) {
-  Trie trie;
+  Trie<int32_t> trie;
 
-  trie.Insert("Hello world!");
-  trie.Insert("123456");
+  trie.Insert("Hello world!", 5);
+  trie.Insert("123456", 10);
 
-  EXPECT_FALSE(trie.Lookup("234"));
-  EXPECT_FALSE(trie.Lookup("ello"));
+  EXPECT_FALSE(trie.Lookup("234").first);
+  EXPECT_FALSE(trie.Lookup("ello").first);
+  EXPECT_FALSE(trie.Lookup("H").first);
+  EXPECT_FALSE(trie.Lookup("").first);
 
-  EXPECT_TRUE(trie.Lookup("Hello"));
-  EXPECT_TRUE(trie.Lookup("H"));
-  EXPECT_TRUE(trie.Lookup(""));
-  EXPECT_TRUE(trie.Lookup("1"));
-  EXPECT_TRUE(trie.Lookup("123456"));
+  EXPECT_TRUE(trie.Lookup("Hello world!").first);
+  EXPECT_EQ(trie.Lookup("Hello world!").second, 5);
+  EXPECT_TRUE(trie.Lookup("123456").first);
+  EXPECT_EQ(trie.Lookup("123456").second, 10);
 }
 
-// Whether LookupKey function matches the key against prefixes correctly
-TEST(TrieTest, LookupKey) {
-  Trie trie;
+TEST(TrieTest, LookupWithEmptyValue) {
+  Trie<std::tuple<>> trie;
 
-  trie.Insert("Hel");
-  trie.Insert("12");
+  trie.Insert("Hello world!", {});
+  trie.Insert("123456", {});
 
-  EXPECT_FALSE(trie.LookupKey("He1"));
-  EXPECT_FALSE(trie.LookupKey("1"));
+  EXPECT_FALSE(trie.Lookup("234").first);
+  EXPECT_FALSE(trie.Lookup("ello").first);
+  EXPECT_FALSE(trie.Lookup("H").first);
+  EXPECT_FALSE(trie.Lookup("").first);
 
-  EXPECT_TRUE(trie.LookupKey("Hel"));
-  EXPECT_TRUE(trie.LookupKey("Hello"));
-  EXPECT_TRUE(trie.LookupKey("12"));
-  EXPECT_TRUE(trie.LookupKey("123"));
-  EXPECT_TRUE(trie.LookupKey("123456"));
+  EXPECT_TRUE(trie.Lookup("Hello world!").first);
+  EXPECT_TRUE(trie.Lookup("123456").first);
 }
 
-// Whether an empty Trie behaves correctly with LookupKey and Lookup
+// Check whether prefix keys work, especially in combination with non-prefix
+// keys.
+TEST(TrieTest, InsertPrefixes) {
+  Trie<int32_t> trie;
+
+  trie.Insert("Hel", 1, true);
+  trie.Insert("Hello", 2, true);
+  trie.Insert("12", 3, true);
+  trie.Insert("Hello World", 4, false);
+
+  EXPECT_FALSE(trie.Lookup("He2").first);
+  EXPECT_FALSE(trie.Lookup("1").first);
+  EXPECT_FALSE(trie.Match("He2"));
+  EXPECT_FALSE(trie.Match("1"));
+
+  EXPECT_TRUE(trie.Match("Hel"));
+  EXPECT_TRUE(trie.Match("Hell"));
+  EXPECT_TRUE(trie.Match("Hello"));
+  EXPECT_TRUE(trie.Match("Hello World"));
+  EXPECT_TRUE(trie.Match("12"));
+  EXPECT_TRUE(trie.Match("123"));
+  EXPECT_TRUE(trie.Match("1234"));
+
+  EXPECT_TRUE(trie.Lookup("Hel").first);
+  EXPECT_TRUE(trie.Lookup("Hell").first);
+  EXPECT_TRUE(trie.Lookup("Hello").first);
+  EXPECT_TRUE(trie.Lookup("Hello ").first);
+
+  EXPECT_EQ(trie.Lookup("Hel").second, 1);
+  EXPECT_EQ(trie.Lookup("Hell").second, 1);
+  EXPECT_EQ(trie.Lookup("Hello").second, 2);
+  EXPECT_EQ(trie.Lookup("Hello y'all").second, 2);
+  EXPECT_EQ(trie.Lookup("Hello World").second, 4);
+  EXPECT_EQ(trie.Lookup("Hello World!!!").second, 2);
+
+  EXPECT_TRUE(trie.Lookup("12").first);
+  EXPECT_TRUE(trie.Lookup("123").first);
+  EXPECT_TRUE(trie.Lookup("123456").first);
+
+  EXPECT_EQ(trie.Lookup("12").second, 3);
+  EXPECT_EQ(trie.Lookup("123").second, 3);
+  EXPECT_EQ(trie.Lookup("123456").second, 3);
+}
+
+// Whether an empty Trie behaves correctly
 TEST(TrieTest, Empty) {
-  Trie trie;
+  Trie<int32_t> trie;
 
-  EXPECT_FALSE(trie.Lookup("234"));
-  EXPECT_FALSE(trie.Lookup("ello"));
-  EXPECT_FALSE(trie.Lookup("Hello"));
-  EXPECT_FALSE(trie.Lookup("H"));
+  EXPECT_FALSE(trie.Match("234"));
+  EXPECT_FALSE(trie.Match("ello"));
+  EXPECT_FALSE(trie.Match("Hello"));
+  EXPECT_FALSE(trie.Match("H"));
 
-  EXPECT_TRUE(trie.Lookup(""));
+  EXPECT_TRUE(trie.MatchPrefix(""));
+  EXPECT_FALSE(trie.MatchPrefix(" "));
 
-  EXPECT_FALSE(trie.LookupKey("234"));
-  EXPECT_FALSE(trie.LookupKey("ello"));
-  EXPECT_FALSE(trie.LookupKey("Hello"));
-  EXPECT_FALSE(trie.LookupKey("H"));
-  EXPECT_FALSE(trie.LookupKey(""));
+  EXPECT_FALSE(trie.Lookup("234").first);
+  EXPECT_FALSE(trie.Lookup("ello").first);
+  EXPECT_FALSE(trie.Lookup("Hello").first);
+  EXPECT_FALSE(trie.Lookup("H").first);
+  EXPECT_FALSE(trie.Lookup("").first);
+}
+
+// Whether an Trie with the "" prefix behaves correctly
+TEST(TrieTest, EmptyPrefix) {
+  Trie<int32_t> trie;
+  trie.Insert("", 2, true);
+
+  EXPECT_TRUE(trie.Match(""));
+  EXPECT_TRUE(trie.Match("234"));
+  EXPECT_TRUE(trie.Match("ello"));
+  EXPECT_TRUE(trie.Match("Hello"));
+  EXPECT_TRUE(trie.Match("H"));
+  EXPECT_TRUE(trie.MatchPrefix("Hello"));
+  EXPECT_TRUE(trie.MatchPrefix(""));
+
+  EXPECT_TRUE(trie.Lookup("Hello").first);
+  EXPECT_EQ(trie.Lookup("Hello").second, 2);
+
+  EXPECT_TRUE(trie.Lookup("H").first);
+  EXPECT_EQ(trie.Lookup("H").second, 2);
 }
 
 // Test the copy constructor
 TEST(TrieTest, Copy) {
-  Trie trie0;
+  Trie<int32_t> trie0;
 
-  Trie trie1 = trie0;
-  EXPECT_FALSE(trie1.Lookup("Hello"));
-  EXPECT_FALSE(trie1.Lookup("H"));
-  EXPECT_TRUE(trie1.Lookup(""));
-  EXPECT_FALSE(trie1.LookupKey("234"));
-  EXPECT_FALSE(trie1.LookupKey("ello"));
-  EXPECT_FALSE(trie1.LookupKey(""));
+  Trie<int32_t> trie1 = trie0;
+  EXPECT_FALSE(trie1.Match("Hello"));
+  EXPECT_FALSE(trie1.Match("H"));
+  EXPECT_FALSE(trie1.Match(""));
+  EXPECT_FALSE(trie1.MatchPrefix("234"));
+  EXPECT_FALSE(trie1.MatchPrefix("ello"));
+  EXPECT_TRUE(trie1.MatchPrefix(""));
 
-  trie0.Insert("Hello world!");
-  trie0.Insert("123456");
-  Trie trie2 = trie0;
+  trie0.Insert("Hello world!", 1);
+  trie0.Insert("Hello", 2, true);
+  trie0.Insert("123456", 3);
+  Trie<int32_t> trie2 = trie0;
 
-  EXPECT_FALSE(trie2.Lookup("234"));
-  EXPECT_FALSE(trie2.Lookup("ello"));
-  EXPECT_TRUE(trie2.Lookup("Hello"));
-  EXPECT_TRUE(trie2.Lookup("H"));
-  EXPECT_TRUE(trie2.Lookup(""));
-  EXPECT_TRUE(trie2.Lookup("1"));
-  EXPECT_TRUE(trie2.Lookup("123456"));
-  EXPECT_FALSE(trie2.LookupKey("Hello"));
-  EXPECT_FALSE(trie2.LookupKey("1"));
-  EXPECT_TRUE(trie2.LookupKey("Hello world!"));
-  EXPECT_TRUE(trie2.LookupKey("123456"));
-  EXPECT_TRUE(trie2.LookupKey("1234567"));
+  EXPECT_FALSE(trie2.Match("234"));
+  EXPECT_FALSE(trie2.Match("ello"));
+
+  EXPECT_TRUE(trie2.Match("Hello"));
+  EXPECT_TRUE(trie2.Match("Hello y'all"));
+  EXPECT_TRUE(trie2.MatchPrefix("H"));
+  EXPECT_TRUE(trie2.MatchPrefix(""));
+  EXPECT_TRUE(trie2.MatchPrefix("1"));
+
+  EXPECT_TRUE(trie2.Lookup("Hello").first);
+  EXPECT_TRUE(trie2.Lookup("Hello y'all").first);
+  EXPECT_TRUE(trie2.Lookup("Hello World").first);
+
+  EXPECT_EQ(trie2.Lookup("Hello").second, 2);
+  EXPECT_EQ(trie2.Lookup("Hello y'all").second, 2);
+  EXPECT_EQ(trie2.Lookup("Hello World").second, 2);
 }
 
 }  // namespace (unnamed)


### PR DESCRIPTION
A prefix key "asdf" can be inserted into the Trie to match all keys that begin with "asdf". `Lookup()` returns the value associated with the most specific match, prioritizing an exact match over the longest prefix.