### PR TITLE
Fix tcpdump for scattered packet buffers

### DIFF
--- a/core/hooks/tcpdump.cc
+++ b/core/hooks/tcpdump.cc
@@ -102,7 +102,7 @@ void Tcpdump::ProcessBatch(const bess::PacketBatch *batch) {
     };
 
     struct iovec vec[2] = {{&rec, sizeof(rec)},
-                           {pkt->head_data(), (size_t)pkt->total_len()}};
+                           {pkt->head_data(), (size_t)pkt->head_len()}};
 
     ret = writev(fifo_fd_, vec, 2);
     if (ret < 0) {

--- a/core/hooks/tcpdump.cc
+++ b/core/hooks/tcpdump.cc
@@ -44,10 +44,12 @@
 const std::string Tcpdump::kName = "tcpdump";
 
 Tcpdump::Tcpdump()
-    : bess::GateHook(Tcpdump::kName, Tcpdump::kPriority), fifo_fd_() {}
+    : bess::GateHook(Tcpdump::kName, Tcpdump::kPriority), fifo_fd_(-1) {}
 
 Tcpdump::~Tcpdump() {
-  close(fifo_fd_);
+  if (fifo_fd_ >= 0) {
+    close(fifo_fd_);
+  }
 }
 
 CommandResponse Tcpdump::Init(const bess::Gate *,
@@ -107,7 +109,7 @@ void Tcpdump::ProcessBatch(const bess::PacketBatch *batch) {
       if (errno == EPIPE) {
         DLOG(WARNING) << "Broken pipe: stopping tcpdump";
         close(fifo_fd_);
-        fifo_fd_ = 0;
+        fifo_fd_ = -1;
       }
       return;
     }

--- a/core/hooks/tcpdump.h
+++ b/core/hooks/tcpdump.h
@@ -43,9 +43,6 @@ class Tcpdump final : public bess::GateHook {
 
   CommandResponse Init(const bess::Gate *, const bess::pb::TcpdumpArg &);
 
-  int fifo_fd() const { return fifo_fd_; }
-  void set_fifo_fd(int fifo_fd) { fifo_fd_ = fifo_fd; }
-
   void ProcessBatch(const bess::PacketBatch *batch);
 
   static constexpr uint16_t kPriority = 1;


### PR DESCRIPTION
Scattered packet buffers have `total_len` larger than `data_len`, which accounts only the first segment. Since we consider only the first segment has been captured, not the entire packet, only `data_len` bytes must be written to the fifo.

Also, internally `fifo_fd_` stored 0 to represent "no file descriptor is open", but fd 0 might be actually being used. Because of this the class destructor may accidentally close `stdin` or any other file descriptor allocated to 0.