### PR TITLE
Fix crash during checksum calculation upon invalid IP headers

### DIFF
--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -349,14 +349,13 @@ static inline bool VerifyIpv4UdpChecksum(const Udp &udph, be32_t src_ip,
 
 // Returns true if the UDP checksum is correct
 static inline bool VerifyIpv4UdpChecksum(const Ipv4 &iph, const Udp &udph) {
-  size_t ip_len = iph.length.value();
-  size_t ip_header_len = iph.header_length << 2;
+  size_t udp_len = udph.length.value();
 
-  if (unlikely(ip_len < ip_header_len)) {
-    return false;
+  if (unlikely(udp_len < sizeof(udph))) {
+    return false;  // Invalid UDP header
   }
 
-  return VerifyIpv4UdpChecksum(udph, iph.src, iph.dst, ip_len - ip_header_len);
+  return VerifyIpv4UdpChecksum(udph, iph.src, iph.dst, udp_len);
 }
 
 // Returns UDP (on IPv4) checksum of the UDP header 'udph' with pseudo header
@@ -394,15 +393,13 @@ static inline uint16_t CalculateIpv4UdpChecksum(const Udp &udph, be32_t src,
 // It does not set the checksum field in UDP header
 static inline uint16_t CalculateIpv4UdpChecksum(const Ipv4 &iph,
                                                 const Udp &udph) {
-  size_t ip_len = iph.length.value();
-  size_t ip_header_len = iph.header_length << 2;
+  size_t udp_len = udph.length.value();
 
-  if (unlikely(ip_len < ip_header_len)) {
+  if (unlikely(udp_len < sizeof(udph))) {
     return 0;
   }
 
-  return CalculateIpv4UdpChecksum(udph, iph.src, iph.dst,
-                                  ip_len - ip_header_len);
+  return CalculateIpv4UdpChecksum(udph, iph.src, iph.dst, udp_len);
 }
 
 // Returns true if the TCP checksum is correct with the TCP header and
@@ -438,6 +435,7 @@ static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
 
 // Returns true if the TCP checksum is correct
 static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph, const Tcp &tcph) {
+  // Unlike UDP, TCP doesn't have a length field. Derive from IP header.
   size_t ip_len = iph.length.value();
   size_t ip_header_len = iph.header_length << 2;
 
@@ -487,6 +485,7 @@ static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph, be32_t src,
 // It does not set the checksum field in TCP header
 static inline uint16_t CalculateIpv4TcpChecksum(const Ipv4 &iph,
                                                 const Tcp &tcph) {
+  // Unlike UDP, TCP doesn't have a length field. Derive from IP header.
   size_t ip_len = iph.length.value();
   size_t ip_header_len = iph.header_length << 2;
 

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -385,7 +385,8 @@ static inline uint16_t CalculateIpv4UdpChecksum(const Udp &udph, be32_t src,
       : [u0] "m"(buf32[0]), [u1] "g"(buf32[1] & 0xFFFF),  // skip checksum field
         [src] "r"(src.raw_value()), [dst] "r"(dst.raw_value()), [len] "r"(len));
 
-  return FoldChecksum(sum);
+  // If the result of UDP checksum calculation is 0, return all ones (rfc 768)
+  return FoldChecksum(sum) ?: 0xFFFF;
 }
 
 // Returns UDP (on IPv4) checksum of the UDP header 'udph' with ip header 'iph'

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -207,7 +207,7 @@ static inline bool VerifyGenericChecksum(const void *buf, size_t len) {
   return VerifyGenericChecksum(buf, len, 0);
 }
 
-// Returns true if the IP checksum is true
+// Returns true if the IP checksum is correct
 static inline bool VerifyIpv4NoOptChecksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   uint32_t sum = buf32[0];
@@ -250,7 +250,7 @@ static inline uint16_t CalculateIpv4NoOptChecksum(const Ipv4 &iph) {
   return FoldChecksum(sum);
 }
 
-// Returns true if the IP checksum is true
+// Returns true if the IP checksum is correct
 static inline bool VerifyIpv4Checksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   size_t ip_header_len = iph.header_length << 2;
@@ -315,13 +315,18 @@ static inline uint16_t CalculateIpv4Checksum(const Ipv4 &iph) {
   return FoldChecksum(sum);
 }
 
-// Returns true if the UDP checksum is true with the UDP header and
+// Returns true if the UDP checksum is correct with the UDP header and
 // pseudo header info - source ip, destiniation ip, and UDP byte stream length
 // udp_len: UDP header + payload in bytes.
 // NOTE: Undefined behavior if udp_len < 8
 static inline bool VerifyIpv4UdpChecksum(const Udp &udph, be32_t src_ip,
                                          be32_t dst_ip, uint16_t udp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&udph);
+
+  // UDP checksum is optional, and all zeroes mean "not computed"
+  if (udph.checksum == 0) {
+    return true;
+  }
 
   // UDP payload
   uint32_t sum = CalculateSum(buf32 + 2, udp_len - sizeof(udph));
@@ -342,7 +347,7 @@ static inline bool VerifyIpv4UdpChecksum(const Udp &udph, be32_t src_ip,
   return FoldChecksum(sum) == 0;
 }
 
-// Returns true if the UDP checksum is true
+// Returns true if the UDP checksum is correct
 static inline bool VerifyIpv4UdpChecksum(const Ipv4 &iph, const Udp &udph) {
   size_t ip_len = iph.length.value();
   size_t ip_header_len = iph.header_length << 2;
@@ -399,7 +404,7 @@ static inline uint16_t CalculateIpv4UdpChecksum(const Ipv4 &iph,
                                   ip_len - ip_header_len);
 }
 
-// Returns true if the TCP checksum is true with the TCP header and
+// Returns true if the TCP checksum is correct with the TCP header and
 // pseudo header info - source ip, destiniation ip, and tcp byte stream length
 // tcp_len: TCP header + payload in bytes
 // NOTE: Undefined behavior if tcp_len < 20
@@ -430,7 +435,7 @@ static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
   return FoldChecksum(sum) == 0;
 }
 
-// Returns true if the TCP checksum is true
+// Returns true if the TCP checksum is correct
 static inline bool VerifyIpv4TcpChecksum(const Ipv4 &iph, const Tcp &tcph) {
   size_t ip_len = iph.length.value();
   size_t ip_header_len = iph.header_length << 2;

--- a/core/utils/checksum.h
+++ b/core/utils/checksum.h
@@ -255,15 +255,16 @@ static inline bool VerifyIpv4Checksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   size_t ip_header_len = iph.header_length << 2;
 
-  if (likely(ip_header_len == 20)) {
+  if (likely(ip_header_len == sizeof(iph))) {
     return VerifyIpv4NoOptChecksum(iph);
   }
 
-  if (unlikely(ip_header_len < 20)) {
+  if (unlikely(ip_header_len < sizeof(iph))) {
     return false;  // Invalid IP header
   }
 
-  uint32_t sum = CalculateSum(buf32 + 5, ip_header_len - 20);
+  uint32_t sum = CalculateSum(buf32 + sizeof(iph) / sizeof(*buf32),
+                              ip_header_len - sizeof(iph));
 
   // Calculate internet checksum, the optimized way is
   // 1. get 32-bit one's complement sum including carrys
@@ -288,15 +289,16 @@ static inline uint16_t CalculateIpv4Checksum(const Ipv4 &iph) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&iph);
   size_t ip_header_len = iph.header_length << 2;
 
-  if (likely(ip_header_len == 20)) {
+  if (likely(ip_header_len == sizeof(iph))) {
     return CalculateIpv4NoOptChecksum(iph);
   }
 
-  if (unlikely(ip_header_len < 20)) {
+  if (unlikely(ip_header_len < sizeof(iph))) {
     return 0;  // Invalid IP header. Give up.
   }
 
-  uint32_t sum = CalculateSum(buf32 + 5, ip_header_len - 20);
+  uint32_t sum = CalculateSum(buf32 + sizeof(iph) / sizeof(*buf32),
+                              ip_header_len - sizeof(iph));
 
   // Calculate internet checksum, the optimized way is
   // 1. get 32-bit one's complement sum including carrys
@@ -329,7 +331,8 @@ static inline bool VerifyIpv4UdpChecksum(const Udp &udph, be32_t src_ip,
   }
 
   // UDP payload
-  uint32_t sum = CalculateSum(buf32 + 2, udp_len - sizeof(udph));
+  uint32_t sum = CalculateSum(buf32 + sizeof(udph) / sizeof(*buf32),
+                              udp_len - sizeof(udph));
   uint32_t len = static_cast<uint32_t>(be16_t::swap(udp_len));
 
   // Calculate the checksum of UDP header and pseudo header
@@ -369,7 +372,8 @@ static inline uint16_t CalculateIpv4UdpChecksum(const Udp &udph, be32_t src,
                                                 be32_t dst, uint16_t udp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&udph);
   // UDP payload
-  uint32_t sum = CalculateSum(buf32 + 2, udp_len - sizeof(udph));
+  uint32_t sum = CalculateSum(buf32 + sizeof(udph) / sizeof(*buf32),
+                              udp_len - sizeof(udph));
   uint32_t len = static_cast<uint32_t>(be16_t::swap(udp_len));
 
   // Calculate the checksum of UDP header and pseudo header
@@ -411,7 +415,8 @@ static inline bool VerifyIpv4TcpChecksum(const Tcp &tcph, be32_t src_ip,
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
 
   // TCP options and payload
-  uint32_t sum = CalculateSum(buf32 + 5, tcp_len - sizeof(tcph));
+  uint32_t sum = CalculateSum(buf32 + sizeof(tcph) / sizeof(*buf32),
+                              tcp_len - sizeof(tcph));
   uint32_t len = static_cast<uint32_t>(be16_t::swap(tcp_len));
 
   // Calculate the checksum of TCP header and pseudo header
@@ -457,7 +462,8 @@ static inline uint16_t CalculateIpv4TcpChecksum(const Tcp &tcph, be32_t src,
                                                 be32_t dst, uint16_t tcp_len) {
   const uint32_t *buf32 = reinterpret_cast<const uint32_t *>(&tcph);
   // tcp options and payload
-  uint32_t sum = CalculateSum(buf32 + 5, tcp_len - sizeof(tcph));
+  uint32_t sum = CalculateSum(buf32 + sizeof(tcph) / sizeof(*buf32),
+                              tcp_len - sizeof(tcph));
   uint32_t len = static_cast<uint32_t>(be16_t::swap(tcp_len));
 
   // Calculate the checksum of TCP header and pseudo header

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -241,7 +241,7 @@ TEST(ChecksumTest, UdpChecksum) {
     cksum_bess = CalculateIpv4NoOptChecksum(*ip);
 
     if (cksum_dpdk == 0xffff) {
-      // While the value of IP/UDP/TCP checksum field must not be -0 (0xffff),
+      // While the value of IP/TCP checksum field must not be -0 (0xffff),
       // but DPDK often (incorrectly) gives that value. (RFC 768, 1071, 1624)
       EXPECT_EQ(0, cksum_bess);
     } else {
@@ -254,13 +254,10 @@ TEST(ChecksumTest, UdpChecksum) {
         rte_ipv4_udptcp_cksum(reinterpret_cast<const ipv4_hdr *>(ip), udp);
     cksum_bess = CalculateIpv4UdpChecksum(*ip, *udp);
 
-    if (cksum_dpdk == 0xffff) {
-      // While the value of IP/UDP/TCP checksum field must not be -0 (0xffff),
-      // but DPDK often (incorrectly) gives that value. (RFC 768, 1071, 1624)
-      EXPECT_EQ(0, cksum_bess);
-    } else {
-      EXPECT_EQ(cksum_dpdk, cksum_bess);
-    }
+    EXPECT_EQ(cksum_dpdk, cksum_bess);
+
+    // The result of UDP checksum must not be zero
+    EXPECT_NE(0, cksum_bess);
   }
 }
 
@@ -302,7 +299,7 @@ TEST(ChecksumTest, TcpChecksum) {
   // Should not crash with incorrect IP headers
   ip->length = be16_t(39);
   EXPECT_EQ(0, CalculateIpv4TcpChecksum(*ip, *tcp));
-  //EXPECT_FALSE(VerifyIpv4TcpChecksum(*ip, *tcp));
+  EXPECT_FALSE(VerifyIpv4TcpChecksum(*ip, *tcp));
 
   ip->length = be16_t(40);
 
@@ -321,7 +318,7 @@ TEST(ChecksumTest, TcpChecksum) {
     cksum_bess = CalculateIpv4NoOptChecksum(*ip);
 
     if (cksum_dpdk == 0xffff) {
-      // While the value of IP/UDP/TCP checksum field must not be -0 (0xffff),
+      // While the value of IP/TCP checksum field must not be -0 (0xffff),
       // but DPDK often (incorrectly) gives that value. (RFC 768, 1071, 1624)
       EXPECT_EQ(0, cksum_bess);
     } else {
@@ -335,7 +332,7 @@ TEST(ChecksumTest, TcpChecksum) {
     cksum_bess = CalculateIpv4TcpChecksum(*ip, *tcp);
 
     if (cksum_dpdk == 0xffff) {
-      // While the value of IP/UDP/TCP checksum field must not be -0 (0xffff),
+      // While the value of IP/TCP checksum field must not be -0 (0xffff),
       // but DPDK often (incorrectly) gives that value. (RFC 768, 1071, 1624)
       EXPECT_EQ(0, cksum_bess);
     } else {

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -228,6 +228,12 @@ TEST(ChecksumTest, UdpChecksum) {
   udp->checksum = 0;
   EXPECT_TRUE(VerifyIpv4UdpChecksum(*ip, *udp));
 
+  // Return 0 upon invalid header?
+  udp->length = be16_t(7);
+  EXPECT_EQ(0, CalculateIpv4UdpChecksum(*ip, *udp));
+
+  udp->length = be16_t(8);
+
   for (int i = 0; i < kTestLoopCount; i++) {
     ip->src = be32_t(rd.Get());
     ip->dst = be32_t(rd.Get());

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -42,7 +42,7 @@ using namespace bess::utils;
 namespace {
 
 Random rd;
-static int TestLoopCount = 100000;
+const int kTestLoopCount = 1000000;
 
 // Tests generic checksum
 TEST(ChecksumTest, GenericChecksum) {
@@ -70,7 +70,7 @@ TEST(ChecksumTest, GenericChecksum) {
   EXPECT_TRUE(VerifyGenericChecksum(buf, 159, cksum_bess));
   EXPECT_TRUE(VerifyGenericChecksum(buf, 159, cksum_dpdk));
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     for (int j = 0; j < 40; j++) {
       buf[j] = rd.Get();
     }
@@ -111,7 +111,7 @@ TEST(ChecksumTest, Ipv4NoOptChecksum) {
 
   ip->checksum = 0x0000;  // for dpdk
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     ip->src = be32_t(rd.Get());
     ip->dst = be32_t(rd.Get());
 
@@ -165,7 +165,7 @@ TEST(ChecksumTest, Ipv4Checksum) {
 
   ip->checksum = 0x0000;  // for dpdk
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     size_t ip_opts_len = rd.Get() % 10;  // Maximum IP option length is 10 << 2
     ip->header_length = 5 + ip_opts_len;
     ip->src = be32_t(rd.Get());
@@ -228,7 +228,7 @@ TEST(ChecksumTest, UdpChecksum) {
   udp->checksum = 0;
   EXPECT_TRUE(VerifyIpv4UdpChecksum(*ip, *udp));
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     ip->src = be32_t(rd.Get());
     ip->dst = be32_t(rd.Get());
     udp->src_port = be16_t(rd.Get() >> 16);
@@ -306,7 +306,7 @@ TEST(ChecksumTest, TcpChecksum) {
 
   ip->length = be16_t(40);
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     ip->src = be32_t(rd.Get());
     ip->dst = be32_t(rd.Get());
     tcp->src_port = be16_t(rd.Get() >> 16);
@@ -357,7 +357,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum16) {
 
   EXPECT_EQ(cksum_new, cksum_update);
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     for (int j = 0; j < 5; j++)
       buf[j] = rd.Get() >> 16;
 
@@ -386,7 +386,7 @@ TEST(ChecksumTest, IncrementalUpdateChecksum32) {
 
   EXPECT_EQ(cksum_new, cksum_update);
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     for (int j = 0; j < 5; j++) {
       buf[j] = rd.Get();
     }
@@ -429,7 +429,7 @@ TEST(ChecksumTest, IncrementalUpdateSrcIpPort) {
   EXPECT_TRUE(VerifyIpv4NoOptChecksum(*ip));
   EXPECT_TRUE(VerifyIpv4TcpChecksum(*ip, *tcp));
 
-  for (int i = 0; i < TestLoopCount; i++) {
+  for (int i = 0; i < kTestLoopCount; i++) {
     be32_t src_ip_old = ip->src;
     be16_t src_port_old = tcp->src_port;
     uint16_t ip_cksum_old = ip->checksum;

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -224,6 +224,10 @@ TEST(ChecksumTest, UdpChecksum) {
   udp->checksum = cksum_bess;
   EXPECT_TRUE(VerifyIpv4UdpChecksum(*ip, *udp));
 
+  // Empty checksum is always considered correct for UDP
+  udp->checksum = 0;
+  EXPECT_TRUE(VerifyIpv4UdpChecksum(*ip, *udp));
+
   for (int i = 0; i < TestLoopCount; i++) {
     ip->src = be32_t(rd.Get());
     ip->dst = be32_t(rd.Get());

--- a/core/utils/checksum_test.cc
+++ b/core/utils/checksum_test.cc
@@ -158,6 +158,11 @@ TEST(ChecksumTest, Ipv4Checksum) {
   ip->checksum = cksum_bess;
   EXPECT_TRUE(VerifyIpv4Checksum(*ip));
 
+  // Should not crash with incorrect IP headers
+  ip->header_length = 4;
+  EXPECT_EQ(0, CalculateIpv4Checksum(*ip));
+  EXPECT_FALSE(VerifyIpv4Checksum(*ip));
+
   ip->checksum = 0x0000;  // for dpdk
 
   for (int i = 0; i < TestLoopCount; i++) {
@@ -289,6 +294,13 @@ TEST(ChecksumTest, TcpChecksum) {
 
   tcp->checksum = cksum_bess;
   EXPECT_TRUE(VerifyIpv4TcpChecksum(*ip, *tcp));
+
+  // Should not crash with incorrect IP headers
+  ip->length = be16_t(39);
+  EXPECT_EQ(0, CalculateIpv4TcpChecksum(*ip, *tcp));
+  //EXPECT_FALSE(VerifyIpv4TcpChecksum(*ip, *tcp));
+
+  ip->length = be16_t(40);
 
   for (int i = 0; i < TestLoopCount; i++) {
     ip->src = be32_t(rd.Get());


### PR DESCRIPTION
BESS daemon process may crash if an IP header is malformed, e.g.
* IP header length is larger than IP total length
* IP header is incomplete (smaller than 20B)

Similar issues happen with malformed UDP/TCP packets. The crash is due to expression like `iph.length.value() - (iph.header_length << 2)`, which causes underflow of an unsigned type. Error conditions are now checked for packets from a potentially untrusted source.

This PR also addresses the following less-severe, corner-case issues:
* `VerifyIpv4UdpChecksum()` does not work correctly if the checksum field is 0.
  * For UDP packets, checksum 0 should always be considered "correct"
* If a UDP checksum result happens to be 0, the field must have 0xffff (rfc768)
* In contrast to TCP, UDP header has its own length field. This one must be preferred over the derived L4 length from IP header fields.