### PR TITLE
Fix Travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ before_script:
   - export CC=$VER_CC
 
 script:
-  - ./container_build.py bess
+  # travis_wait extends the 10-min timeout to 20mins.
+  - travis_wait ./container_build.py bess
   - ./container_build.py kmod_buildtest
   - (cd core && ./all_test --gtest_shuffle)  # TcpFlowReconstructTest requires working directory to be `core/`
   - coverage2 run -m unittest discover -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ install:
   - "[[ ${DEBUG:-0} == 0 ]] || sudo apt-get install -y g++-5"  # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"
-  - ln -s /build/dpdk-17.05 deps
+  # HOTFIX: do not use prebuilt DPDK binary, in case Travis VM runs on an old processor
+  # - ln -s /build/dpdk-17.05 deps
   - "docker pull nefelinetworks/bess_build:latest${TAG_SUFFIX} | cat"  # cat suppresses progress bars
 
 before_script:

--- a/build.py
+++ b/build.py
@@ -51,7 +51,10 @@ DPDK_TAG = 'v17.05'
 
 DPDK_VER = 'dpdk-17.05'
 
-arch = subprocess.check_output('uname -m', shell=True).strip()
+# In some 32-bit container images "uname -m" incorrectly(?) reports "x86_64".
+# To work around this issue, we use "gcc -dumpmachine" to detect target architecture.
+# The output looks like "i686-linux-gnu".
+arch = subprocess.check_output(['gcc', '-dumpmachine']).split('-')[0]
 if arch == 'x86_64':
     DPDK_TARGET = 'x86_64-native-linuxapp-gcc'
 elif arch == 'i686':
@@ -59,7 +62,7 @@ elif arch == 'i686':
 else:
     assert False, 'Unsupported arch %s' % arch
 
-kernel_release = subprocess.check_output('uname -r', shell=True).strip()
+kernel_release = subprocess.check_output(['uname', '-r']).strip()
 
 DPDK_DIR = '%s/%s' % (DEPS_DIR, DPDK_VER)
 DPDK_CFLAGS = '"-g -w -fPIC"'


### PR DESCRIPTION
1. It seems that Travis VMs recently are more often run on old systems (SandyBridge or older). We use DPDK binary prebuilt in the build container. Since the binary is built with RDRAND support with `-march=native`, all apps linked against the DPDK binary fail if Travis VM runs on an old processor. As a hot fix, now DPDK is built locally in the Travis VM.

1. Also, now the build more frequently fails due to the 10-min timeout. `travis_wait` is used to extend the timeout to 20mins.

1. We switched to a 32-bit Ubuntu container image maintained by Docket (#664). Within the new container `arch` reports `x86_64`, not `i686`, causing build errors. I replaced `arch` with 'gcc -dumpmachine` to work around this issue.