### PR TITLE
modules/set_metadata: add shift/mask support

### DIFF
--- a/bessctl/conf/metadata/attr_match.bess
+++ b/bessctl/conf/metadata/attr_match.bess
@@ -31,8 +31,8 @@
 # For metadata attribute usage for wildcard matching,
 # also see samples/wildcardmatch.bess
 
-em::ExactMatch(fields=[{'attribute':'foo', 'size':1}, \
-                       {'attribute':'bar', 'size':2}])
+em::ExactMatch(fields=[{'attr_name':'foo', 'num_bytes':1}, \
+                       {'attr_name':'bar', 'num_bytes':2}])
 Source() \
         -> SetMetadata(attrs=[{'name': 'foo', 'size': 1, 'value_int': 0xcc}]) \
         -> SetMetadata(attrs=[{'name': 'bar', 'size': 2, 'value_int': 0x1122}]) \
@@ -49,5 +49,5 @@ em:1 -> Sink()
 em:2 -> Sink()
 
 # NOTE: metadata attribute values are stored in host order (little endian)!
-em.add(fields=[b'\xcc', b'\x22\x11'], gate=1)
-em.add(fields=[b'\x42', b'\x33\x44'], gate=2)
+em.add(fields=[{'value_bin': b'\xcc'}, {'value_bin': b'\x22\x11'}], gate=1)
+em.add(fields=[{'value_bin': b'\x42'}, {'value_bin': b'\x33\x44'}], gate=2)

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -189,13 +189,15 @@ inline void SetMetadata::DoProcessBatch(bess::PacketBatch *batch,
                                         const struct Attr *attr,
                                         mt_offset_t mt_offset) {
   if (mode == Mode::FromPacket) {
-    bool shift = attr->shift;
+    bool shift = attr->shift != 0;
     if (shift && attr->do_mask) {
       CopyFromPacket<true, true>(batch, attr, mt_offset);
     } else if (shift) {
-      CopyFromPacket<true>(batch, attr, mt_offset);
+      CopyFromPacket<true, false>(batch, attr, mt_offset);
+    } else if (!shift) {
+      CopyFromPacket<false, true>(batch, attr, mt_offset);
     } else {
-      CopyFromPacket<false>(batch, attr, mt_offset);
+      CopyFromPacket<false, false>(batch, attr, mt_offset);
     }
   } else {
     CopyFromValue(batch, attr, mt_offset);

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -28,29 +28,44 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <cmath>
+#include <x86intrin.h>
+
 #include "set_metadata.h"
 
+#include "../utils/bits.h"
 #include "../utils/endian.h"
 
+using bess::metadata::mt_offset_t;
+
+template <bool do_shift = false, bool do_mask = false>
 static void CopyFromPacket(bess::PacketBatch *batch, const struct Attr *attr,
-                           bess::metadata::mt_offset_t mt_off) {
+                           mt_offset_t mt_off) {
   int cnt = batch->cnt();
   int size = attr->size;
-
+  int shift = attr->shift;
   int pkt_off = attr->offset;
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
-    char *head = pkt->head_data<char *>();
-    void *mt_ptr;
-
-    mt_ptr = _ptr_attr_with_offset<value_t>(mt_off, pkt);
-    bess::utils::CopySmall(mt_ptr, head + pkt_off, size);
+    uint8_t *head = pkt->head_data<uint8_t *>(pkt_off);
+    uint8_t *mt_ptr = _ptr_attr_with_offset<uint8_t>(mt_off, pkt);
+    bess::utils::CopySmall(mt_ptr, head, size);
+    if (do_shift) {
+      if (shift > 0) {
+        bess::utils::ShiftBytesRight(mt_ptr, size, shift);
+      } else {
+        bess::utils::ShiftBytesLeft(mt_ptr, size, -shift);
+      }
+    }
+    if (do_mask) {
+      bess::utils::MaskBytes(mt_ptr, attr->mask.bytes, size);
+    }
   }
 }
 
 static void CopyFromValue(bess::PacketBatch *batch, const struct Attr *attr,
-                          bess::metadata::mt_offset_t mt_off) {
+                          mt_offset_t mt_off) {
   int cnt = batch->cnt();
   int size = attr->size;
 
@@ -70,7 +85,10 @@ CommandResponse SetMetadata::AddAttrOne(
   std::string name;
   size_t size = 0;
   int offset = -1;
-  value_t value = value_t();
+  int rshift_bytes = attr.rshift_bits() / 8;
+  value_t value;
+  mask_t mask;
+  bool do_mask = false;
 
   int ret;
 
@@ -79,10 +97,10 @@ CommandResponse SetMetadata::AddAttrOne(
   }
   name = attr.name();
   size = attr.size();
+  do_mask = attr.mask().length() > 0;
 
-  if (size < 1 || size > bess::metadata::kMetadataAttrMaxSize) {
-    return CommandFailure(EINVAL, "'size' must be 1-%zu",
-                          bess::metadata::kMetadataAttrMaxSize);
+  if (size < 1 || size > kMetadataAttrMaxSize) {
+    return CommandFailure(EINVAL, "'size' must be 1-%zu", kMetadataAttrMaxSize);
   }
 
   // All metadata values are stored in a reserved area of packet data.
@@ -112,18 +130,38 @@ CommandResponse SetMetadata::AddAttrOne(
     if (offset < 0 || offset + size >= SNBUF_DATA) {
       return CommandFailure(EINVAL, "invalid packet offset");
     }
+    if (rshift_bytes * 8 != attr.rshift_bits()) {
+      return CommandFailure(EINVAL, "'rshift_bits' must be a multiple of 8");
+    }
+    if (static_cast<size_t>(std::abs(rshift_bytes)) > size) {
+      return CommandFailure(EINVAL, "'rshift_bits' must be in [-%zu,%zu]",
+                            8 * size, 8 * size);
+    }
+    if (do_mask) {
+      memset(mask.bytes, 0xFF, size);
+      if (attr.mask().length() != size) {
+        return CommandFailure(EINVAL,
+                              "'mask' field has not a "
+                              "correct %zu-byte value",
+                              size);
+      }
+      bess::utils::Copy(&mask, attr.mask().data(), size);
+    }
   }
 
   ret = AddMetadataAttr(name, size,
                         bess::metadata::Attribute::AccessMode::kWrite);
-  if (ret < 0)
+  if (ret < 0) {
     return CommandFailure(-ret, "add_metadata_attr() failed");
+  }
 
-  attrs_.emplace_back();
-  attrs_.back().name = name;
-  attrs_.back().size = size;
-  attrs_.back().offset = offset;
-  attrs_.back().value = value;
+  attrs_.push_back({.name = name,
+                    .value = value,
+                    .mask = mask,
+                    .offset = offset,
+                    .size = size,
+                    .do_mask = do_mask,
+                    .shift = rshift_bytes});
 
   return CommandSuccess();
 }
@@ -146,21 +184,37 @@ CommandResponse SetMetadata::Init(const bess::pb::SetMetadataArg &arg) {
   return CommandSuccess();
 }
 
+template <SetMetadata::Mode mode>
+inline void SetMetadata::DoProcessBatch(bess::PacketBatch *batch,
+                                        const struct Attr *attr,
+                                        mt_offset_t mt_offset) {
+  if (mode == Mode::FromPacket) {
+    bool shift = attr->shift;
+    if (shift && attr->do_mask) {
+      CopyFromPacket<true, true>(batch, attr, mt_offset);
+    } else if (shift) {
+      CopyFromPacket<true>(batch, attr, mt_offset);
+    } else {
+      CopyFromPacket<false>(batch, attr, mt_offset);
+    }
+  } else {
+    CopyFromValue(batch, attr, mt_offset);
+  }
+}
+
 void SetMetadata::ProcessBatch(bess::PacketBatch *batch) {
   for (size_t i = 0; i < attrs_.size(); i++) {
     const struct Attr *attr = &attrs_[i];
-
-    bess::metadata::mt_offset_t mt_offset = attr_offset(i);
+    mt_offset_t mt_offset = attr_offset(i);
 
     if (!bess::metadata::IsValidOffset(mt_offset)) {
       continue;
     }
 
-    /* copy data from the packet */
-    if (attr->offset >= 0) {
-      CopyFromPacket(batch, attr, mt_offset);
+    if (attr->offset > 0) {
+      DoProcessBatch<Mode::FromPacket>(batch, attr, mt_offset);
     } else {
-      CopyFromValue(batch, attr, mt_offset);
+      DoProcessBatch<Mode::FromValue>(batch, attr, mt_offset);
     }
   }
 

--- a/core/utils/bits.h
+++ b/core/utils/bits.h
@@ -1,0 +1,169 @@
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_UTILS_BITS_H_
+#define BESS_UTILS_BITS_H_
+
+#include <glog/logging.h>
+#include <x86intrin.h>
+
+#include <algorithm>
+
+namespace bess {
+namespace utils {
+
+// TODO(melvinw): add support for shifting at bit granularity
+// Shifts `buf` to the left by `len` bytes and fills in with zeroes using
+// std::memmove() and std::memset().
+static inline void ShiftBytesLeftSmall(uint8_t *buf, const size_t len,
+                                       size_t shift) {
+  shift = std::min(shift, len);
+  memmove(buf, buf + shift, len - shift);
+  memset(buf + len - shift, 0, shift);
+}
+
+// TODO(melvinw): add support for shifting at bit granularity
+// Shifts `buf` to the left by `len` bytes and fills in with zeroes.
+// Will shift in 8-byte chunks if `shift` <= 8, othersize, uses
+// std::memmove() and std::memset().
+static inline void ShiftBytesLeft(uint8_t *buf, const size_t len,
+                                  const size_t shift) {
+  if (len < sizeof(__m64) || shift > sizeof(__m64)) {
+    return ShiftBytesLeftSmall(buf, len, shift);
+  }
+
+  uint8_t *tmp_buf = buf;
+  size_t tmp_len = len;
+  size_t inc = sizeof(__m64) - shift;
+  while (tmp_len >= sizeof(__m64)) {
+    __m64 *block = reinterpret_cast<__m64 *>(tmp_buf);
+    *block = _mm_srl_si64(*block, _m_from_int64(shift * 8));
+    tmp_buf += inc;
+    tmp_len = buf + len - tmp_buf;
+  }
+
+  buf += len;
+  if (static_cast<size_t>(buf - tmp_buf) > shift) {
+    tmp_len = buf - tmp_buf - shift;
+    memmove(tmp_buf, tmp_buf + shift, tmp_len);
+    memset(buf - shift, 0, shift);
+  }
+}
+
+// TODO(melvinw): add support for shifting at bit granularity
+// Shifts `buf` to the right by `len` bytes and fills in with zeroes using
+// std::memmove() and std::memset().
+static inline void ShiftBytesRightSmall(uint8_t *buf, const size_t len,
+                                        size_t shift) {
+  shift = std::min(shift, len);
+  memmove(buf + shift, buf, len - shift);
+  memset(buf, 0, shift);
+}
+
+// TODO(melvinw): add support for shifting at bit granularity
+// Shifts `buf` to the right by `len` bytes and fills in with zeroes.
+// Will shift in 8-byte chunks if `shift` <= 8, othersize, uses
+// std::memmove() and std::memset().
+static inline void ShiftBytesRight(uint8_t *buf, const size_t len,
+                                   const size_t shift) {
+  if (len < sizeof(__m64) || shift > sizeof(__m64)) {
+    return ShiftBytesRightSmall(buf, len, shift);
+  }
+
+  uint8_t *tmp_buf = buf + len - sizeof(__m64);
+  size_t dec = sizeof(__m64) - shift;
+  size_t leftover = len;
+  while (tmp_buf >= buf) {
+    __m64 *block = reinterpret_cast<__m64 *>(tmp_buf);
+    *block = _mm_sll_si64(*block, _m_from_int64(shift * 8));
+    tmp_buf -= dec;
+    leftover -= dec;
+  }
+  ShiftBytesRightSmall(buf, leftover, shift);
+}
+
+// Applies the `len`-byte bitmask `mask` to `buf`, in 1-byte chunks.
+static inline void MaskBytesSmall(uint8_t *buf, const uint8_t *mask,
+                                  const size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    buf[i] &= mask[i];
+  }
+}
+
+// Applies the `len`-byte bitmask `mask` to `buf`, in 8-byte chunks if able,
+// otherwise, falls back to 1-byte chunks.
+static inline void MaskBytes64(uint8_t *buf, uint8_t const *mask,
+                               const size_t len) {
+  size_t n = len / sizeof(__m64);
+  size_t leftover = len - n * sizeof(__m64);
+  __m64 *buf64 = reinterpret_cast<__m64 *>(buf);
+  const __m64 *mask64 = reinterpret_cast<const __m64 *>(mask);
+  for (size_t i = 0; i < n; i++) {
+    *buf64 = _mm_and_si64(buf64[i], mask64[i]);
+  }
+
+  if (leftover) {
+    buf = reinterpret_cast<uint8_t *>(buf64 + n);
+    mask = reinterpret_cast<uint8_t const *>(mask64 + n);
+    MaskBytesSmall(buf, mask, leftover);
+  }
+}
+
+// Applies the `len`-byte bitmask `mask` to `buf`, in 16-byte chunks if able,
+// otherwise, falls back to 8-byte chunks and possibly 1-byte chunks.
+static inline void MaskBytes(uint8_t *buf, uint8_t const *mask,
+                             const size_t len) {
+  if (len <= sizeof(__m64)) {
+    return MaskBytes64(buf, mask, len);
+  }
+
+  // AVX2?
+  size_t n = len / sizeof(__m128i);
+  size_t leftover = len - n * sizeof(__m128i);
+  __m128i *buf128 = reinterpret_cast<__m128i *>(buf);
+  const __m128i *mask128 = reinterpret_cast<const __m128i *>(mask);
+  for (size_t i = 0; i < n; i++) {
+    __m128i a = _mm_loadu_si128(buf128 + i);
+    __m128i b = _mm_loadu_si128(mask128 + i);
+    _mm_storeu_si128(buf128 + i, _mm_and_si128(a, b));
+  }
+
+  buf = reinterpret_cast<uint8_t *>(buf128 + n);
+  mask = reinterpret_cast<uint8_t const *>(mask128 + n);
+  if (leftover >= sizeof(__m64)) {
+    MaskBytes64(buf, mask, leftover);
+  } else {
+    MaskBytesSmall(buf, mask, leftover);
+  }
+}
+
+}  // namespace utils
+}  // namespace bess
+
+#endif  // BESS_UTILS_BITS_H_

--- a/core/utils/bits_test.cc
+++ b/core/utils/bits_test.cc
@@ -1,0 +1,308 @@
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "bits.h"
+
+#include <gtest/gtest.h>
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void PrintBytes(const std::string &label, const std::vector<uint8_t> &buf) {
+  std::cout << label << ": ";
+  for (uint8_t b : buf) {
+    std::cout << std::hex << std::setw(2) << std::setfill('0') << int(b) << " ";
+  }
+  std::cout << std::endl;
+}
+
+void SetupBuffers(std::vector<uint8_t> *a, std::vector<uint8_t> *b,
+                  size_t len) {
+  a->clear();
+  b->clear();
+  for (size_t i = 0; i < len; i++) {
+    a->push_back(i + 1);
+    b->push_back(i + 1);
+  }
+}
+
+// Shifting ------------------------------------------------------------------
+
+TEST(ShiftRight, ShortBuffer) {
+  const size_t kLength = 5;
+  std::vector<std::vector<uint8_t>> exp = {
+      {0xAA, 0xBB, 0xCC, 0xDD, 0xEE}, {0x00, 0xAA, 0xBB, 0xCC, 0xDD},
+      {0x00, 0x00, 0xAA, 0xBB, 0xCC}, {0x00, 0x00, 0x00, 0xAA, 0xBB},
+      {0x00, 0x00, 0x00, 0x00, 0xAA}, {0x00, 0x00, 0x00, 0x00, 0x00}};
+  for (size_t i = 0; i < exp.size(); i++) {
+    std::vector<uint8_t> buf = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
+    bess::utils::ShiftBytesRightSmall(buf.data(), kLength, i);
+    int ret = memcmp(exp[i].data(), buf.data(), kLength);
+    if (ret != 0) {
+      EXPECT_TRUE(false) << "equality check failed for shift: " << i;
+      PrintBytes("buf", buf);
+      PrintBytes("exp", exp[i]);
+    }
+  }
+}
+
+TEST(ShiftRight, Aligned) {
+  std::vector<size_t> lengths = {8, 16, 24, 32};
+  std::vector<size_t> shifts = {1, 2, 3, 5, 7, 13};
+  std::vector<uint8_t> buf, exp;
+
+  for (size_t len : lengths) {
+    for (size_t shift : shifts) {
+      SetupBuffers(&buf, &exp, len);
+      bess::utils::ShiftBytesRightSmall(exp.data(), len, shift);
+      bess::utils::ShiftBytesRight(buf.data(), len, shift);
+      int ret = memcmp(exp.data(), buf.data(), len);
+      if (ret != 0) {
+        EXPECT_TRUE(false) << "equality check failed for len: " << len
+                           << ", shift: " << shift;
+        PrintBytes("buf", buf);
+        PrintBytes("exp", exp);
+      }
+    }
+  }
+}
+
+TEST(ShiftRight, Unaligned) {
+  std::vector<size_t> lengths = {9, 10, 11, 12, 13, 14, 15};
+  std::vector<size_t> shifts = {1, 2, 3, 5, 7, 13};
+  std::vector<uint8_t> buf, exp;
+
+  for (size_t len : lengths) {
+    for (size_t shift : shifts) {
+      SetupBuffers(&buf, &exp, len);
+      bess::utils::ShiftBytesRightSmall(exp.data(), len, shift);
+      bess::utils::ShiftBytesRight(buf.data(), len, shift);
+      int ret = memcmp(exp.data(), buf.data(), len);
+      if (ret != 0) {
+        EXPECT_TRUE(false) << "equality check failed for len: " << len
+                           << ", shift: " << shift;
+        PrintBytes("buf", buf);
+        PrintBytes("exp", exp);
+      }
+    }
+  }
+}
+
+TEST(ShiftLeft, ShortBuffer) {
+  const size_t kLength = 5;
+  std::vector<std::vector<uint8_t>> exp = {
+      {0xAA, 0xBB, 0xCC, 0xDD, 0xEE}, {0xBB, 0xCC, 0xDD, 0xEE, 0x00},
+      {0xCC, 0xDD, 0xEE, 0x00, 0x00}, {0xDD, 0xEE, 0x00, 0x00, 0x00},
+      {0xEE, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00}};
+  for (size_t i = 0; i < exp.size(); i++) {
+    std::vector<uint8_t> buf = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
+    bess::utils::ShiftBytesLeftSmall(buf.data(), kLength, i);
+    int ret = memcmp(exp[i].data(), buf.data(), kLength);
+    if (ret != 0) {
+      EXPECT_TRUE(false) << "equality check failed for shift: " << i;
+      PrintBytes("buf", buf);
+      PrintBytes("exp", exp[i]);
+    }
+  }
+}
+
+TEST(ShiftLeft, Aligned) {
+  std::vector<size_t> lengths = {8, 16, 24, 32};
+  std::vector<size_t> shifts = {1, 2, 3, 5, 7, 13};
+  std::vector<uint8_t> buf, exp;
+
+  for (size_t len : lengths) {
+    for (size_t shift : shifts) {
+      SetupBuffers(&buf, &exp, len);
+      bess::utils::ShiftBytesLeftSmall(exp.data(), len, shift);
+      bess::utils::ShiftBytesLeft(buf.data(), len, shift);
+      int ret = memcmp(exp.data(), buf.data(), len);
+      if (ret != 0) {
+        EXPECT_TRUE(false) << "equality check failed for len: " << len
+                           << ", shift: " << shift;
+        PrintBytes("buf", buf);
+        PrintBytes("exp", exp);
+      }
+    }
+  }
+}
+
+TEST(ShiftLeft, Unaligned) {
+  std::vector<size_t> lengths = {9, 10, 11, 12, 13, 14, 15};
+  std::vector<size_t> shifts = {1, 2, 3, 5, 7, 13};
+  std::vector<uint8_t> buf, exp;
+
+  for (size_t len : lengths) {
+    for (size_t shift : shifts) {
+      SetupBuffers(&buf, &exp, len);
+      bess::utils::ShiftBytesLeftSmall(exp.data(), len, shift);
+      bess::utils::ShiftBytesLeft(buf.data(), len, shift);
+      int ret = memcmp(exp.data(), buf.data(), len);
+      if (ret != 0) {
+        EXPECT_TRUE(false) << "equality check failed for len: " << len
+                           << ", shift: " << shift;
+        PrintBytes("buf", buf);
+        PrintBytes("exp", exp);
+      }
+    }
+  }
+}
+
+// Masking -------------------------------------------------------------------
+TEST(Mask, SmallAllBits) {
+  const size_t kLength = 5;
+  std::vector<uint8_t> buf = {0x01, 0x02, 0x03, 0x04, 0x05};
+  std::vector<uint8_t> mask = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  std::vector<uint8_t> exp = {0x01, 0x02, 0x03, 0x04, 0x05};
+
+  bess::utils::MaskBytesSmall(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+TEST(Mask, SmallNoBits) {
+  const size_t kLength = 5;
+  std::vector<uint8_t> buf = {0x01, 0x02, 0x03, 0x04, 0x05};
+  std::vector<uint8_t> mask = {0x00, 0x00, 0x00, 0x00, 0x00};
+  std::vector<uint8_t> exp = {0x00, 0x00, 0x00, 0x00, 0x00};
+
+  bess::utils::MaskBytesSmall(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+TEST(Mask, SmallSomeBits) {
+  const size_t kLength = 5;
+  std::vector<uint8_t> buf = {0x01, 0x02, 0x03, 0x04, 0x05};
+  std::vector<uint8_t> mask = {0x00, 0x00, 0xFF, 0x00, 0x00};
+  std::vector<uint8_t> exp = {0x00, 0x00, 0x03, 0x00, 0x00};
+
+  bess::utils::MaskBytesSmall(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+TEST(Mask, LongAligned) {
+  const size_t kLength = 8;
+  std::vector<uint8_t> buf = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  std::vector<uint8_t> mask = {0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00};
+  std::vector<uint8_t> exp = {0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00};
+
+  bess::utils::MaskBytes(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+TEST(Mask, LongUnaligned) {
+  const size_t kLength = 10;
+  std::vector<uint8_t> buf = {0x01, 0x02, 0x03, 0x04, 0x05,
+                              0x06, 0x07, 0x08, 0x09, 0x0A};
+  std::vector<uint8_t> mask = {0x00, 0x00, 0x00, 0x00, 0x00,
+                               0xFF, 0x00, 0x00, 0x00, 0x00};
+  std::vector<uint8_t> exp = {0x00, 0x00, 0x00, 0x00, 0x00,
+                              0x06, 0x00, 0x00, 0x00, 0x00};
+
+  bess::utils::MaskBytes(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+TEST(Mask, ExtraLongAligned) {
+  const size_t kLength = 32;
+  std::vector<uint8_t> buf = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                              0x09, 0x0A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+                              0x07, 0x08, 0x09, 0x0A, 0x01, 0x02, 0x03, 0x04,
+                              0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x01, 0x02};
+  std::vector<uint8_t> mask = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                               0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00};
+  std::vector<uint8_t> exp = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00,
+                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                              0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00};
+
+  bess::utils::MaskBytes(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+TEST(Mask, ExtraLongUnAligned) {
+  const size_t kLength = 33;
+  std::vector<uint8_t> buf = {
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x01,
+      0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x01, 0x02,
+      0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x01, 0x02, 0xAB};
+  std::vector<uint8_t> mask = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00, 0xFF};
+  std::vector<uint8_t> exp = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0xAB};
+
+  bess::utils::MaskBytes(buf.data(), mask.data(), kLength);
+  int ret = memcmp(exp.data(), buf.data(), kLength);
+  if (ret != 0) {
+    EXPECT_TRUE(false) << "equality check failed";
+    PrintBytes("buf", buf);
+    PrintBytes("exp", exp);
+  }
+}
+
+}  // namespace (unnamed)

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -828,7 +828,7 @@ message ReplicateCommandSetGatesArg {
 message SetMetadataArg {
   /**
    * SetMetadata Attribute describes a metadata attribute and value to attach to every packet.
-   * If copying data from a packet buffer, SetMetadata will optionally shift
+   * If copying data from a packet buffer, SetMetadata can also logically shift
    * then mask the value before storing it as metadata, i.e.,
    * metadata_value = (packet_value >> `rshift_bits`) & `mask`.
    */

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -828,6 +828,9 @@ message ReplicateCommandSetGatesArg {
 message SetMetadataArg {
   /**
    * SetMetadata Attribute describes a metadata attribute and value to attach to every packet.
+   * If copying data from a packet buffer, SetMetadata will optionally shift
+   * then mask the value before storing it as metadata, i.e.,
+   * metadata_value = (packet_value >> `rshift_bits`) & `mask`.
    */
   message Attribute {
     string name = 1; /// The metadata attribute name.
@@ -836,7 +839,9 @@ message SetMetadataArg {
       uint64 value_int = 3; /// An integer value to store in the packet (host-order).
       bytes value_bin = 4; /// A binary value to store in the packet (host-order).
     }
-    int64 offset = 5; /// An index in the packet data to store copy into the metadata attribute.
+    int32 offset = 5; /// An index in the packet data to store copy into the metadata attribute.
+    bytes mask = 6; /// An array of bit masks to apply to each of the bytes copied starting from `offset`. If empty, the mask [0xFF,....,0xFF] will be used.
+    int32 rshift_bits = 7; /// The number of bits to shift the value at `offset` by before masking. Must be a multiple of 8. Positive and negative values represent right and left shifts respectively.
   }
   repeated Attribute attrs = 1; /// A list of attributes to attach to the packet.
 }


### PR DESCRIPTION
This commit changes SetMetadata to optionally shift and mask (in that
order) values when copying metadata values from the contents of a
packet. It also makes some small optimizations and cleans up parts of
the module.

A quick micro benchmark on a 2.1GHz xeon 2620v4 with the script below shows the new features impose no undue overhead when they aren't used.

```
ATTR_SIZE = int($ATTR_SIZE!'1')
Source() \
    -> SetMetadata(attrs=[{'name': 'foo', 'size': ATTR_SIZE, 'offset': 0}]) \
    -> MetadataTest(read={'foo': ATTR_SIZE}) \
    -> Sink()
```

| Attr. Size | Mpps Before | Mpps After |
| - | - | - |
| 1 | 103.293| 114.835 |
| 2 | 103.518| 114.918 |
| 4 | 109.368| 109.702 |
| 8 | 109.321| 114.845 |
| 16 | 109.904| 113.136 |
| 24 | 111.408| 119.894 |
| 32 | 114.985| 120.66 |

I'm not too sure how useful the shift functions other than `Shift*Small` are since the scope of my interest was limited to `SetMetadata` and it only operates on up to 32 bytes. I'll open another PR in the future (or append to this one if people prefer) with a proper benchmark and possible changes for larger buffers.