### PR TITLE
set_metadata: make packet mode logic explicit

### DIFF
--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -203,11 +203,11 @@ inline void SetMetadata::DoProcessBatch(bess::PacketBatch *batch,
     bool shift = attr->shift != 0;
     if (shift && attr->do_mask) {
       CopyFromPacket<true, true>(batch, attr, mt_offset);
-    } else if (shift) {
+    } else if (shift && !attr->do_mask) {
       CopyFromPacket<true, false>(batch, attr, mt_offset);
-    } else if (!shift) {
+    } else if (!shift && attr->do_mask) {
       CopyFromPacket<false, true>(batch, attr, mt_offset);
-    } else {
+    } else if (!shift && !attr->do_mask) {
       CopyFromPacket<false, false>(batch, attr, mt_offset);
     }
   } else {


### PR DESCRIPTION
The existing version is hard to reason about and makes the no shift/no
mask code path unreachable.