### PR TITLE
Kill container by name, but not by python subprocessor

### DIFF
--- a/bessctl/conf/port/vhost/launch_container.py
+++ b/bessctl/conf/port/vhost/launch_container.py
@@ -130,9 +130,9 @@ def main(argv):
             time.sleep(100)
     except KeyboardInterrupt:
         pass
-
-    for cid in range(num_containers):
-        kill(cid)
+    finally:
+        for cid in range(num_containers):
+            kill(cid)
 
     return 0
 


### PR DESCRIPTION
Container daemons are not children of `docker run`, but children of docker daemon. Therefore, killing `docker run` does not always guarantee killing container daemons