### PR TITLE
modules/set_metadata: add shift and mask support

### DIFF
--- a/bessctl/conf/metadata/attr_match.bess
+++ b/bessctl/conf/metadata/attr_match.bess
@@ -31,8 +31,8 @@
 # For metadata attribute usage for wildcard matching,
 # also see samples/wildcardmatch.bess
 
-em::ExactMatch(fields=[{'attribute':'foo', 'size':1}, \
-                       {'attribute':'bar', 'size':2}])
+em::ExactMatch(fields=[{'attr_name':'foo', 'num_bytes':1}, \
+                       {'attr_name':'bar', 'num_bytes':2}])
 Source() \
         -> SetMetadata(attrs=[{'name': 'foo', 'size': 1, 'value_int': 0xcc}]) \
         -> SetMetadata(attrs=[{'name': 'bar', 'size': 2, 'value_int': 0x1122}]) \
@@ -49,5 +49,5 @@ em:1 -> Sink()
 em:2 -> Sink()
 
 # NOTE: metadata attribute values are stored in host order (little endian)!
-em.add(fields=[b'\xcc', b'\x22\x11'], gate=1)
-em.add(fields=[b'\x42', b'\x33\x44'], gate=2)
+em.add(fields=[{'value_bin': b'\xcc'}, {'value_bin': b'\x22\x11'}], gate=1)
+em.add(fields=[{'value_bin': b'\x42'}, {'value_bin': b'\x33\x44'}], gate=2)

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -28,24 +28,87 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <cmath>
+#include <x86intrin.h>
+
 #include "set_metadata.h"
 
 #include "../utils/endian.h"
+#include "../utils/simd.h"
 
 static void CopyFromPacket(bess::PacketBatch *batch, const struct Attr *attr,
                            bess::metadata::mt_offset_t mt_off) {
   int cnt = batch->cnt();
   int size = attr->size;
-
+  int shift = attr->shift;
   int pkt_off = attr->offset;
+  int mt_adj = 0;
+  if (shift < 0) {
+    pkt_off += std::abs(shift);
+  } else if (shift > 0) {
+    mt_adj += shift;
+  }
+  size -= std::abs(shift);
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
-    char *head = pkt->head_data<char *>();
-    void *mt_ptr;
+    uint8_t *head = pkt->head_data<uint8_t *>(pkt_off);
+    uint8_t *mt_ptr = _ptr_attr_with_offset<uint8_t>(mt_off + mt_adj, pkt);
+    bess::utils::CopySmall(mt_ptr, head, size);
+  }
+}
 
-    mt_ptr = _ptr_attr_with_offset<value_t>(mt_off, pkt);
-    bess::utils::CopySmall(mt_ptr, head + pkt_off, size);
+static void CopyFromPacketWithMask(bess::PacketBatch *batch,
+                                   const struct Attr *attr,
+                                   bess::metadata::mt_offset_t mt_off) {
+  int cnt = batch->cnt();
+  int size = attr->size;
+  mask_t mask = attr->mask;
+  int shift = attr->shift;
+  int pkt_off = attr->offset;
+  int mt_adj = 0;
+  if (shift < 0) {
+    pkt_off += std::abs(shift);
+  } else if (shift > 0) {
+    mt_adj += shift;
+  }
+
+  // Copy data
+  size -= std::abs(shift);
+  for (int i = 0; i < cnt; i++) {
+    bess::Packet *pkt = batch->pkts()[i];
+    uint8_t *head = pkt->head_data<uint8_t *>(pkt_off);
+    uint8_t *mt_ptr = _ptr_attr_with_offset<uint8_t>(mt_off + mt_adj, pkt);
+    bess::utils::CopySmall(mt_ptr, head, size);
+  }
+  size += std::abs(shift);
+
+  // Apply mask
+  for (int i = 0; i < cnt; i++) {
+    bess::Packet *pkt = batch->pkts()[i];
+    int len = size;
+
+    uint64_t *mt64 = _ptr_attr_with_offset<uint64_t>(mt_off + mt_adj, pkt);
+    uint64_t *mask64 = reinterpret_cast<uint64_t *>(mask.bytes);
+    __m128i *mt128 = reinterpret_cast<__m128i *>(mt64);
+    __m128i a = gather_m128i(mt64, mt64 + 1);
+    __m128i b = gather_m128i(mask64, mask64 + 1);
+    *mt128 = _mm_and_si128(a, b);
+
+    len -= sizeof(__m128i);
+    mt128++;
+    mt64 += 2;
+    mask64 += 2;
+
+    while (len >= int{sizeof(__m128i)}) {
+      a = gather_m128i(mt64, mt64 + 1);
+      b = gather_m128i(mask64, mask64 + 1);
+      *mt128 = _mm_and_si128(a, b);
+      len -= sizeof(__m128i);
+      mt128++;
+      mt64 += 2;
+      mask64 += 2;
+    }
   }
 }
 
