### PR TITLE
Make the Measure module thread-safe

### DIFF
--- a/bessctl/conf/port/latency.bess
+++ b/bessctl/conf/port/latency.bess
@@ -28,42 +28,54 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import scapy.all as scapy
 import time
 
-# latency will be high, since the queue builds up
-# as the Linux network stack is the bottleneck
-
 v = VPort(loopback=1, rxq_cpus=[1])
+pkt = bytes(scapy.Ether()/scapy.IP()/scapy.UDP()/'hello world!')
 
-Source() -> Timestamp() -> PortOut(port=v.name)
+s::Source() -> Rewrite(templates=[pkt]) -> Timestamp() -> PortOut(port=v.name)
 PortInc(port=v.name) -> m::Measure() -> Sink()
 
-last = m.get_summary()
+bess.add_tc('pktgen', policy='rate_limit',
+            resource='packet', limit={'packet': 1500000})
+s.attach_task('pktgen')
+
+start_time = time.time()
+last_time = start_time
+
+bess.resume_all()
+
+print('{} RTT (us)                             '.format(' ' * 41), end='')
+print('   jitter (us)')
+print('{}    avg    min    50%    99%      max '.format(' ' * 41), end='')
+print('      avg    min    50%    99%      max')
 
 while True:
-    bess.resume_all()
     time.sleep(1)
-    bess.pause_all()
 
-    now = m.get_summary()
-    diff_ts = last.timestamp - now.timestamp
-    diff_pkts = (last.packets - now.packets) / diff_ts
-    diff_bits = (last.bits - now.bits) / diff_ts
-    diff_total_latency_ns = (last.total_latency_ns - now.total_latency_ns) / diff_ts
-    last = now
+    # get_summary() doesn't require workers to be stopped
+    ret = m.get_summary(clear=True,  # reset stats every interval
+                        latency_percentiles=[55, 99],
+                        jitter_percentiles=[55, 99])
 
-    if diff_pkts >= 1.0:
-        ns_per_packet = diff_total_latency_ns / diff_pkts
-    else:
-        ns_per_packet = 0
+    diff_ts = ret.timestamp - last_time
+    diff_pkts = ret.packets / diff_ts
+    diff_bits = ret.bits / diff_ts
+    last_time = ret.timestamp
 
-    print('%s: %.3f Mpps, %.3f Mbps, rtt_avg: %.3f us, rtt_med: %.3f us, '\
-          'rtt_99th: %.3f us, jitter_med: %.3f us, jitter_99th: %.3f us' % \
-            (time.ctime(now.timestamp),
-             diff_pkts / 1e6,
-             diff_bits / 1e6,
-             ns_per_packet / 1e3,
-             last.latency_50_ns / 1e3,
-             last.latency_99_ns / 1e3,
-             last.jitter_50_ns / 1e3,
-             last.jitter_99_ns / 1e3))
+    print('%12.6f: %5.3f Mpps, %8.3f Mbps, ' \
+          '%7.3f %6.1f %6.1f %6.1f %8.1f   %7.3f %6.1f %6.1f %6.1f %8.1f' %
+          (ret.timestamp - start_time,
+           diff_pkts / 1e6,
+           diff_bits / 1e6,
+           ret.latency.avg_ns / 1e3,
+           ret.latency.min_ns / 1e3,
+           ret.latency.percentile_values_ns[0] / 1e3,
+           ret.latency.percentile_values_ns[1] / 1e3,
+           ret.latency.max_ns / 1e3,
+           ret.jitter.avg_ns / 1e3,
+           ret.jitter.min_ns / 1e3,
+           ret.jitter.percentile_values_ns[0] / 1e3,
+           ret.jitter.percentile_values_ns[1] / 1e3,
+           ret.jitter.max_ns / 1e3))

