### PR TITLE
metadata: Fix crash when igate is nullptr.

### DIFF
--- a/bessctl/conf/metadata/test17.bess
+++ b/bessctl/conf/metadata/test17.bess
@@ -29,7 +29,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-# testing nodes with non contiguous gates
+# Regression test for a bug in the graph traversal code for metadata:
+# if the input gate indexes in a node are not contiguous (i.e. there's a
+# gate 4, but not a gate 3), BESS crashed because one of the gates in the
+# module is stored as nullptr.
 
 a::MetadataTest(write={'foo':2, 'bar':3, 'baz':5, 'quz':8})
 b::MetadataTest(read={'foo':2, 'bar':3})

--- a/bessctl/conf/metadata/test17.bess
+++ b/bessctl/conf/metadata/test17.bess
@@ -1,0 +1,38 @@
+# Copyright (c) 2014-2016, The Regents of the University of California.
+# Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the names of the copyright holders nor the names of their
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+# testing nodes with non contiguous gates
+
+a::MetadataTest(write={'foo':2, 'bar':3, 'baz':5, 'quz':8})
+b::MetadataTest(read={'foo':2, 'bar':3})
+c::MetadataTest(read={'baz':5, 'quz':8})
+
+a:1->2:b:3->4:c

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -208,7 +208,10 @@ void Pipeline::TraverseUpstream(Module *m, const struct Attribute *attr) {
   }
   module_scopes_[m] = static_cast<int>(scope_components_.size());
 
-  for (const auto &g : m->igates()) {
+  for (const IGate *g : m->igates()) {
+    if (g == nullptr) {
+      continue;
+    }
     for (const auto &og : g->ogates_upstream()) {
       TraverseUpstream(og->module(), attr);
     }


### PR DESCRIPTION
`igate`s are stored in a vector, with the gate number used as index.
If a gate index in a module is not used, the vector will have nullptr
where the igate pointer should be.

Pipeline::TraverseUpstream() didn't check for nullptr.  This caused
a crash (reproducible with the test included in the commit).

The commit fixes the crash.