### PR TITLE
ignore autogen files in pybess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ doxygen/latex/
 
 # Auto-genereated by make
 core/version.h
-pybess/
+pybess/*_pb2*
 
 # Code coverage files
 core/*.gcda

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ doxygen/latex/
 
 # Auto-genereated by make
 core/version.h
+pybess/
 
 # Code coverage files
 core/*.gcda


### PR DESCRIPTION
noted to ignore only pb2 autogen files