### PR TITLE
Make path for module tests configurable

### DIFF
--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -38,9 +38,6 @@ import sugar
 import traceback
 from time import gmtime, strftime
 
-# Env variable used to run a single test
-test_name = $TEST_NAME!'*'
-
 ## HANDY UTILS AND GLOBAL VARS ##
 SOCKET_PATH = '/tmp/bess_unix_'
 SCRIPT_STARTTIME = strftime("%Y-%m-%d-%H-%M-%S", gmtime())
@@ -156,15 +153,19 @@ def monitor_task(module, wid):
 def run_tests():
     DID_TESTS_FAIL = False
 
-    path = os.path.dirname(os.path.realpath(sys.argv[0]))
+    # Env variable used to run a subset of tests
+    test_name = $TEST_NAME!'*'
+
+    default_path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])),
+                                'conf/testing/module_tests')
+    test_path = $TEST_PATH!default_path
 
     # Note: os.path.join will discard the leading parts if test
     # begins with '/', so callers should provide an absolute path
+
     # if and only if they want to override the internal BESS
     # path prefixing.
-    for filename in glob.glob(os.path.join(path,
-                                           "conf/testing/module_tests",
-                                           test_name + ".py")):
+    for filename in glob.glob(os.path.join(test_path, test_name + ".py")):
         bess.reset_all()
 
         print("-- Running Module Tests for %s --" % filename.split("/")[-1])


### PR DESCRIPTION
This commit introduces a new env variable `TEST_PATH`, to specify custom module test directory other than `conf/testing/module_tests`.