### PR TITLE
Implement a simple bessctl command to capture packet data and metadata

### DIFF
--- a/core/hooks/pcapng.cc
+++ b/core/hooks/pcapng.cc
@@ -34,6 +34,8 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include <limits>
+
 #include <glog/logging.h>
 
 #include "../message.h"
@@ -58,12 +60,37 @@ T PadSize(T a, T b) {
   return RoundUp(a, b) - a;
 }
 
+// Return the single hex digit representing `nibble`.  If it cannot be
+// represented, return the char 'X'.
+char NibbleToHD(char nibble) {
+  if (nibble >= 0 && nibble <= 9) {
+    return nibble + '0';
+  } else if (nibble >= 10 && nibble <= 15) {
+    return nibble - 10 + 'A';
+  } else {
+    return 'X';
+  }
+}
+
+// Represent the buffer `src` (long `len` bytes) as an hex string.  Put
+// the result into `dst` (which must be at least `len * 2` bytes long).
+void BytesToHexDump(const void *src, size_t len, char *dst) {
+  for (size_t i = 0; i < len; i++) {
+    char byte = static_cast<const char *>(src)[i];
+    dst[i * 2] = NibbleToHD((byte >> 4) & 0xF);
+    dst[i * 2 + 1] = NibbleToHD(byte & 0xF);
+  }
+}
+
 }  // namespace
 
 const std::string Pcapng::kName = "pcapng";
 
 Pcapng::Pcapng()
