### PR TITLE
Add a new primitive "shared object" to bess core

### DIFF
--- a/core/shared_obj.cc
+++ b/core/shared_obj.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "shared_obj.h"
+
+namespace bess {
+
+SharedObjectSpace shared_objects;
+
+}  // namespace bess

--- a/core/shared_obj.h
+++ b/core/shared_obj.h
@@ -1,0 +1,133 @@
+// Copyright (c) 2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_SHARED_OBJ_H_
+#define BESS_SHARED_OBJ_H_
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+
+#include "utils/common.h"  // for PairHasher functor
+
+namespace bess {
+
+// SharedObjectSpace provides a simple mechanism for independent modules to
+// share arbitrary objects. There is a global "shared_objects" instance in the
+// "bess" namespace (see shared_obj.cc). Modules (or port drivers) can use the
+// global instance to create and access shared objects by name. Shared objects
+// are instances of an arbitrary class T, referenced by a shared_ptr<T>. Just
+// like any other shared_ptr objects, shared objects are automatically
+// destructed once all references to the object have gone.
+//
+// Usage:
+// shared_ptr<TypeFoo> bess::shared_objects::Get<TypeFoo>("foo_name");
+//
+// If there is no object named "foo_name", a new instance of TypeFoo is created
+// (of course with its constructor). The module is expected to keep the
+// shared_ptr to the object until it is no longer needed.
+//
+// Type safety: The type of an object must be identical for all users of the
+// object. To prevent type errors, this class provides a separate namespace
+// for each object type. For example, if another module requests an object
+// also named "foo_name" but with a different type other than TypeFoo, a
+// different object will be returned.
+//
+// Thread safety: Get() and Lookup() functions are thread safe as they are
+// protected by a mutex. However, shared objects themselves are not protected
+// by default; you should use any synchronization mechanism for objects as
+// necessary.
+class SharedObjectSpace {
+ public:
+  // By default, the Get() method creates a new object with its default
+  // constructor (a constructor without any arguments). To change this behavior,
+  // you can use the optional argument "constructor", a callable object
+  // (function pointer, functor, lambda function, etc.) that creates the object
+  // in a way you'd like, e.g., to create an object with a non-default
+  // constructor, or to reuse an already existing object.
+  template <typename T>
+  std::shared_ptr<T> Get(
+      const std::string &name,
+      std::function<std::shared_ptr<T>()> constructor = DefaultConstructor<T>) {
+    SharedObjectKey key = std::make_pair(std::type_index(typeid(T)), name);
+
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+
+    auto it = obj_map_.find(key);
+    if (it != obj_map_.end()) {
+      // Found, but check if the weak pointer has become stale.
+      if (auto ret = it->second.lock()) {
+        // Fresh. Convert from shared_ptr<void> to shared_ptr<T> and return
+        return std::static_pointer_cast<T>(ret);
+      }
+    }
+
+    // "constructor" returns an empty shared_ptr if object allocation
+    // failed or no object should be newly made.
+    std::shared_ptr<T> new_object = constructor();
+    if (new_object) {
+      obj_map_[key] = std::weak_ptr<T>(new_object);
+    }
+
+    return new_object;
+  }
+
+  // If no object with the specified type&name is found, this method does not
+  // create a new one.
+  template <typename T>
+  std::shared_ptr<T> Lookup(const std::string &name) {
+    return Get<T>(name, LookupOnly<T>);
+  }
+
+  template <typename T>
+  static std::shared_ptr<T> DefaultConstructor() {
+    return std::shared_ptr<T>(new T());
+  }
+
+  template <typename T>
+  static std::shared_ptr<T> LookupOnly() {
+    return std::shared_ptr<T>();
+  }
+
+ private:
+  using SharedObjectKey = std::pair<std::type_index, std::string>;
+
+  std::unordered_map<SharedObjectKey, std::weak_ptr<void>, PairHasher> obj_map_;
+};
+
+extern SharedObjectSpace shared_objects;
+
+}  // namespace bess
+
+#endif  // BESS_SHARED_OBJ_H_

