### PR TITLE
travis: Use grpcio 1.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ install:
   # want to avoid the "ln -s /build/dpdk-17.05 deps" step below
   - sudo apt-get install -y python2.7 python3 python3-pip ruby-dev
   - sudo gem install ffi fpm
-  - pip2 install grpcio scapy codecov
-  - pip3 install grpcio scapy-python3 coverage
+  - pip2 install -r env/requirements2.txt
+  - pip3 install -r env/requirements3.txt
   - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y g++-5"  # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are new to BESS, we recommend you start here:
 To install BESS on Linux quickly, you can download the binary from [Release](https://github.com/NetSys/bess/releases/latest). Please refer to [GCC x86 Options](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html) to determine which tarball to use. Suppose `bess-core2-linux.tar.gz` is downloaded:
 
     sudo apt-get install -y python python-pip python-scapy libgraph-easy-perl
-    pip install grpcio
+    pip install grpcio<=1.4.0
     sudo sysctl vm.nr_hugepages=1024  # For single NUMA node systems
     tar -xf bess-core2-linux.tar.gz
     cd bess/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are new to BESS, we recommend you start here:
 To install BESS on Linux quickly, you can download the binary from [Release](https://github.com/NetSys/bess/releases/latest). Please refer to [GCC x86 Options](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html) to determine which tarball to use. Suppose `bess-core2-linux.tar.gz` is downloaded:
 
     sudo apt-get install -y python python-pip python-scapy libgraph-easy-perl
-    pip install grpcio<=1.4.0
+    pip install 'grpcio<=1.4.0'
     sudo sysctl vm.nr_hugepages=1024  # For single NUMA node systems
     tar -xf bess-core2-linux.tar.gz
     cd bess/

--- a/env/requirements2.txt
+++ b/env/requirements2.txt
@@ -1,0 +1,3 @@
+grpcio<=1.4.0
+scapy
+codecov

--- a/env/requirements3.txt
+++ b/env/requirements3.txt
@@ -1,0 +1,3 @@
+grpcio<=1.4.0
+scapy-python3
+coverage


### PR DESCRIPTION
grpcio 1.6.0 (released yesterday) creates problems to the BESS testsuite.
Until we figure out how to make it work, use grpcio 1.4.0.  This fixes a
travis failure observed on master.