### PR TITLE
drivers/unix_socket: Let clients to freely connect/disconnect

### DIFF
--- a/bessctl/conf/testing/module_tests/vlan.py
+++ b/bessctl/conf/testing/module_tests/vlan.py
@@ -81,8 +81,7 @@ else:
                     'output_port': default_gate,
                     'input_packet': q,
                     'output_packet': q})
-        return [VLANSplit(), 1, 150, expected]
+        return [VLANSplit(), 1, 30, expected]
 
-    OUTPUT_TEST_INPUTS.append(output_test([1, 100, 77, -1, 149, 50, 100, -1]))
-    OUTPUT_TEST_INPUTS.append(output_test([100, 77, -1, 149, 50, 100, -1, 33, 70]))
-    OUTPUT_TEST_INPUTS.append(output_test([100, 77, -1, 149, 50, 100, -1, 33, 70], True))
+    OUTPUT_TEST_INPUTS.append(output_test([1, 17, -1, 29, 10, 13, 7]))
+    OUTPUT_TEST_INPUTS.append(output_test([1, 17, -1, 29, 10, 13, 7], True))

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -41,9 +41,6 @@
 // TODO: Revise this once the interrupt mode is  implemented.
 
 #define RECV_SKIP_TICKS 256
-#define MAX_TX_FRAGS 8
-
-#define SIG_THREAD_EXIT SIGUSR2
 
 
 static void EpollAdd(int epoll_fd, int new_fd, uint32_t events)
@@ -67,8 +64,6 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
   size_t addrlen;
 
   int ret;
