### PR TITLE
modules: Thread safety checker fixes.

### DIFF
--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -41,7 +41,10 @@ class PortInc final : public Module {
 
   static const Commands cmds;
 
-  PortInc() : Module(), port_(), prefetch_(), burst_() { is_task_ = true; }
+  PortInc() : Module(), port_(), prefetch_(), burst_() {
+    is_task_ = true;
+    max_allowed_workers_ = Worker::kMaxWorkers;
+  }
 
   CommandResponse Init(const bess::pb::PortIncArg &arg);
 

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -50,6 +50,7 @@ class Queue final : public Module {
         low_water_() {
     is_task_ = true;
     propagate_workers_ = false;
+    max_allowed_workers_ = Worker::kMaxWorkers;
   }
 
   CommandResponse Init(const bess::pb::QueueArg &arg);

--- a/core/modules/vlan_split.h
+++ b/core/modules/vlan_split.h
@@ -35,6 +35,10 @@
 
 class VLANSplit final : public Module {
  public:
+  VLANSplit() : Module() {
+    max_allowed_workers_ = Worker::kMaxWorkers;
+  }
+
   static const gate_idx_t kNumOGates = 4096;
 
   void ProcessBatch(bess::PacketBatch *batch) override;


### PR DESCRIPTION
VLANSplit is stateless and can be run from multiple threads.

Queue contains a multiproducer ring.  It is single consumer, but since
the module registers only one task that shouldn't be a problem.

PortInc supports more than one task, and that needs to be taken into
account.