--- a/core/shared_obj_test.cc
+++ b/core/shared_obj_test.cc
@@ -1,0 +1,155 @@
+// Copyright (c) 2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "shared_obj.h"
+
+#include <gtest/gtest.h>
+
+namespace bess {
+
+int num_constructed;
+int num_destructed;
+
+class Test : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    num_constructed = 0;
+    num_destructed = 0;
+  }
+  virtual void TearDown() { ASSERT_EQ(num_constructed, num_destructed); }
+};
+
+class FooType final {
+ public:
+  FooType() : a_(1) { num_constructed++; }
+  FooType(int x, int y) : a_(x + y) { num_constructed++; }
+  virtual ~FooType() { num_destructed++; }
+  int a_;
+};
+
+class BarType final {
+ public:
+  BarType() : b_(2) { num_constructed++; }
+  virtual ~BarType() { num_destructed++; }
+  int b_;
+};
+
+TEST_F(Test, Basic) {
+  std::shared_ptr<FooType> ref_a = shared_objects.Get<FooType>("foo");
+  ASSERT_EQ(num_constructed, 1);
+
+  std::shared_ptr<FooType> ref_b = shared_objects.Get<FooType>("foo");
+  ASSERT_EQ(num_constructed, 1);
+  ASSERT_EQ(ref_a, ref_b);
+  ASSERT_EQ(num_destructed, 0);
+
+  ref_a.reset();
+  ASSERT_EQ(num_constructed, 1);
+  ASSERT_EQ(num_destructed, 0);  // ref_b is still holding a reference
+  ASSERT_NE(ref_a, ref_b);
+
+  ref_b.reset();
+  ASSERT_EQ(num_destructed, 1);
+  ASSERT_EQ(ref_a, ref_b);
+}
+
+TEST_F(Test, MultipleObjects) {
+  std::shared_ptr<FooType> ref_a = shared_objects.Get<FooType>("foo1");
+  ASSERT_EQ(num_constructed, 1);
+
+  std::shared_ptr<FooType> ref_b = shared_objects.Get<FooType>("foo2");
+  ASSERT_EQ(num_constructed, 2);
+  ASSERT_NE(ref_a, ref_b);
+  ASSERT_EQ(num_destructed, 0);
+
+  ref_a.reset();
+  ASSERT_EQ(num_destructed, 1);
+  ASSERT_NE(ref_a, ref_b);
+
+  ref_b.reset();
+  ASSERT_EQ(num_destructed, 2);
+  ASSERT_EQ(ref_a, ref_b);
+}
+
+TEST_F(Test, TypeIsolation) {
+  {
+    std::shared_ptr<FooType> ref_a = shared_objects.Get<FooType>("foo");
+    ASSERT_EQ(num_constructed, 1);
+    ASSERT_EQ(ref_a->a_, 1);
+    ref_a->a_ = 3;
+
+    {
+      std::shared_ptr<BarType> ref_b = shared_objects.Get<BarType>("foo");
+      ASSERT_EQ(num_constructed, 2);
+      ASSERT_EQ(ref_b->b_, 2);
+      ASSERT_EQ(num_destructed, 0);
+    }
+
+    ASSERT_EQ(num_destructed, 1);
+  }
+
+  ASSERT_EQ(num_destructed, 2);
+
+  // This is a newly created object with the same name as the previous one
+  std::shared_ptr<FooType> ref_c = shared_objects.Get<FooType>("foo");
+  ASSERT_EQ(num_constructed, 3);
+  ASSERT_EQ(ref_c->a_, 1);
+}
+
+TEST_F(Test, Lookup) {
+  std::shared_ptr<FooType> ref_a = shared_objects.Lookup<FooType>("foo");
+  ASSERT_EQ(num_constructed, 0);
+  ASSERT_EQ(static_cast<bool>(ref_a), false);
+  ASSERT_EQ(ref_a.use_count(), 0);
+
+  std::shared_ptr<FooType> ref_b = shared_objects.Get<FooType>("foo");
+  ASSERT_EQ(num_constructed, 1);
+  ASSERT_EQ(ref_b.use_count(), 1);
+
+  std::shared_ptr<FooType> ref_c = shared_objects.Get<FooType>("foo");
+  ASSERT_EQ(num_constructed, 1);
+  ASSERT_EQ(ref_b.use_count(), 2);
+  ASSERT_EQ(ref_c.use_count(), 2);
+}
+
+static int deferred_arg() {
+  return 2;
+}
+
+TEST_F(Test, CustomConstructor) {
+  int u = 40;
+  std::shared_ptr<FooType> ref_a =
+      shared_objects.Get<FooType>("foo", [&]() -> std::shared_ptr<FooType> {
+        return std::make_shared<FooType>(u, deferred_arg());
+      });
+  ASSERT_EQ(num_constructed, 1);
+  ASSERT_EQ(ref_a->a_, 42);
+}
+
+}  // namespace bess

--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -208,4 +208,20 @@ T absdiff(const T &lhs, const T &rhs) {
   return lhs > rhs ? lhs - rhs : rhs - lhs;
 }
 
+struct PairHasher {
+  template <typename T1, typename T2>
+  std::size_t operator()(const std::pair<T1, T2> &p) const noexcept {
+    // Adopted from Google's cityhash Hash128to64(), MIT licensed
+    const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+    std::size_t x = std::hash<T1>{}(p.first);
+    std::size_t y = std::hash<T2>{}(p.second);
+    uint64_t a = (x ^ y) * kMul;
+    a ^= (a >> 47);
+    uint64_t b = (x ^ y) * kMul;
+    b ^= (b >> 47);
+    b *= kMul;
+    return static_cast<size_t>(b);
+  }
+};
+
 #endif  // BESS_UTILS_COMMON_H_


### PR DESCRIPTION
Often multiple modules need to share the same "object". One straightforward way to do this would be (and its issues):

1. Module A creates/owns an object (so loading/unloading order matters), 
1. other modules find the module (module lookup by name is not supposed to be used by modules), and
1. the object is referenced by the modules somehow, e.g., via an A's method (the modules now need to know A's class definition)

To work around these issues, this PR adds a simple primitive to share arbitrary objects among modules (or ports or whatever). It's designed to be minimal with a single API:

```
shared_ptr<TypeFoo> foo_obj = bess::shared_objects::Get<TypeFoo>("foo_name");
```

`Get()` takes an arbitrary string as the name of an object, then:
* If the object with the specified name already exists, it returns a `shared_ptr` to the object.
* If not, it creates an instance of TypeFoo (of course with its constructor, if any).
  * Use `Lookup()` helper function if you don't want this behavior.
* Just like any other `shared_ptr` objects, the returned object is destroyed when none has a reference.
* Each type (`TypeFoo` above) has its own namespace, i.e., another type `TypeBar` may have a different object also named `foo_name`. This is to avoid potential type errors.
* `Get()` and `Lookup()` themselves are thread-safe.
  * You are still responsible for the thread safety of objects, though.