### PR TITLE
state saving and restoring prototypes

### DIFF
--- a/bessctl/conf/testing/run_module_tests.bess
+++ b/bessctl/conf/testing/run_module_tests.bess
@@ -37,6 +37,7 @@ import time
 import sugar
 import traceback
 from time import gmtime, strftime
+from pybess import protobuf_to_dict as pb_conv
 
 # Env variable used to run a single test
 test_name = $TEST_NAME!'*'
@@ -134,6 +135,7 @@ def load_test(filename):
         'CRASH_TEST_INPUTS': [],
         'OUTPUT_TEST_INPUTS': [],
         'CUSTOM_TEST_FUNCTIONS': [],
+        'protobuf_to_dict': pb_conv.protobuf_to_dict,
     }
     # pre-import all the actual creator modules directly
     namespace.update(__bess_creators__)

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -60,6 +60,9 @@ class ExactMatch final : public Module {
   std::string GetDesc() const override;
 
   CommandResponse Init(const bess::pb::ExactMatchArg &arg);
+  CommandResponse GetInitialArg(const bess::pb::EmptyArg &arg);
+  CommandResponse GetRuntimeConfig(const bess::pb::EmptyArg &arg);
+  CommandResponse SetRuntimeConfig(const bess::pb::ExactMatchConfig &arg);
   CommandResponse CommandAdd(const bess::pb::ExactMatchCommandAddArg &arg);
   CommandResponse CommandDelete(
       const bess::pb::ExactMatchCommandDeleteArg &arg);
@@ -72,8 +75,10 @@ class ExactMatch final : public Module {
                               const bess::pb::FieldData &mask, int idx);
   void RuleFieldsFromPb(const RepeatedPtrField<bess::pb::FieldData> &fields,
                         bess::utils::ExactMatchRuleFields *rule);
+  Error AddRule(const bess::pb::ExactMatchCommandAddArg &arg);
 
   gate_idx_t default_gate_;
+  bool empty_masks_;		// mainly for GetInitialArg
 
   ExactMatchTable<gate_idx_t> table_;
 };

--- a/core/utils/exact_match_table.h
+++ b/core/utils/exact_match_table.h
@@ -309,6 +309,10 @@ class ExactMatchTable {
   // Returns the ith field.
   const ExactMatchField &get_field(size_t i) const { return fields_[i]; }
 
+  typename EmTable::iterator begin() { return table_.begin(); }
+
+  typename EmTable::iterator end() { return table_.end(); }
+
  private:
   Error MakeError(int code, const std::string &msg = "") {
     return std::make_pair(code, msg);

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -495,6 +495,16 @@ message ExactMatchArg {
 }
 
 /**
+ * ExactMatchConfig represents the current runtime configuration
+ * of an ExactMatch module, as returned by get_runtime_config and
+ * set by set_runtime_config.
+ */
+message ExactMatchConfig {
+  uint64 default_gate = 1;
+  repeated ExactMatchCommandAddArg rules = 2;
+}
+
+/**
  * The FlowGen module generates simulated TCP flows of packets with correct SYN/FIN flags and sequence numbers.
  * This module is useful for testing, e.g., a NAT module or other flow-aware code.
  * Packets are generated off a base, "template" packet by modifying the IP src/dst and TCP src/dst. By default, only the ports are changed and will be modified by incrementing the template ports by up to 20000 more than the template values.

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -36,6 +36,7 @@ import errno
 import grpc
 import os
 import pprint
+import re
 import sys
 import time
 
@@ -59,7 +60,7 @@ from .builtin_pb import module_msg_pb2 as module_msg
 
 
 def _import_modules(name, subdir):
-    """Return a module instance retaining just the *Arg and *Response
+    """Return a module instance retaining just the right protobuf
     names, built by importing most of the *_msg_pb2.py files in the
     builtin_pb and plugin_pb directories, or a subdirectory of them.
     We skip bess_msg_pb2 for historical reasons.
@@ -85,7 +86,13 @@ def _import_modules(name, subdir):
                     yield import_name
 
     def keep_name(name):
-        return name.endswith('Arg') or name.endswith('Response')
+        """
+        This defines the set of protobuf names to keep.  Those ending
+        with Arg, Response, or Config are kept: Arg for arguments to
+        a command, Response for a reply to a command, and Config for
+        get_config / set_config state.
+        """
+        return re.search(r'(?:Arg|Config|Response)$', name) is not None
 
     try:
         mod = _pm.pm_import(name, protobufs(subdir),


### PR DESCRIPTION
Some modules (like ExactMatch) make it difficult to load up a BESS instance with a full state all at once, or to inspect how they were initially constructed.  To help out, we add `GetArg` and `GetMut` (get generally-immutable-state from the argument used to construct a module, and get the entire generally-mutable state that can be set piecewise in some module).  A similar `SetMut` command sets the mutable state all at once.

Wiki documentation is yet to come based on whether this gets taken in this form.  (Left undone here is the notion of saving, or not, any dynamic state, such as internal NAT tables.  The overall idea is that if for whatever reason one must shoot down an existing BESS instance—or this has already happened because one crashed—and use saved state to create a new one, it would be much easier.)  Not all modules need to support these commands; the plan is to add them when they're convenient.

The current test for exact-match mutable state is a bit sloppy and will be full of redundancies with similar tests for other modules, once the test is more comprehensive, but I think it's better right now to wait for the new test framework.