### PR TITLE
Allow module inheritance across shared objects

### DIFF
--- a/core/bessd.h
+++ b/core/bessd.h
@@ -40,6 +40,11 @@
 namespace bess {
 namespace bessd {
 
+// When Modules extend other Modules, they may reference a shared object
+// that has not yet been loaded by the BESS daemon. kInheritanceLimit is
+// the number of passes that will be made while loading Module shared objects,
+// and thus the maximum inheritance depth of any Module.
+const int kInheritanceLimit = 10;
 // Process command line arguments from gflags.
 void ProcessCommandLineArgs();
 


### PR DESCRIPTION
Previously, modules could not access (and therefore inherit from)
other modules because the RTLD_GLOBAL flag was not set. This patch
allows inheritance by dlopening module shared objects with the
RTLD_GLOBAL flag and by loading modules in multiple passes.

Nearly all of the work in this patch was done by
Steven Wang <@sirspinach> and Vivian Fang <@vivi>