-
-  client_fd_ = kNotConnectedFd;
 
   if (num_txq > 1 || num_rxq > 1) {
     return CommandFailure(EINVAL, "Cannot have more than 1 queue per RX/TX");

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -80,6 +80,9 @@ void UnixSocketPort::AcceptThread() {
       }
       if (fd < 0) {
         PLOG(ERROR) << "[UnixSocketPort]:accept4()";
+      } else if (client_fd_ != kNotConnectedFd) {
+        LOG(WARNING) << "[UnixSocketPort]: Ignoring additional client\n";
+        close(fd);
       } else {
         client_fd_ = fd;
       }

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -97,7 +97,7 @@ void UnixSocketPort::AcceptThread() {
 }
 
 static void AcceptThreadHandler(int sig) {
-  sig = sig;
+  int arg __attribute__((unused)) = sig; // keep compiler happy
 }
 
 CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -57,8 +57,7 @@ class UnixSocketPort final : public Port {
         recv_skip_cnt_(),
         listen_fd_(),
         addr_(),
-        client_fd_(),
-        old_client_fd_() {}
+        client_fd_() {}
 
   /*!
    * Initialize the port, ie, open the socket.
@@ -117,11 +116,6 @@ class UnixSocketPort final : public Port {
   static const int kNotConnectedFd = -1;
 
   /*!
-   * Closes the client connection but does not shut down the listener fd.
-   */
-  void CloseConnection();
-
-  /*!
   * Calling recv() system call is expensive so we only do it every
   * RECV_SKIP_TICKS times -- this counter keeps track of how many ticks its been
   * since we last called recv().
@@ -138,13 +132,15 @@ class UnixSocketPort final : public Port {
    */
   struct sockaddr_un addr_;
 
+  /*!
+   * The epoll fd -- detect when client closes.
+   */
+  int epoll_fd_;
+
   // NOTE: three threads (accept / recv / send) may race on this, so use
   // volatile.
   /* FD for client connection.*/
   volatile int client_fd_;
-  /* If client FD is not connected, what was the fd the last time we were
-   * connected to a client? */
-  int old_client_fd_;
 };
 
 #endif  // BESS_DRIVERS_UNIXSOCKET_H_

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -55,9 +55,10 @@ class UnixSocketPort final : public Port {
   UnixSocketPort()
       : Port(),
         recv_skip_cnt_(),
-        listen_fd_(),
+        listen_fd_(kNotConnectedFd),
         addr_(),
-        client_fd_() {}
+        epoll_fd_(kNotConnectedFd),
+        client_fd_(kNotConnectedFd) {}
 
   /*!
    * Initialize the port, ie, open the socket.

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -32,6 +32,7 @@
 #define BESS_DRIVERS_UNIXSOCKET_H_
 
 #include <assert.h>
+#include <atomic>
 #include <errno.h>
 #include <poll.h>
 #include <stdio.h>
@@ -55,8 +56,7 @@ class UnixSocketPort final : public Port {
   UnixSocketPort()
       : Port(),
         recv_skip_cnt_(),
-        accept_thread_stopped_fd_(kNotConnectedFd),
-        accept_thread_stop_fd_(kNotConnectedFd),
+        accept_thread_stop_req_(false),
         listen_fd_(kNotConnectedFd),
         addr_(),
         epoll_fd_(kNotConnectedFd),
@@ -131,14 +131,9 @@ class UnixSocketPort final : public Port {
   std::thread accept_thread_;
 
   /*!
-   * FD to read stop signal in accept thread.
+   * Sent stop request to accept thread.
    */
-  int accept_thread_stopped_fd_;
-
-  /*!
-   * FD to signal accept thread to stop.
-   */
-  int accept_thread_stop_fd_;
+  std::atomic<bool> accept_thread_stop_req_;
 
   /*!
    * The listener fd -- listen for new connections here.

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -121,7 +121,12 @@ class UnixSocketPort final : public Port {
   uint32_t recv_skip_cnt_;
 
   /*!
-   * Thread accepting and monitoring clients.
+   * Function for the thread accepting and monitoring clients (accept thread).
+   */
+  void AcceptThread();
+
+  /*!
+   * Accept thread handle.
    */
   std::thread accept_thread_;
 

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -55,6 +55,8 @@ class UnixSocketPort final : public Port {
   UnixSocketPort()
       : Port(),
         recv_skip_cnt_(),
+        accept_thread_stopped_fd_(kNotConnectedFd),
+        accept_thread_stop_fd_(kNotConnectedFd),
         listen_fd_(kNotConnectedFd),
         addr_(),
         epoll_fd_(kNotConnectedFd),
@@ -107,11 +109,6 @@ class UnixSocketPort final : public Port {
    */
   int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
-  /*!
-   * Waits for a client to connect to the socket.
-   */
-  void AcceptNewClient();
-
  private:
   // Value for a disconnected socket.
   static const int kNotConnectedFd = -1;
@@ -122,6 +119,21 @@ class UnixSocketPort final : public Port {
   * since we last called recv().
   * */
   uint32_t recv_skip_cnt_;
+
+  /*!
+   * Thread accepting and monitoring clients.
+   */
+  std::thread accept_thread_;
+
+  /*!
+   * FD to read stop signal in accept thread.
+   */
+  int accept_thread_stopped_fd_;
+
+  /*!
+   * FD to signal accept thread to stop.
+   */
+  int accept_thread_stop_fd_;
 
   /*!
    * The listener fd -- listen for new connections here.

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -31,18 +31,12 @@
 #ifndef BESS_DRIVERS_UNIXSOCKET_H_
 #define BESS_DRIVERS_UNIXSOCKET_H_
 
-#include <assert.h>
-#include <atomic>
-#include <errno.h>
-#include <poll.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <thread>
 #include <unistd.h>
 
-#include <glog/logging.h>
+#include <atomic>
+#include <thread>
 
 #include "../message.h"
 #include "../port.h"

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -59,7 +59,6 @@ class UnixSocketPort final : public Port {
         accept_thread_stop_req_(false),
         listen_fd_(kNotConnectedFd),
         addr_(),
-        epoll_fd_(kNotConnectedFd),
         client_fd_(kNotConnectedFd) {}
 
   /*!
@@ -144,11 +143,6 @@ class UnixSocketPort final : public Port {
    * My socket address on the listener fd.
    */
   struct sockaddr_un addr_;
-
-  /*!
-   * The epoll fd -- detect when client closes.
-   */
-  int epoll_fd_;
 
   // NOTE: three threads (accept / recv / send) may race on this, so use
   // volatile.


### PR DESCRIPTION
In order to allow external controllers (connected through a UNIX socket) truly
independent of bessd, client disconnection must always be detected, regardless
of whether the port is used or not. This is done by keeping a thread
around (using epoll).

Before, this driver would only reliably detect disconnects when the port is used
to receive packets. When used to send packets, the port would only detect
disconnects on an actual send, which depends on the processed packets; this led
to only some instances accepting new clients, making external program
reconnection impossible.