### PR TITLE
Prevent zombie processes of tcpdump, tshark

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1869,6 +1869,7 @@ def _capture_module(cli, module_name, direction, gate, opts, program, hook_fn):
         os.killpg(proc.pid, signal.SIGTERM)
         raise
     finally:
+        proc.wait()
         try:
             if unhook:
                 hook_fn(False, module_name, direction, gate)


### PR DESCRIPTION
* tcpdump / tshark becomes zombie processes when bess daemon responses with error codes
* handling bess error codes for processing cleanups