### PR TITLE
module tests: pause workers after custom tests

### DIFF
--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -169,7 +169,6 @@ def run_tests():
 
         print("-- Running Module Tests for %s --" % filename.split("/")[-1])
 
-       # Wrap in a function to make sure scope doesn't leak.
         CRASH_TEST_INPUTS, OUTPUT_TEST_INPUTS, CUSTOM_TEST_FUNCTIONS = load_test(
             filename)
 
@@ -260,7 +259,12 @@ def run_tests():
                 print("\n")
                 traceback.print_exc()
                 print("\n")
-        # All done!
+        # Pause any running workers left over by sloppy or failed
+        # custom test.  Next trip through outer loop will fail reset
+        # otherwise.
+        if len(CUSTOM_TEST_FUNCTIONS):
+            bess.pause_all()
+        # All done with this module, on to the next!
 
     bess.pause_all()
     bess.reset_all()


### PR DESCRIPTION
When we run custom tests, the custom-test loop reads:

    for each test:
        pause workers
        reset pipeline
        run test

so that each one starts with a fresh context.  But custom
tests, especially if they fail, may leave workers running.

Meanwhile the main loop expects not to need to pause, it just
does a pipeline reset:

    for each module:
        reset pipeline
        (run all the module tests)

To keep the number of rpc's down do one extra "pause" after
all custom tests if and only if there are any custom tests.
It would be simpler to do a pause at the top of the "for each
module" loop, though...

(While here, trim out unrelated now-irrelevant comment about
scope, fixed in c524bc8f85a9fa32d49654d59e2f223498731a2b.)