### PR TITLE
Print out BESS envvar warnings to stderr

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -94,8 +94,8 @@ def __bess_env__(key, default=None):
         if default is None:
             raise ConfError('Environment variable "%s" must be set.')
 
-        print('Environment variable "%s" is not set. \
-              Using default value "%s"' % (key, default))
+        print('Environment variable "%s" is not set. '
+              'Using default value "%s"' % (key, default), file=sys.stderr)
         return default
 
 


### PR DESCRIPTION
`Environment variable XXX is not set. Using default value YYY` better be sent to stderr, so that external scripts can read stdout for "real" output.