### PR TITLE
Fix RoundRobin crash with zero output gate

### DIFF
--- a/core/modules/round_robin.cc
+++ b/core/modules/round_robin.cc
@@ -101,15 +101,24 @@ CommandResponse RoundRobin::CommandSetGates(
 void RoundRobin::ProcessBatch(bess::PacketBatch *batch) {
   gate_idx_t out_gates[bess::PacketBatch::kMaxBurst];
 
+  if (ngates_ <= 0) {
+    bess::Packet::Free(batch);
+    return;
+  }
+
   if (per_packet_) {
     for (int i = 0; i < batch->cnt(); i++) {
       out_gates[i] = gates_[current_gate_];
-      current_gate_ = (current_gate_ + 1) % ngates_;
+      if (++current_gate_ >= ngates_) {
+        current_gate_ = 0;
+      }
     }
     RunSplit(out_gates, batch);
   } else {
     gate_idx_t gate = gates_[current_gate_];
-    current_gate_ = (current_gate_ + 1) % ngates_;
+    if (++current_gate_ >= ngates_) {
+      current_gate_ = 0;
+    }
     RunChooseModule(gate, batch);
   }
 }


### PR DESCRIPTION
If RoundRobin module has no output gate, it crashes due to division by zero. In this case, the "right" behavior should be just dropping packets.

Also, this commit replaces the modulo(%) operation with a simple `if` branch. It saves about 22 cycles per batch or packet, depending on the operation mode of RoundRobin.