### PR TITLE
Add clang 4 and 5 to the build container

### DIFF
--- a/env/packages.yml
+++ b/env/packages.yml
@@ -1,7 +1,16 @@
 - hosts: all
   tags: package
   tasks:
-    - apt_repository: repo='ppa:ubuntu-toolchain-r/test' state=present
+    - apt_repository: repo='ppa:ubuntu-toolchain-r/test/ubuntu'
+      become: true
+
+    - apt_key: url='http://apt.llvm.org/llvm-snapshot.gpg.key'
+      become: true
+
+    - apt_repository: repo='deb http://apt.llvm.org/{{ ansible_distribution_release }}/ llvm-toolchain-{{ ansible_distribution_release }}-4.0 main'
+      become: true
+
+    - apt_repository: repo='deb http://apt.llvm.org/{{ ansible_distribution_release }}/ llvm-toolchain-{{ ansible_distribution_release }}-5.0 main'
       become: true
 
     - name: Install list of packages (this step may take a long time)
@@ -15,7 +24,7 @@
         - g++-6
         - g++-7
         - clang-3.8
-        - clang-3.9
+        - clang-4.0
         - autoconf
         - automake
         - libtool
@@ -44,6 +53,13 @@
         - linux-headers-generic
         - lcov
         - python-autopep8
+
+    # The server doesn't seem to have 32-bit binaries for clang-5.0 package.
+    # Remove "when" once it's fixed.
+    - name: Install clang-5.0 on x86_64
+      apt: name=clang-5.0
+      become: true
+      when: ansible_machine != 'i386'
 
     - name: Set default gcc and g++ version
       alternatives: name={{item}} link=/usr/bin/{{item}} path=/usr/bin/{{item}}-5

--- a/env/rebuild_images.py
+++ b/env/rebuild_images.py
@@ -41,7 +41,7 @@ TARGET_REPO = 'nefelinetworks/bess_build'
 
 imgs = {'trusty64': {'arch': 'x86_64', 'base': 'ubuntu:trusty',
                      'tag_suffix': ''},
-        'trusty32': {'arch': 'i386', 'base': 'ioft/i386-ubuntu:trusty',
+        'trusty32': {'arch': 'i386', 'base': 'i386/ubuntu:trusty',
                      'tag_suffix': '_32'}, }
 
 


### PR DESCRIPTION
Unlike gcc, the clang versions installed in the build container are quite old. This PR adds clang 4.0 and 5.0 to the compiler collection.

A few notes:
* clang-4.0 and higher are not directly provided by Ubuntu, so the `apt.llvm.org` repo was added.
* It seems that the apt server returns 404 for clang 5.0 binary for i386 arch at the moment. Because of this issue the 32bit build container does not install clang5 for now.
* The 3rd-party `ioft/i386-ubuntu:trusty` base image does not accept the root certificate (w/ 1024bit key) for the `*.googlecode.com` any longer, which is necessary to download submodules of gRPC. I am not sure why we were using that image in the first place... but switched to `i386/ubuntu`, which is managed by Docker.