### PR TITLE
bessctl: Add GRAPHEASY_OPTS to show/monitor pipeline.

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -386,6 +386,11 @@ def get_var_attrs(cli, var_token, partial_word):
             var_desc = 'tshark(1) command-line options ' \
                 '(default "-z proto,colinfo,frame.comment,frame.comment")'
 
+        elif var_token == '[GRAPHEASY_OPTS...]':
+            var_type = 'opts'
+            var_desc = 'graph-easy(1p) command-line options ' \
+                '(e.g. --as dot | dot -Tsvg -o graph.svg)'
+
         elif var_token == '[BESSD_OPTS...]':
             var_type = 'opts'
             var_desc = 'bess daemon command-line options (see "bessd -h")'
@@ -1266,7 +1271,10 @@ def show_status(cli):
 
 
 # last_stats: a map of (node name, gateid) -> (timestamp, counter value)
-def _draw_pipeline(cli, field, units, last_stats=None):
+def _draw_pipeline(cli, field, units, last_stats=None, graph_args=[]):
+    if graph_args is None:
+        graph_args = []
+
     modules = sorted(cli.bess.list_modules().modules, key=lambda x: x.name)
     names = []
     node_labels = {}
@@ -1278,10 +1286,8 @@ def _draw_pipeline(cli, field, units, last_stats=None):
         node_labels[name] = '%s\\n%s' % (name, mclass)
         node_labels[name] += '\\n%s' % m.desc
 
-    port_inc_list = []
-
     try:
-        f = subprocess.Popen('graph-easy', shell=True,
+        f = subprocess.Popen('graph-easy ' + ' '.join(graph_args), shell=True,
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
@@ -1324,28 +1330,28 @@ def _draw_pipeline(cli, field, units, last_stats=None):
 
     except IOError as e:
         if e.errno == errno.EPIPE:
-            raise cli.CommandError('"graph-easy" program is not availabe? '
+            raise cli.CommandError('"graph-easy" program is not available? '
                                    'Check if the package "libgraph-easy-perl" '
                                    'is installed.')
         else:
             raise
 
 
-@cmd('show pipeline', 'Show the current datapath pipeline')
-def show_pipeline(cli):
-    cli.fout.write(_draw_pipeline(cli, 'pkts', ''))
+@cmd('show pipeline [GRAPHEASY_OPTS...]', 'Show the current datapath pipeline')
+def show_pipeline(cli, opts):
+    cli.fout.write(_draw_pipeline(cli, 'pkts', '', graph_args=opts))
 
 
-@cmd('show pipeline batch',
+@cmd('show pipeline batch [GRAPHEASY_OPTS...]',
      'Show the current datapath pipeline with batch counters')
-def show_pipeline_batch(cli):
-    cli.fout.write(_draw_pipeline(cli, 'cnt', ''))
+def show_pipeline_batch(cli, opts):
+    cli.fout.write(_draw_pipeline(cli, 'cnt', '', graph_args=opts))
 
 
-@cmd('show pipeline bit',
+@cmd('show pipeline bit [GRAPHEASY_OPTS...]',
      'Show the current datapath pipeline with Megabit counters')
-def show_pipeline_bit(cli):
-    cli.fout.write(_draw_pipeline(cli, 'bytes', 'Mb'))
+def show_pipeline_bit(cli, opts):
+    cli.fout.write(_draw_pipeline(cli, 'bytes', 'Mb', graph_args=opts))
 
 
 def _show_port(cli, port):
@@ -1572,7 +1578,7 @@ def show_version(cli):
     cli.fout.write('%s\n' % version.version)
 
 
-def _monitor_pipeline(cli, field, units):
+def _monitor_pipeline(cli, field, units, graph_args=[]):
     modules = sorted(cli.bess.list_modules().modules, key=lambda x: x.name)
 
     last_stats = {}
@@ -1586,27 +1592,29 @@ def _monitor_pipeline(cli, field, units):
     try:
         while True:
             time.sleep(1)
-            cli.fout.write(_draw_pipeline(cli, field, units, last_stats))
+            cli.fout.write(_draw_pipeline(cli, field, units, last_stats,
+                                          graph_args=graph_args))
             cli.fout.write('\n')
     except KeyboardInterrupt:
         pass
 
 
-@cmd('monitor pipeline', 'Monitor packet counters in the datapath pipeline')
-def monitor_pipeline(cli):
-    _monitor_pipeline(cli, 'pkts', '')
+@cmd('monitor pipeline [GRAPHEASY_OPTS...]',
+     'Monitor packet counters in the datapath pipeline')
+def monitor_pipeline(cli, opts):
+    _monitor_pipeline(cli, 'pkts', '', graph_args=opts)
 
 
-@cmd('monitor pipeline batch',
+@cmd('monitor pipeline batch [GRAPHEASY_OPTS...]',
      'Monitor batch counters in the datapath pipeline')
-def monitor_pipeline_batch(cli):
-    _monitor_pipeline(cli, 'cnt', '')
+def monitor_pipeline_batch(cli, opts):
+    _monitor_pipeline(cli, 'cnt', '', graph_args=opts)
 
 
-@cmd('monitor pipeline bit',
+@cmd('monitor pipeline bit [GRAPHEASY_OPTS...]',
      'Monitor Megabit counters in the datapath pipeline')
-def monitor_pipeline_bit(cli):
-    _monitor_pipeline(cli, 'bytes', 'Mbps')
+def monitor_pipeline_bit(cli, opts):
+    _monitor_pipeline(cli, 'bytes', 'Mbps', graph_args=opts)
 
 
 PortRate = collections.namedtuple('PortRate',


### PR DESCRIPTION
Similar to TCPDUMP_OPTS, this lets the user provide additional options
to the graph-easy invocation (or even pipe the graph-easy output to other
programs).

I find this change useful because sometimes the graph is too complicated to
be shown on the terminal.  With this commit

```
localhost:10514 $ show pipeline --as dot | dot -Tsvg -o graph.svg
```

outputs the graph to a file on disk.