### PR TITLE
Avoid undefined behavior of __builtin_clz()

### DIFF
--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -96,8 +96,11 @@ struct Ipv4Prefix {
 
   // Returns true if ip is within the range of Ipv4Prefix
   bool Match(const be32_t &ip) const { return (addr & mask) == (ip & mask); }
+
   // Returns the prefix length
-  uint32_t prefix_length() const { return ((32 - __builtin_clz(mask.raw_value()))); }
+  uint32_t prefix_length() const {
+    return ((32 - __builtin_clz(mask.raw_value())));
+  }
 
   be32_t addr;
   be32_t mask;

--- a/core/utils/ip.h
+++ b/core/utils/ip.h
@@ -99,7 +99,12 @@ struct Ipv4Prefix {
 
   // Returns the prefix length
   uint32_t prefix_length() const {
-    return ((32 - __builtin_clz(mask.raw_value())));
+    uint32_t mask_val = mask.value();
+    if (mask_val == 0) {
+      return 0;
+    } else {
+      return 32 - __builtin_ctz(mask_val);
+    }
   }
 
   be32_t addr;

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -86,13 +86,13 @@ TEST(IPTest, PrefixMatch) {
 
 TEST(IPTest, PrefixCalc) {
   Ipv4Prefix prefix_1("192.168.0.1/24");
-  ASSERT_EQ(24, prefix_1.prefix_length());
+  EXPECT_EQ(24, prefix_1.prefix_length());
   Ipv4Prefix prefix_2("0.0.0.0/0");
-  ASSERT_EQ(0, prefix_2.prefix_length());
+  EXPECT_EQ(0, prefix_2.prefix_length());
   Ipv4Prefix prefix_3("192.168.0.1/32");
-  ASSERT_EQ(32, prefix_3.prefix_length());
+  EXPECT_EQ(32, prefix_3.prefix_length());
   Ipv4Prefix prefix_4("192.168.0.1/16");
-  ASSERT_EQ(16, prefix_4.prefix_length());
+  EXPECT_EQ(16, prefix_4.prefix_length());
 }
 
 }  // namespace (unnamed)

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -86,13 +86,13 @@ TEST(IPTest, PrefixMatch) {
 
 TEST(IPTest, PrefixCalc) {
   Ipv4Prefix prefix_1("192.168.0.1/24");
-  ASSERT_EQ(24, prefix_1.prefix_length()) ;
+  ASSERT_EQ(24, prefix_1.prefix_length());
   Ipv4Prefix prefix_2("0.0.0.0/0");
-  ASSERT_EQ(0, prefix_2.prefix_length()) ;
+  ASSERT_EQ(0, prefix_2.prefix_length());
   Ipv4Prefix prefix_3("192.168.0.1/32");
-  ASSERT_EQ(32, prefix_3.prefix_length()) ;
+  ASSERT_EQ(32, prefix_3.prefix_length());
   Ipv4Prefix prefix_4("192.168.0.1/16");
-  ASSERT_EQ(16, prefix_4.prefix_length()) ;
-
+  ASSERT_EQ(16, prefix_4.prefix_length());
 }
+
 }  // namespace (unnamed)

--- a/core/utils/ip_test.cc
+++ b/core/utils/ip_test.cc
@@ -87,12 +87,16 @@ TEST(IPTest, PrefixMatch) {
 TEST(IPTest, PrefixCalc) {
   Ipv4Prefix prefix_1("192.168.0.1/24");
   EXPECT_EQ(24, prefix_1.prefix_length());
-  Ipv4Prefix prefix_2("0.0.0.0/0");
-  EXPECT_EQ(0, prefix_2.prefix_length());
-  Ipv4Prefix prefix_3("192.168.0.1/32");
-  EXPECT_EQ(32, prefix_3.prefix_length());
-  Ipv4Prefix prefix_4("192.168.0.1/16");
-  EXPECT_EQ(16, prefix_4.prefix_length());
+  Ipv4Prefix prefix_2("192.168.0.1/32");
+  EXPECT_EQ(32, prefix_2.prefix_length());
+  Ipv4Prefix prefix_3("192.168.0.1/16");
+  EXPECT_EQ(16, prefix_3.prefix_length());
+
+  // exhaustive test
+  for (int i = 0; i <= 32; i++) {
+    Ipv4Prefix p("0.0.0.0/" + std::to_string(i));
+    EXPECT_EQ(i, p.prefix_length());
+  }
 }
 
 }  // namespace (unnamed)


### PR DESCRIPTION
The code `uint32_t prefix_length() const { return ((32 - __builtin_clz(mask.raw_value()))); }` may fail if the value of `mask` is 0. In this case the behavior of `__builtin_clz` is undefined. While it does work as intended on newer x86 CPUs with BMI instruction set, the function on older CPUs returns some garbage value. This caused occasional failures on Travis.

Another issue in the same code is that it works only when prefix length is a multiple of 8. Bit reversing should have been done instead of byte reversing. It was fixed by using `ctz` in place of `clz`.