### PR TITLE
allow module .so's to be symbolic links

### DIFF
--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -443,9 +443,12 @@ bool LoadPlugins(const std::string &directory) {
   }
   dirent *entry;
   while ((entry = readdir(dir)) != nullptr) {
-    if (entry->d_type == DT_REG && HasSuffix(entry->d_name, ".so")) {
+    if ((entry->d_type == DT_REG || entry->d_type == DT_LNK)
+	&& HasSuffix(entry->d_name, ".so")) {
       const std::string full_path = directory + "/" + entry->d_name;
+      LOG(INFO) << "Loading plugin: " << full_path;
       if (!LoadPlugin(full_path)) {
+        LOG(WARNING) << "Cannot load plugin " << full_path << "dlerror=" << dlerror();
         closedir(dir);
         return false;
       }


### PR DESCRIPTION
If libtool is used to build libraries, then come in the form of .so.0.0.1 for example and then the .so is linked to the version specific .so. With this commit, bessd can load such symlinks. I also added some
logging to add diagnostics on modules loaded and failure to load modules.