### PR TITLE
Add missing dependency files in Makefile

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -438,4 +438,4 @@ $(eval $(call BUILD, \
 # "clean".  But it's a lot easier than carefully expanding
 # # out all the MODULE, DRIVER, and UTIL names to have the correct
 # prefixes.
--include $(wildcard $(DEPDIR)/**/*.d)
+-include $(wildcard $(DEPDIR)/*.d) $(wildcard $(DEPDIR)/*/*.d)


### PR DESCRIPTION
In the line in Makefile `-include $(wildcard $(DEPDIR)/**/*.d)`, `**` is a shell feature and not supported by Makefile. As a result, this clause won't include `$(DEPDIR)/*.d` files, missing dependencies for the files in `core/` (not in its sub directories). Incremental building behaves incorrectly.