### PR TITLE
Automatically pause workers on certain commands

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -87,28 +87,6 @@ static inline Status return_with_errno(T* response, int code) {
   return Status::OK;
 }
 
-
-// This class is used as a resource manager to automatically pause workers if
-// running and then restarts workers if they were previously paused.
-class WorkerPauser {
- public:
-  explicit WorkerPauser() {
-    if (is_any_worker_running()) {
-      workers_paused = true;
-      pause_all_workers();
-    } else {
-      workers_paused = false;
-    }
-  }
-  ~WorkerPauser() {
-    if (workers_paused) {
-      resume_all_workers();
-    }
-  }
- private:
-  bool workers_paused;
-};
-
 static CommandResponse enable_hook_for_module(
     const Module* m, gate_idx_t gate_idx, bool is_igate, bool use_gate,
     const bess::GateHookFactory& factory, const google::protobuf::Any& arg) {

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -402,3 +402,22 @@ bool detach_tc(bess::TrafficClass *c) {
   // Try to remove from orphan_tcs
   return remove_tc_from_orphan(c);
 }
+
+WorkerPauser::WorkerPauser() {
+  if (is_any_worker_running()) {
+    for (int wid = 0; wid < Worker::kMaxWorkers; wid++) {
+      if (is_worker_running(wid)) {
+	workers_paused_.push_back(wid);
+	VLOG(1) << "*** Pausing Worker " << wid << " ***";
+	pause_worker(wid);
+	}
+    }
+  }
+}
+
+WorkerPauser:: ~WorkerPauser() {
+  for (int wid : workers_paused_) {
+    resume_worker(wid);
+    VLOG(1) << "*** Worker " << wid << " Resumed ***";
+  }
+}

--- a/core/worker.h
+++ b/core/worker.h
@@ -233,4 +233,14 @@ const std::list<std::pair<int, bess::TrafficClass *>> &list_orphan_tcs();
 // Otherwise, return false
 bool detach_tc(bess::TrafficClass *c);
 
+// This class is used as a resource manager to automatically pause workers if
+// running and then restarts workers if they were previously paused.
+class WorkerPauser {
+ public:
+  explicit WorkerPauser();
+  ~WorkerPauser();
+ private:
+  std::list<int> workers_paused_;
+};
+
 #endif  // BESS_WORKER_H_


### PR DESCRIPTION
The following changes are being proposed to automatically pause workers when commands requiring that workers be paused are executed.

This change alleviates the application from having to pause/resume workers and the associated maintenance of the worker state. This issue more particularly effects asynchronous clients.

This change is also expected to improve the performance of bessd when configuration changes are made under traffic load as workers are paused only when the message is processed. As is currently implemented, workers are paused from the processing of PauseAll to the subsequent ResumeAll, which could be a significant period of time given the gRPC round trips between controller and bessd.
