### PR TITLE
Make module aligned to 64B

### DIFF
--- a/core/module.h
+++ b/core/module.h
@@ -249,9 +249,15 @@ enum CheckConstraintResult {
   CHECK_FATAL_ERROR = 2
 };
 
-class Module {
+class alignas(64) Module {
   // overide this section to create a new module -----------------------------
  public:
+  static void *operator new(std::size_t size) {
+    return mem_alloc_ex(size, alignof(Module), 0);
+  }
+
+  static void operator delete(void *ptr) { mem_free(ptr); }
+
   Module()
       : name_(),
         module_builder_(),

--- a/core/packet.h
+++ b/core/packet.h
@@ -87,13 +87,11 @@ class alignas(64) Packet {
 
   // The default new operator does not honor the 64B alignment requirement of
   // this class, since it is larger than max_align_t (16B)
-  static void* operator new(size_t count) {
-    return mem_alloc_ex(sizeof(Packet) * count, alignof(Packet), 0);
+  static void *operator new(size_t size) {
+    return mem_alloc_ex(size, alignof(Packet), 0);
   }
 
-  static void operator delete(void *ptr) {
-    mem_free(ptr);
-  }
+  static void operator delete(void *ptr) { mem_free(ptr); }
 
   struct rte_mbuf &as_rte_mbuf() {
     return *reinterpret_cast<struct rte_mbuf *>(this);


### PR DESCRIPTION
* plus, fix a bug `operator new()` in Packet class 
* `alinged_alloc()` is available from C++17, so I use legacy `mem_alloc_ex()`.