### PR TITLE
fix FlowGen documentation typo

### DIFF
--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -483,7 +483,7 @@ message ExactMatchArg {
 /**
  * The FlowGen module generates simulated TCP flows of packets with correct SYN/FIN flags and sequence numbers.
  * This module is useful for testing, e.g., a NAT module or other flow-aware code.
- * Packets are generated off a base, "template" packet by modifying the IP src/dst and TCP src/dst. By default, only the ports are changed and will be modified by incrementing the template ports by up to 2000 more than the template values.
+ * Packets are generated off a base, "template" packet by modifying the IP src/dst and TCP src/dst. By default, only the ports are changed and will be modified by incrementing the template ports by up to 20000 more than the template values.
  *
  * __Input Gates__: 0
  * __Output Gates__: 1


### PR DESCRIPTION
The actual core/modules/flowgen.cc code reads:

  if (ip_src_range_ == 0 && ip_dst_range_ == 0 && port_src_range_ == 0 &&
      port_dst_range_ == 0) {
    /*randomize ports anyway*/
    port_dst_range_ = 20000;
    port_src_range_ = 20000;
  }

but the comment in module_msg.proto said "2000".  On the assumption
that the code is more correct than the documentation, fix the
documentation.