@@ -71,6 +134,8 @@ CommandResponse SetMetadata::AddAttrOne(
   size_t size = 0;
   int offset = -1;
   value_t value = value_t();
+  mask_t mask = mask_t();
+  bool do_mask = false;
 
   int ret;
 
@@ -79,6 +144,7 @@ CommandResponse SetMetadata::AddAttrOne(
   }
   name = attr.name();
   size = attr.size();
+  do_mask = attr.mask().length() > 0;
 
   if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize) {
     return CommandFailure(EINVAL, "'size' must be 1-%zu",
@@ -112,6 +178,16 @@ CommandResponse SetMetadata::AddAttrOne(
     if (offset < 0 || offset + size >= SNBUF_DATA) {
       return CommandFailure(EINVAL, "invalid packet offset");
     }
+    if (do_mask) {
+      memset(mask.bytes, 0xFF, size);
+      if (attr.mask().length() != size) {
+        return CommandFailure(EINVAL,
+                              "'mask' field has not a "
+                              "correct %zu-byte value",
+                              size);
+      }
+      bess::utils::Copy(&mask, attr.mask().data(), size);
+    }
   }
 
   ret = AddMetadataAttr(name, size,
@@ -124,6 +200,9 @@ CommandResponse SetMetadata::AddAttrOne(
   attrs_.back().size = size;
   attrs_.back().offset = offset;
   attrs_.back().value = value;
+  attrs_.back().do_mask = do_mask;
+  attrs_.back().mask = mask;
+  attrs_.back().shift = attr.shift();
 
   return CommandSuccess();
 }
@@ -158,7 +237,11 @@ void SetMetadata::ProcessBatch(bess::PacketBatch *batch) {
 
     /* copy data from the packet */
     if (attr->offset >= 0) {
-      CopyFromPacket(batch, attr, mt_offset);
+      if (attr->do_mask) {
+        CopyFromPacketWithMask(batch, attr, mt_offset);
+      } else {
+        CopyFromPacket(batch, attr, mt_offset);
+      }
     } else {
       CopyFromValue(batch, attr, mt_offset);
     }

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -178,6 +178,10 @@ CommandResponse SetMetadata::AddAttrOne(
     if (offset < 0 || offset + size >= SNBUF_DATA) {
       return CommandFailure(EINVAL, "invalid packet offset");
     }
+    if (std::abs(attr.shift()) > size) {
+      return CommandFailure(EINVAL, "'shift' must be in [-%zu,%zu]", size,
+                            size);
+    }
     if (do_mask) {
       memset(mask.bytes, 0xFF, size);
       if (attr.mask().length() != size) {

--- a/core/modules/set_metadata.h
+++ b/core/modules/set_metadata.h
@@ -34,13 +34,17 @@
 #include "../module.h"
 #include "../pb/module_msg.pb.h"
 
-typedef struct { char bytes[bess::metadata::kMetadataAttrMaxSize]; } value_t;
+typedef struct { uint8_t bytes[bess::metadata::kMetadataAttrMaxSize]; } value_t;
+typedef struct { uint8_t bytes[bess::metadata::kMetadataAttrMaxSize]; } mask_t;
 
 struct Attr {
   std::string name;
   value_t value;
   int offset;
   int size;
+  bool do_mask;
+  mask_t mask;
+  int shift;
 };
 
 class SetMetadata final : public Module {

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -837,6 +837,8 @@ message SetMetadataArg {
       bytes value_bin = 4; /// A binary value to store in the packet (host-order).
     }
     int64 offset = 5; /// An index in the packet data to store copy into the metadata attribute.
+    bytes mask = 6; /// An array of bit masks to apply to each of the bytes copied starting from `offset`. If empty, the mask [0xFF,....,0xFF] will be used.
+    int32 shift = 7; /// The number of bytes to shift the masked value at offset by before storing it in metadata. Positive and negative values represent right and left shifts respectively.
   }
   repeated Attribute attrs = 1; /// A list of attributes to attach to the packet.
 }


### PR DESCRIPTION
This patch changes SetMetadata to optionally shift and mask (in that
order) values when copying metadata values from the contents of a
packet. It also fixes one of the metadata test scripts.

A quick micro benchmark on a 2.1GHz Xeon 2620v4 with the script below shows relatively minor overhead is imposed when `SetMetadata` is not configured to use the new features.

```
ATTR_SIZE = int($ATTR_SIZE!'1')
Source() \
    -> SetMetadata(attrs=[{'name': 'foo', 'size': ATTR_SIZE, 'offset': 0}]) \
    -> MetadataTest(read={'foo': ATTR_SIZE}) \
    -> Sink()
```

### Before

| attr. size | Mpps | cycles/pkt |
| - | - | - |
| 1 | 108.108 | 19.422 |
| 2 | 108.407 | 19.372 |
| 4 | 111.280 | 18.872 |
| 8 | 113.383 | 18.522 |
| 16 | 106.242 | 19.767 |
| 24 | 115.461 | 18.188 |
| 32 | 116.844 | 17.973 |

### After

|attr. size | Mpps | cycles/pkt |
| - | - | - |
| 1 | 103.293 | 20.331 |
| 2 | 103.518 | 20.287 |
| 4 | 109.368 | 19.202 |
| 8 | 109.321 | 19.210 |
| 16 | 109.904 | 19.108 |
| 24 | 111.408 | 18.850 |
| 32 | 114.985 | 18.264 |