-    : bess::GateHook(Pcapng::kName, Pcapng::kPriority), fifo_fd_(-1) {}
+    : bess::GateHook(Pcapng::kName, Pcapng::kPriority),
+      fifo_fd_(-1),
+      attrs_(),
+      attr_template_() {}
 
 Pcapng::~Pcapng() {
   if (fifo_fd_ >= 0) {
@@ -71,9 +98,40 @@ Pcapng::~Pcapng() {
   }
 }
 
-CommandResponse Pcapng::Init(const bess::Gate *,
+CommandResponse Pcapng::Init(const bess::Gate *gate,
                              const bess::pb::PcapngArg &arg) {
+  Module *m = gate->module();
+  std::string tmpl;
   int ret;
+
+  size_t i = 0;
+  for (const auto &it : m->all_attrs()) {
+    tmpl += it.name + " = ";
+
+    size_t tmpl_offset = tmpl.size();
+
+    tmpl += std::string(it.size * 2, 'X') + " ";
+
+    if (tmpl.size() > std::numeric_limits<uint16_t>::max()) {
+      // Doesn't fit in the option string.
+      break;
+    }
+
+    attrs_.emplace_back(Attr{.md_offset = m->attr_offset(i),
+                             .size = it.size,
+                             .tmpl_offset = tmpl_offset});
+    i++;
+  }
+
+  if (!tmpl.empty() && tmpl.back() == ' ') {
+    tmpl.pop_back();
+  }
+
+  if (tmpl.size() > std::numeric_limits<uint16_t>::max()) {
+    tmpl.resize(std::numeric_limits<uint16_t>::max());
+  }
+
+  attr_template_ = std::vector<char>(tmpl.begin(), tmpl.end());
 
   fifo_fd_ = open(arg.fifo().c_str(), O_WRONLY | O_NONBLOCK);
   if (fifo_fd_ < 0) {
@@ -129,14 +187,35 @@ void Pcapng::ProcessBatch(const bess::PacketBatch *batch) {
   gettimeofday(&tv, nullptr);
 
   uint64_t ts = tv.tv_sec * 1000000 + tv.tv_usec;
+  uint16_t comment_size = static_cast<uint16_t>(attr_template_.size());
 
   for (int i = 0; i < batch->cnt(); i++) {
     bess::Packet *pkt = batch->pkts()[i];
 
+    Option opt_comment = {
+        .code = Option::kComment, .len = comment_size,
+    };
+
+    for (const Attr &attr : attrs_) {
+      const char *attr_data = ptr_attr_with_offset<char>(attr.md_offset, pkt);
+      if (attr_data != nullptr) {
+        BytesToHexDump(attr_data, attr.size, &attr_template_[attr.tmpl_offset]);
+      } else {
+        auto string_it = attr_template_.begin() + attr.tmpl_offset;
+        std::fill(string_it, string_it + attr.size * 2, 'X');
+      }
+    }
+
+    Option opt_end = {
+        .code = Option::kEndOfOpts, .len = 0,
+    };
+
     EnhancedPacketBlock epb = {
         .type = EnhancedPacketBlock::kType,
-        .tot_len = static_cast<uint32_t>(sizeof(epb) + sizeof(uint32_t) +
-                                         RoundUp(pkt->head_len(), 4)),
+        .tot_len = static_cast<uint32_t>(
+            sizeof(epb) + sizeof(uint32_t) +
+            RoundUp<uint32_t>(pkt->head_len(), 4) + sizeof(opt_comment) +
+            RoundUp<uint32_t>(comment_size, 4) + sizeof(opt_end)),
         .interface_id = 0,
         .timestamp_high = static_cast<uint32_t>(ts >> 32),
         .timestamp_low = static_cast<uint32_t>(ts),
@@ -144,17 +223,23 @@ void Pcapng::ProcessBatch(const bess::PacketBatch *batch) {
         .orig_len = static_cast<uint32_t>(pkt->total_len()),
     };
 
-    uint32_t pkt_data_padding = 0;
+    uint32_t padding = 0;
 
     uint32_t epb_tot_len = epb.tot_len;
 
-    struct iovec vec[4] = {
+    struct iovec vec[8] = {
         {&epb, sizeof(epb)},
         {pkt->head_data(), static_cast<size_t>(pkt->head_len())},
-        {&pkt_data_padding, static_cast<size_t>(PadSize(pkt->head_len(), 4))},
+        {&padding, static_cast<size_t>(PadSize(pkt->head_len(), 4))},
+
+        {&opt_comment, sizeof(opt_comment)},
+        {attr_template_.data(), comment_size},
+        {&padding, static_cast<size_t>(PadSize<uint32_t>(comment_size, 4))},
+        {&opt_end, sizeof(opt_end)},
+
         {&epb_tot_len, sizeof(epb_tot_len)}};
 
-    ret = writev(fifo_fd_, vec, 4);
+    ret = writev(fifo_fd_, vec, 8);
     if (ret < 0) {
       if (errno == EPIPE) {
         DLOG(WARNING) << "Broken pipe: stopping pcapng";

--- a/core/hooks/pcapng.cc
+++ b/core/hooks/pcapng.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "pcapng.h"
+
+#include <fcntl.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <glog/logging.h>
+
+#include "../message.h"
+#include "../utils/common.h"
+#include "../utils/pcapng.h"
+#include "../utils/time.h"
+
+using namespace bess::utils::pcapng;
+
+namespace {
+
+// Return `a` rounded up to the nearest multiple of `b`
+template <typename T>
+T RoundUp(T a, T b) {
+  return ((a + (b - 1)) / b) * b;
+}
+
+// Return the number of bytes of padding to align a buffer long `a` to
+// `b` units.
+template <typename T>
+T PadSize(T a, T b) {
+  return RoundUp(a, b) - a;
+}
+
+}  // namespace
+
+const std::string Pcapng::kName = "pcapng";
+
+Pcapng::Pcapng()
+    : bess::GateHook(Pcapng::kName, Pcapng::kPriority), fifo_fd_(-1) {}
+
+Pcapng::~Pcapng() {
+  if (fifo_fd_ >= 0) {
+    close(fifo_fd_);
+  }
+}
+
+CommandResponse Pcapng::Init(const bess::Gate *,
+                             const bess::pb::PcapngArg &arg) {
+  int ret;
+
+  fifo_fd_ = open(arg.fifo().c_str(), O_WRONLY | O_NONBLOCK);
+  if (fifo_fd_ < 0) {
+    return CommandFailure(-errno, "Failed to open FIFO");
+  }
+
+  ret = fcntl(fifo_fd_, F_SETFL, fcntl(fifo_fd_, F_GETFL) | O_NONBLOCK);
+  if (ret < 0) {
+    close(fifo_fd_);
+    return CommandFailure(-errno, "fnctl() on FIFO failed");
+  }
+
+  SectionHeaderBlock shb = {
+      .type = SectionHeaderBlock::kType,
+      .tot_len = sizeof(shb) + sizeof(uint32_t),
+      .bom = SectionHeaderBlock::kBom,
+      .maj_ver = SectionHeaderBlock::kMajVer,
+      .min_ver = SectionHeaderBlock::kMinVer,
+      .sec_len = -1,
+  };
+
+  uint32_t shb_tot_len = shb.tot_len;
+
+  InterfaceDescriptionBlock idb = {
+      .type = InterfaceDescriptionBlock::kType,
+      .tot_len = sizeof(idb) + sizeof(uint32_t),
+      .link_type = InterfaceDescriptionBlock::kEthernet,
+      .reserved = 0,
+      .snap_len = 1518,
+  };
+
+  uint32_t idb_tot_len = idb.tot_len;
+
+  struct iovec vec[4] = {{&shb, sizeof(shb)},
+                         {&shb_tot_len, sizeof(shb_tot_len)},
+                         {&idb, sizeof(idb)},
+                         {&idb_tot_len, sizeof(idb_tot_len)}};
+
+  ret = writev(fifo_fd_, vec, 4);
+  if (ret < 0) {
+    close(fifo_fd_);
+    return CommandFailure(-errno, "Failed to write PCAP header");
+  }
+
+  return CommandSuccess();
+}
+
+void Pcapng::ProcessBatch(const bess::PacketBatch *batch) {
+  struct timeval tv;
+
+  int ret = 0;
+
+  gettimeofday(&tv, nullptr);
+
+  uint64_t ts = tv.tv_sec * 1000000 + tv.tv_usec;
+
+  for (int i = 0; i < batch->cnt(); i++) {
+    bess::Packet *pkt = batch->pkts()[i];
+
+    EnhancedPacketBlock epb = {
+        .type = EnhancedPacketBlock::kType,
+        .tot_len = static_cast<uint32_t>(sizeof(epb) + sizeof(uint32_t) +
+                                         RoundUp(pkt->head_len(), 4)),
+        .interface_id = 0,
+        .timestamp_high = static_cast<uint32_t>(ts >> 32),
+        .timestamp_low = static_cast<uint32_t>(ts),
+        .captured_len = static_cast<uint32_t>(pkt->head_len()),
+        .orig_len = static_cast<uint32_t>(pkt->total_len()),
+    };
+
+    uint32_t pkt_data_padding = 0;
+
+    uint32_t epb_tot_len = epb.tot_len;
+
+    struct iovec vec[4] = {
+        {&epb, sizeof(epb)},
+        {pkt->head_data(), static_cast<size_t>(pkt->head_len())},
+        {&pkt_data_padding, static_cast<size_t>(PadSize(pkt->head_len(), 4))},
+        {&epb_tot_len, sizeof(epb_tot_len)}};
+
+    ret = writev(fifo_fd_, vec, 4);
+    if (ret < 0) {
+      if (errno == EPIPE) {
+        DLOG(WARNING) << "Broken pipe: stopping pcapng";
+        close(fifo_fd_);
+        fifo_fd_ = -1;
+      }
+      return;
+    }
+  }
+}
+
+ADD_GATE_HOOK(Pcapng)

--- a/core/hooks/pcapng.h
+++ b/core/hooks/pcapng.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_HOOKS_PCAPNG_
+#define BESS_HOOKS_PCAPNG_
+
+#include "../message.h"
+#include "../module.h"
+
+// Pcapng dumps copies of the packets seen by a gate in pcapng format.
+// Useful for debugging.
+class Pcapng final : public bess::GateHook {
+ public:
+  Pcapng();
+
+  ~Pcapng();
+
+  CommandResponse Init(const bess::Gate *, const bess::pb::PcapngArg &);
+
+  void ProcessBatch(const bess::PacketBatch *batch);
+
+  static constexpr uint16_t kPriority = 2;
+  static const std::string kName;
+
+ private:
+  int fifo_fd_;
+};
+
+#endif  // BESS_HOOKS_PCAPNG_

--- a/core/hooks/pcapng.h
+++ b/core/hooks/pcapng.h
@@ -40,7 +40,7 @@ class Pcapng final : public bess::GateHook {
  public:
   Pcapng();
 
-  ~Pcapng();
+  virtual ~Pcapng();
 
   CommandResponse Init(const bess::Gate *, const bess::pb::PcapngArg &);
 

--- a/core/hooks/pcapng.h
+++ b/core/hooks/pcapng.h
@@ -34,8 +34,8 @@
 #include "../message.h"
 #include "../module.h"
 
-// Pcapng dumps copies of the packets seen by a gate in pcapng format.
-// Useful for debugging.
+// Pcapng dumps copies of the packets seen by a gate (data + metadata) in
+// pcapng format.  Useful for debugging.
 class Pcapng final : public bess::GateHook {
  public:
   Pcapng();
@@ -50,7 +50,23 @@ class Pcapng final : public bess::GateHook {
   static const std::string kName;
 
  private:
+  struct Attr {
+    // Attribute offset in the packet metadata.
+    int md_offset;
+    // Size in bytes of the attribute.
+    size_t size;
+    // Offset where this attribute hex dump should go inside `attr_template_`.
+    size_t tmpl_offset;
+  };
+
+  // The file descripton where to output the pcapng stream.
   int fifo_fd_;
+  // List of attributes to dump.
+  std::vector<Attr> attrs_;
+  // Preallocated string with attribute names and values.  For each packet,
+  // we will change in place the values and send the string out, without
+  // doing any memory allocation.
+  std::vector<char> attr_template_;
 };
 
 #endif  // BESS_HOOKS_PCAPNG_

--- a/core/hooks/tcpdump.h
+++ b/core/hooks/tcpdump.h
@@ -39,7 +39,7 @@ class Tcpdump final : public bess::GateHook {
  public:
   Tcpdump();
 
-  ~Tcpdump();
+  virtual ~Tcpdump();
 
   CommandResponse Init(const bess::Gate *, const bess::pb::TcpdumpArg &);
 

--- a/core/utils/pcapng.h
+++ b/core/utils/pcapng.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_UTILS_PCAPNG_H_
+#define BESS_UTILS_PCAPNG_H_
+
+namespace bess {
+namespace utils {
+namespace pcapng {
+
+// This code is based on the specification from
+// https://pcapng.github.io/pcapng/
+
+// A pcapng file is simply one or more sections concatenated. Each section is
+// composed by blocks. Each block is a TLV structure with the length repeated
+// at the at the beginning and at the end, so that unknown block can be skipped
+// and the file can be traversed backwards. The block length includes the
+// header.
+
+// Must be placed at the beginning of each section.  Since a pcapng file
+// starts directly with a section, it also serves the purpose of identifying
+// the file type for tools like `file`.
+struct SectionHeaderBlock {
+  uint32_t type;     // kType
+  uint32_t tot_len;  // Block Total Length (hdr + opts + repeated tot_len)
+  uint32_t bom;      // kBom
+  uint16_t maj_ver;  // kMajVer
+  uint16_t min_ver;  // kMinVer
+  int64_t sec_len;   // Section Length or -1
+  // Options...
+  // uint32_t tot_len     // Repeated
+
+  static constexpr uint32_t kType = 0x0A0D0D0A;
+  static constexpr uint32_t kBom = 0x1A2B3C4D;
+  static constexpr uint32_t kMajVer = 1;
+  static constexpr uint32_t kMinVer = 0;
+};
+
+// Before including any packet block, a section must incluse at least one
+// of these to provide information about the interfaces.
+struct InterfaceDescriptionBlock {
+  uint32_t type;       // kType
+  uint32_t tot_len;    // Block Total Length (hdr + opts + repeated tot_len)
+  uint16_t link_type;  // One of LinkType
+  uint16_t reserved;   // 0/Ignored
+  uint32_t snap_len;   // Maximum number of bytes captured on a packet
+  // Options...
+  // uint32_t tot_len     // Repeated
+
+  enum LinkType {
+    kEthernet = 1,
+  };
+
+  static constexpr uint32_t kType = 0x00000001;
+};
+
+// Stores a packet.
+struct EnhancedPacketBlock {
+  uint32_t type;            // kType
+  uint32_t tot_len;         // Block Total Length (hdr + pkt data +
+                            //                     opts + repeated tot_len)
+  uint32_t interface_id;    // Index of the InterfaceDescriptionBlock
+  uint32_t timestamp_high;  // Most significant 32-bit of the 64-bit timestamp
+  uint32_t timestamp_low;   // Least significant 32-bit of the 64-bit timestamp
+  uint32_t captured_len;    // Length of the packet data in this block
+  uint32_t orig_len;        // Original length of the packet on the wire
+  // Packet data (padded to 32-bit)
+  // Options...
+  // uint32_t tot_len     // Repeated
+
+  static constexpr uint32_t kType = 0x00000006;
+};
+
+// Most block types can be extended with options. Options are TLV structures.
+// Unlike block header, the option doesn't repeat the length, and the length
+// length doesn't account for the header itself.
+struct Option {
+  uint16_t code;  // One of Code
+  uint16_t len;   // Length of the value (not including the header)
+  // Option value (padded to 32-bit)
+
+  enum Code {
+    kEndOfOpts = 0,  // Must always be the last option.  len=0
+    kComment = 1,    // UTF-8 string.  Not zero terminated.
+  };
+};
+
+}  // namespace pcapng
+}  // namespace utils
+}  // namespace bess
+
+#endif  // BESS_UTILS_PCAPNG_H_

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -466,7 +466,7 @@ message TrackArg {
 /// Once the tap is installed, all packets going through the gate will be
 /// captured and sent in PCAP format to the specified named pipe (FIFO).
 /// Thus you can run `tcpdump -r <path to FIFO>` or save the stream in a file.
-/// This feature may afffect performance.
+/// This feature may affect performance.
 ///
 /// NOTE: There should be no running worker to run this command.
 message TcpdumpArg {
@@ -480,7 +480,7 @@ message TcpdumpArg {
 /// Unlike the Tcpdump hook, this also dumps a textual metadata representation,
 /// in the form of a comment to the Enhanced Packet Block. Thus you can run
 /// `tcpdump -r <path to FIFO>` or save the stream in a file.
-/// This feature may afffect performance.
+/// This feature may affect performance.
 ///
 /// NOTE: There should be no running worker to run this command.
 message PcapngArg {

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -477,7 +477,9 @@ message TcpdumpArg {
 ///
 /// Once the tap is installed, all packets going through the gate will be
 /// captured and sent in pcapng format to the specified named pipe (FIFO).
-/// Thus you can run `tcpdump -r <path to FIFO>` or save the stream in a file.
+/// Unlike the Tcpdump hook, this also dumps a textual metadata representation,
+/// in the form of a comment to the Enhanced Packet Block. Thus you can run
+/// `tcpdump -r <path to FIFO>` or save the stream in a file.
 /// This feature may afffect performance.
 ///
 /// NOTE: There should be no running worker to run this command.

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -473,6 +473,18 @@ message TcpdumpArg {
   string fifo = 5;    /// Path to the FIFO file.
 }
 
+/// Enable/Disable pcapng tapping at an input/output gate.
+///
+/// Once the tap is installed, all packets going through the gate will be
+/// captured and sent in pcapng format to the specified named pipe (FIFO).
+/// Thus you can run `tcpdump -r <path to FIFO>` or save the stream in a file.
+/// This feature may afffect performance.
+///
+/// NOTE: There should be no running worker to run this command.
+message PcapngArg {
+  string fifo = 5;    /// Path to the FIFO file.
+}
+
 message ConfigureGateHookRequest {
   string hook_name = 1;         /// Name of the hook
   string module_name = 2;       /// Name of module

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -508,6 +508,13 @@ class BESS(object):
         return self._configure_gate_hook('track', m, arg, enable, direction,
                                          gate)
 
+    def pcapng(self, enable, m, direction='out', gate=0, fifo=None):
+        arg = bess_msg.PcapngArg()
+        if fifo is not None:
+            arg.fifo = fifo
+        return self._configure_gate_hook('pcapng', m, arg, enable, direction,
+                                         gate)
+
     def list_workers(self):
         return self._request('ListWorkers')
 


### PR DESCRIPTION
The new `tcpdump_md` command is similar to `tcpdump`, but:
* It displays a textual representation of the metadata
* It doesn't call external programs, because they don't support showing additional metadata for each packet.
* It doesn't display a human readable representation of the packet data, just a hexdump, since it doesn't rely on external tools.

To implement this new command, a new hook is implemented (`pcapng`), which is similar to the `tcpdump` hook, but
* Uses the pcapng format, which includes optional metadata.
* Adds a textual representation of the metadata info.
Hopefully this hook can be useful beyond the tcpdump_md command.  It has been tested with wireshark and it produces a textual representation of the metadata.