--- a/core/utils/histogram.h
+++ b/core/utils/histogram.h
@@ -80,7 +80,7 @@ class Histogram {
   // Each of percentiles is calculated and its value is returned in
   // percentile_values
   const Summary Summarize(const std::vector<double> &percentiles = {}) const {
-    Summary ret;
+    Summary ret = {};
     ret.count = count_;
     ret.above_range = buckets_.back();
     ret.percentile_values = std::vector<T>(percentiles.size());

--- a/core/utils/histogram_test.cc
+++ b/core/utils/histogram_test.cc
@@ -34,38 +34,48 @@
 namespace {
 
 TEST(HistogramTest, U32Quartiles) {
+  // 1002 is out of range, thus will be floored to 1000
+  const std::vector<uint32_t> values = {1, 2, 3, 4, 5, 1002};
+
   Histogram<uint32_t> hist(1000, 1);
-  std::vector<uint32_t> values = {1, 2, 3, 4, 5, 1001};
   for (uint32_t x : values) {
-    hist.insert(x);
+    hist.Insert(x);
   }
-  ASSERT_EQ(1, hist.above_threshold());
-  ASSERT_EQ(2, hist.min());
-  ASSERT_EQ(6, hist.max());
-  ASSERT_EQ(4, hist.avg());
-  ASSERT_EQ(5, hist.count());
-  ASSERT_EQ(20, hist.total());
-  ASSERT_EQ(1, hist.percentile(25));   // 25th percentile
-  ASSERT_EQ(2, hist.percentile(50));   // 50th percentile
-  ASSERT_EQ(3, hist.percentile(75));   // 75th percentile
-  ASSERT_EQ(5, hist.percentile(100));  // 100th percentile
+
+  auto ret = hist.Summarize({25.0, 50.0, 75.0, 100.0});
+
+  EXPECT_EQ(1, ret.above_range);
+  EXPECT_EQ(1, ret.min);
+  EXPECT_EQ(1000, ret.max);
+  EXPECT_EQ(169, ret.avg);
+  EXPECT_EQ(6, ret.count);
+  EXPECT_EQ(1015, ret.total);
+  EXPECT_EQ(2, ret.percentile_values[0]);     // 25th percentile
+  EXPECT_EQ(4, ret.percentile_values[1]);     // 50th percentile
+  EXPECT_EQ(5, ret.percentile_values[2]);     // 75th percentile
+  EXPECT_EQ(1000, ret.percentile_values[3]);  // 100th percentile
 }
 
 TEST(HistogramTest, DoubleQuartiles) {
+  const std::vector<double> values = {1.0, 1.0, 2.0, 2.0, 4.0, 6.0};
+
   Histogram<double> hist(1000, 0.5);
-  std::vector<double> values = {1.0, 1.0, 2.0, 3.0, 4.0, 5.0};
   for (double x : values) {
-    hist.insert(x);
+    hist.Insert(x);
   }
-  ASSERT_EQ(0, hist.above_threshold());
-  ASSERT_DOUBLE_EQ(1.5, hist.min());
-  ASSERT_DOUBLE_EQ(5.5, hist.max());
-  ASSERT_DOUBLE_EQ(19.0 / 6.0, hist.avg());
-  ASSERT_EQ(6, hist.count());
-  ASSERT_DOUBLE_EQ(19.0, hist.total());
-  ASSERT_DOUBLE_EQ(1.0, hist.percentile(25));   // 25th percentile
-  ASSERT_DOUBLE_EQ(2.0, hist.percentile(50));   // 50th percentile
-  ASSERT_DOUBLE_EQ(3.0, hist.percentile(75));   // 75th percentile
-  ASSERT_DOUBLE_EQ(5.0, hist.percentile(100));  // 100th percentile
+
+  auto ret = hist.Summarize({25.0, 50.0, 75.0, 100.0});
+
+  EXPECT_EQ(0, ret.above_range);
+  EXPECT_DOUBLE_EQ(1.0, ret.min);
+  EXPECT_DOUBLE_EQ(6.0, ret.max);
+  EXPECT_DOUBLE_EQ(16.0 / 6, ret.avg);
+  EXPECT_EQ(6, ret.count);
+  EXPECT_DOUBLE_EQ(16.0, ret.total);
+  EXPECT_DOUBLE_EQ(1.0, ret.percentile_values[0]);  // 25th percentile
+  EXPECT_DOUBLE_EQ(2.0, ret.percentile_values[1]);  // 50th percentile
+  EXPECT_DOUBLE_EQ(4.0, ret.percentile_values[2]);  // 75th percentile
+  EXPECT_DOUBLE_EQ(6.0, ret.percentile_values[3]);  // 100th percentile
 }
-}
+
+}  // namespace (unnamed)

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -205,26 +205,40 @@ message L2ForwardCommandPopulateArg {
   int64 gate_count = 3; /// How many gates to create in the L2Forward module.
 }
 
+/**
+ * The Measure module measures and collects latency/jitter data for packets
+ * annotated by a Timestamp module. Note that Timestamp and Measure module must reside
+ * on the server for accurate measurement (as a result, the most typical use case is
+ * measuring roundtrip time).
+ * Optionally, you can also retrieve percentile values by specifying points in
+ * "percentiles". For example, "percentiles" of [50.0, 99.0] will return
+ * [median, 99'th %-ile tail latency] in "percentile_values_ns" in the response.
+ */
+message MeasureCommandGetSummaryArg {
+  bool clear = 1; /// if true, the data will be all cleared after read
+  repeated double latency_percentiles = 2; /// ascending list of real numbers in [0.0, 100.0]
+  repeated double jitter_percentiles = 3; /// ascending list of real numbers in [0.0, 100.0]
+}
 
 /**
- * The Measure module function `get_summary()` takes no parameters and returns
- * the following values.
+ * The Measure module function `get_summary()` returns the following values.
  */
 message MeasureCommandGetSummaryResponse {
+  message Histogram {
+    uint64 count = 1; /// Total # of measured data points, including above_range
+    uint64 above_range = 2; /// # of data points for the "too large value" bucket
+    uint64 min_ns = 3;;
+    uint64 avg_ns = 4;
+    uint64 max_ns = 5;
+    uint64 total_ns = 6;
+    repeated uint64 percentile_values_ns = 7;
+  }
+
   double timestamp = 1; /// Seconds since boot.
-  uint64 packets = 2; /// The total number of packets seen by this module.
-  uint64 bits = 3; /// The total number of bits seen by this module.
-  uint64 total_latency_ns = 4; /// Sum of all round trip times across all packets
-  uint64 latency_min_ns = 5; /// The minimum latency for any packet observed by the Measure module.
-  uint64 latency_avg_ns = 6; /// The average latency for all packets.
-  uint64 latency_max_ns = 7; /// The max latency for any packet
-  uint64 latency_50_ns = 8; /// The 50th percentile latency over all packets
-  uint64 latency_99_ns = 9; /// The 99th percentile latency over all packets.
-  uint64 jitter_min_ns = 10; /// The minimum observed jitter.
-  uint64 jitter_avg_ns = 11; /// The average observed jitter.
-  uint64 jitter_max_ns = 12; /// The max observed jitter.
-  uint64 jitter_50_ns = 13; /// The 50th percentile of jitter.
-  uint64 jitter_99_ns = 14; /// The 99th percentile of jitter.
+  uint64 packets = 2; /// Total # of packets seen by this module.
+  uint64 bits = 3; /// Total # of bits seen by this module.
+  Histogram latency = 4;
+  Histogram jitter = 5;
 }
 
 


### PR DESCRIPTION
In the past, the Measure module required all workers to be paused to get latency statistics. This pause time incurred a quite amount of inaccuracy, due to increase of the tail latency, undermining its usefulness. While #632 marked `get_summary()` thread-safe making `bess.pause_all()` unnecessary, as a side effect it returns (almost) always zero values for the latency/jitter histogram values. This is due to the internal mechanism of the `Histogram` class; it clears all cached statistics values (min, avg, max, percentiles, etc.) whenever `insert()` is called. Therefore `get_summary()` cannot interleave with `insert()`, strictly requiring workers to be paused.

This PR makes the Measure module thread-safe, in terms of both (1) between a gRPC thread and a worker thread and (2) among worker threads. It includes the following major changes:

* `ProcessBatch()` is now protected with a spinlock, thus one module can be used by multiple worker threads.
  * Locking is done per-batch, incurring little overhead as compared to the non-locking version (unless the module is contended).
* `get_summary()` does not perform "destructive read" (clears all data points) any longer.
  * This is useful especially when the module needs to be monitored by multiple controllers.
  * Data points are only cleared when explicitly asked, i.e., either `get_summary(clear=True)` or `clear()`.
  * SInce it is read only, it doesn't hold the lock.
* Instead of predefined percentiles (50'th and 99'th), any number of percentiles can be calculated.
  * This is done with one-pass scanning over the histogram. Additional percentiles add minimal CPU overheads.