### PR TITLE
Refactoring Module/Task/ModuleBuilder

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1137,7 +1137,7 @@ class BESSControlImpl final : public BESSControl::Service {
       mod_name = request->name();
     } else {
       mod_name = ModuleGraph::GenerateDefaultName(builder.class_name(),
-                                                    builder.name_template());
+                                                  builder.name_template());
     }
 
     pb_error_t* error = response->mutable_error();
@@ -1241,10 +1241,10 @@ class BESSControlImpl final : public BESSControl::Service {
 
     if (is_any_worker_running()) {
       propagate_active_worker();
-      if (m1->num_active_workers() || m2->num_active_workers() ) {
-	WorkerPauser wp; // Only pause when absolutely required
-	ret = m1->ConnectModules(ogate, m2, igate);
-	goto done;
+      if (m1->num_active_workers() || m2->num_active_workers()) {
+        WorkerPauser wp;  // Only pause when absolutely required
+        ret = m1->ConnectModules(ogate, m2, igate);
+        goto done;
       }
     }
     ret = m1->ConnectModules(ogate, m2, igate);
@@ -1286,21 +1286,22 @@ class BESSControlImpl final : public BESSControl::Service {
     return Status::OK;
   }
 
-  Status DumpMempool(ServerContext*,
-                           const DumpMempoolRequest* request,
-                           DumpMempoolResponse* response) override {
+  Status DumpMempool(ServerContext*, const DumpMempoolRequest* request,
+                     DumpMempoolResponse* response) override {
     int socket_filter = request->socket();
-    socket_filter = (socket_filter == -1) ? (RTE_MAX_NUMA_NODES - 1) : socket_filter;
+    socket_filter =
+        (socket_filter == -1) ? (RTE_MAX_NUMA_NODES - 1) : socket_filter;
     int socket = (request->socket() == -1) ? 0 : socket_filter;
     for (; socket <= socket_filter; socket++) {
-      struct rte_mempool *mempool = bess::get_pframe_pool_socket(socket);
-      MempoolDump *dump = response->add_dumps();
+      struct rte_mempool* mempool = bess::get_pframe_pool_socket(socket);
+      MempoolDump* dump = response->add_dumps();
       dump->set_socket(socket);
       dump->set_initialized(mempool != nullptr);
       if (mempool == nullptr) {
         continue;
       }
-      struct rte_ring *ring = reinterpret_cast<struct rte_ring*>(mempool->pool_data);
+      struct rte_ring* ring =
+          reinterpret_cast<struct rte_ring*>(mempool->pool_data);
       dump->set_mp_size(mempool->size);
       dump->set_mp_cache_size(mempool->cache_size);
       dump->set_mp_element_size(mempool->elt_size);

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -50,6 +50,7 @@
 #include "message.h"
 #include "metadata.h"
 #include "module.h"
+#include "module_graph.h"
 #include "opts.h"
 #include "packet.h"
 #include "port.h"
@@ -723,7 +724,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     // Check local constraints
-    for (const auto& pair : ModuleGraph::all_modules()) {
+    for (const auto& pair : ModuleGraph::GetAllModules()) {
       const Module* m = pair.second;
       auto ret = m->CheckModuleConstraints();
       if (ret != CHECK_OK) {
@@ -1099,7 +1100,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
   Status ListModules(ServerContext*, const EmptyRequest*,
                      ListModulesResponse* response) override {
-    for (const auto& pair : ModuleGraph::all_modules()) {
+    for (const auto& pair : ModuleGraph::GetAllModules()) {
       const Module* m = pair.second;
       ListModulesResponse_Module* module = response->add_modules();
 
@@ -1129,8 +1130,8 @@ class BESSControlImpl final : public BESSControl::Service {
 
     std::string mod_name;
     if (request->name().length()) {
-      const auto& it2 = ModuleGraph::all_modules().find(request->name());
-      if (it2 != ModuleGraph::all_modules().end()) {
+      const auto& it2 = ModuleGraph::GetAllModules().find(request->name());
+      if (it2 != ModuleGraph::GetAllModules().end()) {
         return return_with_error(response, EEXIST, "Module %s exists",
                                  request->name().c_str());
       }
@@ -1161,8 +1162,8 @@ class BESSControlImpl final : public BESSControl::Service {
                                "Argument must be a name in str");
     m_name = request->name().c_str();
 
-    const auto& it = ModuleGraph::all_modules().find(request->name());
-    if (it == ModuleGraph::all_modules().end()) {
+    const auto& it = ModuleGraph::GetAllModules().find(request->name());
+    if (it == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m_name);
     }
@@ -1183,8 +1184,8 @@ class BESSControlImpl final : public BESSControl::Service {
                                "Argument must be a name in str");
     m_name = request->name().c_str();
 
-    const auto& it = ModuleGraph::all_modules().find(request->name());
-    if (it == ModuleGraph::all_modules().end()) {
+    const auto& it = ModuleGraph::GetAllModules().find(request->name());
+    if (it == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m_name);
     }
@@ -1224,16 +1225,16 @@ class BESSControlImpl final : public BESSControl::Service {
     if (!m1_name || !m2_name)
       return return_with_error(response, EINVAL, "Missing 'm1' or 'm2' field");
 
-    const auto& it1 = ModuleGraph::all_modules().find(request->m1());
-    if (it1 == ModuleGraph::all_modules().end()) {
+    const auto& it1 = ModuleGraph::GetAllModules().find(request->m1());
+    if (it1 == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m1_name);
     }
 
     m1 = it1->second;
 
-    const auto& it2 = ModuleGraph::all_modules().find(request->m2());
-    if (it2 == ModuleGraph::all_modules().end()) {
+    const auto& it2 = ModuleGraph::GetAllModules().find(request->m2());
+    if (it2 == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m2_name);
     }
@@ -1271,8 +1272,8 @@ class BESSControlImpl final : public BESSControl::Service {
     if (!request->name().length())
       return return_with_error(response, EINVAL, "Missing 'name' field");
 
-    const auto& it = ModuleGraph::all_modules().find(request->name());
-    if (it == ModuleGraph::all_modules().end()) {
+    const auto& it = ModuleGraph::GetAllModules().find(request->name());
+    if (it == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m_name);
     }
@@ -1343,7 +1344,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
     if (request->module_name().length() == 0) {
       // Install this hook on all modules
-      for (const auto& it : ModuleGraph::all_modules()) {
+      for (const auto& it : ModuleGraph::GetAllModules()) {
         if (request->enable()) {
           *response =
               enable_hook_for_module(it.second, gate_idx, is_igate, use_gate,
@@ -1360,8 +1361,8 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     // Install this hook on the specified module
-    const auto& it = ModuleGraph::all_modules().find(request->module_name());
-    if (it == ModuleGraph::all_modules().end()) {
+    const auto& it = ModuleGraph::GetAllModules().find(request->module_name());
+    if (it == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                request->module_name().c_str());
     }
@@ -1467,8 +1468,8 @@ class BESSControlImpl final : public BESSControl::Service {
       return return_with_error(response, EINVAL,
                                "Missing module name field 'name'");
     }
-    const auto& it = ModuleGraph::all_modules().find(request->name());
-    if (it == ModuleGraph::all_modules().end()) {
+    const auto& it = ModuleGraph::GetAllModules().find(request->name());
+    if (it == ModuleGraph::GetAllModules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                request->name().c_str());
     }
@@ -1581,8 +1582,8 @@ class BESSControlImpl final : public BESSControl::Service {
       c = it->second;
     } else if (class_.leaf_module_name().length() != 0) {
       const std::string& module_name = class_.leaf_module_name();
-      const auto& it = ModuleGraph::all_modules().find(module_name);
-      if (it == ModuleGraph::all_modules().end()) {
+      const auto& it = ModuleGraph::GetAllModules().find(module_name);
+      if (it == ModuleGraph::GetAllModules().end()) {
         return_with_error(response, ENOENT, "No module '%s' found",
                           module_name.c_str());
         return nullptr;

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -418,7 +418,7 @@ static Module* create_module(const std::string& name,
     return nullptr;
   }
 
-  if (!ModuleBuilder::AddModule(m)) {
+  if (!ModuleGraph::AddModule(m)) {
     *perr = pb_errno(ENOMEM);
     return nullptr;
   }
@@ -723,7 +723,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     // Check local constraints
-    for (const auto& pair : ModuleBuilder::all_modules()) {
+    for (const auto& pair : ModuleGraph::all_modules()) {
       const Module* m = pair.second;
       auto ret = m->CheckModuleConstraints();
       if (ret != CHECK_OK) {
@@ -1092,14 +1092,14 @@ class BESSControlImpl final : public BESSControl::Service {
                       EmptyResponse*) override {
     WorkerPauser wp;
 
-    ModuleBuilder::DestroyAllModules();
+    ModuleGraph::DestroyAllModules();
     LOG(INFO) << "*** All modules have been destroyed ***";
     return Status::OK;
   }
 
   Status ListModules(ServerContext*, const EmptyRequest*,
                      ListModulesResponse* response) override {
-    for (const auto& pair : ModuleBuilder::all_modules()) {
+    for (const auto& pair : ModuleGraph::all_modules()) {
       const Module* m = pair.second;
       ListModulesResponse_Module* module = response->add_modules();
 
@@ -1129,14 +1129,14 @@ class BESSControlImpl final : public BESSControl::Service {
 
     std::string mod_name;
     if (request->name().length()) {
-      const auto& it2 = ModuleBuilder::all_modules().find(request->name());
-      if (it2 != ModuleBuilder::all_modules().end()) {
+      const auto& it2 = ModuleGraph::all_modules().find(request->name());
+      if (it2 != ModuleGraph::all_modules().end()) {
         return return_with_error(response, EEXIST, "Module %s exists",
                                  request->name().c_str());
       }
       mod_name = request->name();
     } else {
-      mod_name = ModuleBuilder::GenerateDefaultName(builder.class_name(),
+      mod_name = ModuleGraph::GenerateDefaultName(builder.class_name(),
                                                     builder.name_template());
     }
 
@@ -1161,14 +1161,14 @@ class BESSControlImpl final : public BESSControl::Service {
                                "Argument must be a name in str");
     m_name = request->name().c_str();
 
-    const auto& it = ModuleBuilder::all_modules().find(request->name());
-    if (it == ModuleBuilder::all_modules().end()) {
+    const auto& it = ModuleGraph::all_modules().find(request->name());
+    if (it == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m_name);
     }
     m = it->second;
 
-    ModuleBuilder::DestroyModule(m);
+    ModuleGraph::DestroyModule(m);
 
     return Status::OK;
   }
@@ -1183,8 +1183,8 @@ class BESSControlImpl final : public BESSControl::Service {
                                "Argument must be a name in str");
     m_name = request->name().c_str();
 
-    const auto& it = ModuleBuilder::all_modules().find(request->name());
-    if (it == ModuleBuilder::all_modules().end()) {
+    const auto& it = ModuleGraph::all_modules().find(request->name());
+    if (it == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m_name);
     }
@@ -1224,16 +1224,16 @@ class BESSControlImpl final : public BESSControl::Service {
     if (!m1_name || !m2_name)
       return return_with_error(response, EINVAL, "Missing 'm1' or 'm2' field");
 
-    const auto& it1 = ModuleBuilder::all_modules().find(request->m1());
-    if (it1 == ModuleBuilder::all_modules().end()) {
+    const auto& it1 = ModuleGraph::all_modules().find(request->m1());
+    if (it1 == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m1_name);
     }
 
     m1 = it1->second;
 
-    const auto& it2 = ModuleBuilder::all_modules().find(request->m2());
-    if (it2 == ModuleBuilder::all_modules().end()) {
+    const auto& it2 = ModuleGraph::all_modules().find(request->m2());
+    if (it2 == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m2_name);
     }
@@ -1271,8 +1271,8 @@ class BESSControlImpl final : public BESSControl::Service {
     if (!request->name().length())
       return return_with_error(response, EINVAL, "Missing 'name' field");
 
-    const auto& it = ModuleBuilder::all_modules().find(request->name());
-    if (it == ModuleBuilder::all_modules().end()) {
+    const auto& it = ModuleGraph::all_modules().find(request->name());
+    if (it == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                m_name);
     }
@@ -1342,7 +1342,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
     if (request->module_name().length() == 0) {
       // Install this hook on all modules
-      for (const auto& it : ModuleBuilder::all_modules()) {
+      for (const auto& it : ModuleGraph::all_modules()) {
         if (request->enable()) {
           *response =
               enable_hook_for_module(it.second, gate_idx, is_igate, use_gate,
@@ -1359,8 +1359,8 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     // Install this hook on the specified module
-    const auto& it = ModuleBuilder::all_modules().find(request->module_name());
-    if (it == ModuleBuilder::all_modules().end()) {
+    const auto& it = ModuleGraph::all_modules().find(request->module_name());
+    if (it == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                request->module_name().c_str());
     }
@@ -1466,8 +1466,8 @@ class BESSControlImpl final : public BESSControl::Service {
       return return_with_error(response, EINVAL,
                                "Missing module name field 'name'");
     }
-    const auto& it = ModuleBuilder::all_modules().find(request->name());
-    if (it == ModuleBuilder::all_modules().end()) {
+    const auto& it = ModuleGraph::all_modules().find(request->name());
+    if (it == ModuleGraph::all_modules().end()) {
       return return_with_error(response, ENOENT, "No module '%s' found",
                                request->name().c_str());
     }
@@ -1580,8 +1580,8 @@ class BESSControlImpl final : public BESSControl::Service {
       c = it->second;
     } else if (class_.leaf_module_name().length() != 0) {
       const std::string& module_name = class_.leaf_module_name();
-      const auto& it = ModuleBuilder::all_modules().find(module_name);
-      if (it == ModuleBuilder::all_modules().end()) {
+      const auto& it = ModuleGraph::all_modules().find(module_name);
+      if (it == ModuleGraph::all_modules().end()) {
         return_with_error(response, ENOENT, "No module '%s' found",
                           module_name.c_str());
         return nullptr;

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -38,6 +38,7 @@
 
 #include "mem_alloc.h"
 #include "module.h"
+#include "module_graph.h"
 
 namespace bess {
 namespace metadata {
@@ -65,7 +66,7 @@ static mt_offset_t ComputeNextOffset(mt_offset_t curr_offset, int8_t size) {
 
 // Generate warnings for modules that read metadata that never gets set.
 static void CheckOrphanReaders() {
-  for (const auto &it : ModuleGraph::all_modules()) {
+  for (const auto &it : ModuleGraph::GetAllModules()) {
     const Module *m = it.second;
     if (!m) {
       break;
@@ -123,7 +124,7 @@ bool ScopeComponent::DisjointFrom(const ScopeComponent &rhs) {
 // Pipeline ----------------------------------------------------------------
 
 int Pipeline::PrepareMetadataComputation() {
-  for (const auto &it : ModuleGraph::all_modules()) {
+  for (const auto &it : ModuleGraph::GetAllModules()) {
     Module *m = it.second;
     if (!m) {
       break;
@@ -412,7 +413,7 @@ void Pipeline::LogAllScopes() const {
     VLOG(1) << "}";
   }
 
-  for (const auto &it : ModuleGraph::all_modules()) {
+  for (const auto &it : ModuleGraph::GetAllModules()) {
     const Module *m = it.second;
     if (!m) {
       break;
@@ -452,7 +453,7 @@ int Pipeline::ComputeMetadataOffsets() {
     return ret;
   }
 
-  for (const auto &it : ModuleGraph::all_modules()) {
+  for (const auto &it : ModuleGraph::GetAllModules()) {
     Module *m = it.second;
     if (!m) {
       break;

--- a/core/metadata.cc
+++ b/core/metadata.cc
@@ -65,7 +65,7 @@ static mt_offset_t ComputeNextOffset(mt_offset_t curr_offset, int8_t size) {
 
 // Generate warnings for modules that read metadata that never gets set.
 static void CheckOrphanReaders() {
-  for (const auto &it : ModuleBuilder::all_modules()) {
+  for (const auto &it : ModuleGraph::all_modules()) {
     const Module *m = it.second;
     if (!m) {
       break;
@@ -123,7 +123,7 @@ bool ScopeComponent::DisjointFrom(const ScopeComponent &rhs) {
 // Pipeline ----------------------------------------------------------------
 
 int Pipeline::PrepareMetadataComputation() {
-  for (const auto &it : ModuleBuilder::all_modules()) {
+  for (const auto &it : ModuleGraph::all_modules()) {
     Module *m = it.second;
     if (!m) {
       break;
@@ -412,7 +412,7 @@ void Pipeline::LogAllScopes() const {
     VLOG(1) << "}";
   }
 
-  for (const auto &it : ModuleBuilder::all_modules()) {
+  for (const auto &it : ModuleGraph::all_modules()) {
     const Module *m = it.second;
     if (!m) {
       break;
@@ -452,7 +452,7 @@ int Pipeline::ComputeMetadataOffsets() {
     return ret;
   }
 
-  for (const auto &it : ModuleBuilder::all_modules()) {
+  for (const auto &it : ModuleGraph::all_modules()) {
     Module *m = it.second;
     if (!m) {
       break;

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "module.h"
+#include "module_graph.h"
 
 namespace {
 

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -55,7 +55,7 @@ Module *create_foo(const std::string name = "") {
 
   Module *m;
   if (name.size() == 0) {
-    const std::string &mod_name = ModuleBuilder::GenerateDefaultName(
+    const std::string &mod_name = ModuleGraph::GenerateDefaultName(
         builder.class_name(), builder.name_template());
 
     m = builder.CreateModule(mod_name, &bess::metadata::default_pipeline);
@@ -63,7 +63,7 @@ Module *create_foo(const std::string name = "") {
     m = builder.CreateModule(std::string(name),
                              &bess::metadata::default_pipeline);
   }
-  ModuleBuilder::AddModule(m);
+  ModuleGraph::AddModule(m);
 
   return m;
 }
@@ -88,7 +88,7 @@ class MetadataTest : public ::testing::Test {
     ASSERT_TRUE(m1);
   }
 
-  virtual void TearDown() { ModuleBuilder::DestroyAllModules(); }
+  virtual void TearDown() { ModuleGraph::DestroyAllModules(); }
 
   Module *m0;
   Module *m1;
@@ -212,7 +212,7 @@ TEST_F(MetadataTest, MultipeAttrSimplePipe) {
 }
 
 TEST_F(MetadataTest, MultipeAttrComplexPipe) {
-  ModuleBuilder::DestroyAllModules();
+  ModuleGraph::DestroyAllModules();
   std::vector<Module *> mods;
   for (int i = 0; i < 10; i++) {
     mods.push_back(create_foo());
@@ -291,7 +291,7 @@ TEST_F(MetadataTest, MultipeAttrComplexPipe) {
 // to each metadata attribute. ComputeMetadataOffsets() should sort them before
 // handing them to AssignOffsets(). If it doesn't, bad things happen.
 TEST_F(MetadataTest, ScopeComponentDegreeOrder) {
-  ModuleBuilder::DestroyAllModules();
+  ModuleGraph::DestroyAllModules();
   m0 = create_foo("foo5");
   m1 = create_foo("foo3");
   Module *m2 = create_foo("foo6");

--- a/core/module.cc
+++ b/core/module.cc
@@ -39,15 +39,12 @@
 #include "hooks/tcpdump.h"
 #include "hooks/track.h"
 #include "mem_alloc.h"
+#include "module_graph.h"
 #include "scheduler.h"
 #include "utils/pcap.h"
 #include "worker.h"
 
 const Commands Module::cmds;
-
-std::map<std::string, Module *> ModuleGraph::all_modules_;
-std::unordered_map<std::string, Node> ModuleGraph::module_graph_;
-std::unordered_set<std::string> ModuleGraph::tasks_;
 
 bool ModuleBuilder::RegisterModuleClass(
     std::function<Module *()> module_generator, const std::string &class_name,
@@ -95,10 +92,6 @@ const std::map<std::string, ModuleBuilder>
   return all_module_builders_holder();
 }
 
-const std::map<std::string, Module *> &ModuleGraph::all_modules() {
-  return all_modules_;
-}
-
 CommandResponse ModuleBuilder::RunCommand(
     Module *m, const std::string &user_cmd,
     const google::protobuf::Any &arg) const {
@@ -135,192 +128,6 @@ Module *ModuleBuilder::CreateModule(const std::string &name,
   m->set_module_builder(this);
   m->set_pipeline(pipeline);
   return m;
-}
-
-bool ModuleGraph::ExistModuleClass(const ModuleBuilder *builder) {
-  for (auto const &e : all_modules()) {
-    if (e.second->module_builder() == builder) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool ModuleGraph::AddEdge(const std::string &from, const std::string &to) {
-  auto from_it = module_graph_.find(from);
-  if (from_it == module_graph_.end() || module_graph_.count(to) == 0) {
-    return false;
-  }
-  from_it->second.AddChild(to);
-  return UpdateTaskGraph();
-}
-
-bool ModuleGraph::RemoveEdge(const std::string &from, const std::string &to) {
-  auto from_node = module_graph_.find(from);
-  if (from_node == module_graph_.end() || module_graph_.count(to) == 0) {
-    return false;
-  }
-
-  from_node->second.RemoveChild(to);
-
-  // We need to regenerate the task graph.
-  for (auto const &task : tasks_) {
-    auto it = all_modules_.find(task);
-    if (it != all_modules_.end()) {
-      it->second->parent_tasks_.clear();
-    }
-  }
-  return UpdateTaskGraph();
-}
-
-bool ModuleGraph::UpdateTaskGraph() {
-  for (auto const &task : tasks_) {
-    std::unordered_set<std::string> visited;
-    if (!FindNextTask(task, task, &visited)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-bool ModuleGraph::FindNextTask(const std::string &node_name,
-                               const std::string &parent_name,
-                               std::unordered_set<std::string> *visited) {
-  visited->insert(node_name);
-  // While traversing the module graph, if `node` is in the task graph and is
-  // not `parent`, then it must be  the child of `parent`.
-  if (node_name != parent_name && tasks_.find(node_name) != tasks_.end()) {
-    auto parent_it = all_modules_.find(parent_name);
-    auto node_it = all_modules_.find(node_name);
-    if (parent_it == all_modules_.end() || node_it == all_modules_.end()) {
-      return false;
-    }
-
-    Module *node = node_it->second;
-    Module *parent = parent_it->second;
-    for (Module *it : node->parent_tasks_) {
-      if (it == parent) {
-        return true;
-      }
-    }
-    node->parent_tasks_.push_back(parent);
-    return true;
-  }
-
-  auto node_it = module_graph_.find(node_name);
-  if (node_it == module_graph_.end()) {
-    return false;
-  }
-
-  for (auto &child_name : node_it->second.children()) {
-    if (visited->count(child_name) > 0) {
-      continue;
-    }
-    if (!FindNextTask(child_name, parent_name, visited)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-bool ModuleGraph::AddModule(Module *m) {
-  if (m->is_task_) {
-    if (!tasks_.insert(m->name()).second) {
-      return false;
-    }
-  }
-
-  bool module_added = all_modules_.insert({m->name(), m}).second;
-  if (!module_added) {
-    return false;
-  }
-
-  return module_graph_
-      .emplace(std::piecewise_construct, std::forward_as_tuple(m->name()),
-               std::forward_as_tuple(m))
-      .second;
-}
-
-int ModuleGraph::DestroyModule(Module *m, bool erase) {
-  int ret;
-  m->DeInit();
-
-  // disconnect from upstream modules.
-  for (size_t i = 0; i < m->igates_.size(); i++) {
-    ret = m->DisconnectModulesUpstream(i);
-    if (ret) {
-      return ret;
-    }
-  }
-
-  // disconnect downstream modules
-  for (size_t i = 0; i < m->ogates_.size(); i++) {
-    ret = m->DisconnectModules(i);
-    if (ret) {
-      return ret;
-    }
-  }
-
-  m->DestroyAllTasks();
-  m->DeregisterAllAttributes();
-
-  if (erase) {
-    all_modules_.erase(m->name());
-  }
-
-  module_graph_.erase(m->name());
-  if (m->is_task_) {
-    tasks_.erase(m->name());
-  }
-
-  delete m;
-  return 0;
-}
-
-void ModuleGraph::DestroyAllModules() {
-  int ret;
-  for (auto it = all_modules_.begin(); it != all_modules_.end();) {
-    auto it_next = std::next(it);
-    ret = DestroyModule(it->second, false);
-    if (ret) {
-      LOG(ERROR) << "Error destroying module '" << it->first
-                 << "' (errno = " << ret << ")";
-    } else {
-      all_modules_.erase(it);
-    }
-    it = it_next;
-  }
-}
-
-std::string ModuleGraph::GenerateDefaultName(
-    const std::string &class_name, const std::string &default_template) {
-  std::string name_template;
-
-  if (default_template == "") {
-    std::ostringstream ss;
-    char last_char = '\0';
-    for (auto t : class_name) {
-      if (last_char != '\0' && islower(last_char) && isupper(t))
-        ss << '_';
-
-      ss << char(tolower(t));
-      last_char = t;
-    }
-    name_template = ss.str();
-  } else {
-    name_template = default_template;
-  }
-
-  for (int i = 0;; i++) {
-    std::ostringstream ss;
-    ss << name_template << i;
-    std::string name = ss.str();
-
-    if (!all_modules_.count(name))
-      return name;
-  }
-
-  promise_unreachable();
 }
 
 // -------------------------------------------------------------------------
@@ -737,10 +544,11 @@ void _trace_after_call(void) {
 
   s->curr_indent = s->indent[s->depth];
 }
+
 #endif
 
 void propagate_active_worker() {
-  for (auto &pair : ModuleGraph::all_modules()) {
+  for (auto &pair : ModuleGraph::GetAllModules()) {
     Module *m = pair.second;
     m->ResetActiveWorkerSet();
   }

--- a/core/module.cc
+++ b/core/module.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //

--- a/core/module.cc
+++ b/core/module.cc
@@ -41,6 +41,7 @@
 #include "mem_alloc.h"
 #include "module_graph.h"
 #include "scheduler.h"
+#include "task.h"
 #include "utils/pcap.h"
 #include "worker.h"
 
@@ -546,24 +547,3 @@ void _trace_after_call(void) {
 }
 
 #endif
-
-void propagate_active_worker() {
-  for (auto &pair : ModuleGraph::GetAllModules()) {
-    Module *m = pair.second;
-    m->ResetActiveWorkerSet();
-  }
-  for (int i = 0; i < Worker::kMaxWorkers; i++) {
-    if (workers[i] == nullptr) {
-      continue;
-    }
-    if (bess::TrafficClass *root = workers[i]->scheduler()->root()) {
-      for (const auto &tc_pair : bess::TrafficClassBuilder::all_tcs()) {
-        bess::TrafficClass *c = tc_pair.second;
-        if (c->policy() == bess::POLICY_LEAF && c->Root() == root) {
-          auto leaf = static_cast<bess::LeafTrafficClass<Task> *>(c);
-          leaf->task().AddActiveWorker(i);
-        }
-      }
-    }
-  }
-}

--- a/core/module.cc
+++ b/core/module.cc
@@ -71,7 +71,7 @@ bool ModuleBuilder::DeregisterModuleClass(const std::string &class_name) {
   // Check if any module of the class still exists
   const ModuleBuilder *builder = &(it->second);
   if (ModuleGraph::ExistModuleClass(builder))
-	  return false;
+    return false;
 
   all_module_builders_holder().erase(it);
   return true;
@@ -127,7 +127,6 @@ CommandResponse ModuleBuilder::RunInit(Module *m,
                                        const google::protobuf::Any &arg) const {
   return init_func_(m, arg);
 }
-
 
 Module *ModuleBuilder::CreateModule(const std::string &name,
                                     bess::metadata::Pipeline *pipeline) const {
@@ -185,8 +184,8 @@ bool ModuleGraph::UpdateTaskGraph() {
 }
 
 bool ModuleGraph::FindNextTask(const std::string &node_name,
-                                 const std::string &parent_name,
-                                 std::unordered_set<std::string> *visited) {
+                               const std::string &parent_name,
+                               std::unordered_set<std::string> *visited) {
   visited->insert(node_name);
   // While traversing the module graph, if `node` is in the task graph and is
   // not `parent`, then it must be  the child of `parent`.

--- a/core/module.cc
+++ b/core/module.cc
@@ -68,7 +68,7 @@ bool ModuleBuilder::DeregisterModuleClass(const std::string &class_name) {
 
   // Check if any module of the class still exists
   const ModuleBuilder *builder = &(it->second);
-  if (ModuleGraph::ExistModuleClass(builder))
+  if (ModuleGraph::HasModuleOfClass(builder))
     return false;
 
   all_module_builders_holder().erase(it);

--- a/core/module.h
+++ b/core/module.h
@@ -52,33 +52,6 @@ using bess::gate_idx_t;
 #define MAX_TASKS_PER_MODULE 32
 #define UNCONSTRAINED_SOCKET ((0x1ull << MAX_NUMA_NODE) - 1)
 
-// Represents a node in `module_graph_`.
-class Node {
- public:
-  // Creates a new Node that represents `module_`.
-  Node(Module *module) : module_(module), children_() {}
-
-  // Add a child to the node.
-  bool AddChild(const std::string &child) {
-    return children_.insert(child).second;
-  }
-
-  // Remove a child from the node.
-  void RemoveChild(const std::string &child) { children_.erase(child); }
-
-  const Module *module() const { return module_; }
-  const std::unordered_set<std::string> &children() const { return children_; }
-
- private:
-  // Module that this Node represents.
-  Module *module_;
-
-  // Children of `module_` in the pipeline.
-  std::unordered_set<std::string> children_;
-
-  DISALLOW_COPY_AND_ASSIGN(Node);
-};
-
 struct task_result {
   bool block;
   uint32_t packets;
@@ -199,51 +172,6 @@ class ModuleBuilder {
   const std::string help_text_;
   const Commands cmds_;
   const module_init_func_t init_func_;
-};
-
-// A static class for managing module graphs
-class ModuleGraph {
- public:
-  // Return true if any module from the builder exists
-  static bool ExistModuleClass(const ModuleBuilder *);
-
-  // Add a module to the collection. Returns true on success, false otherwise.
-  static bool AddModule(Module *m);
-
-  // Remove a module from the collection. Returns 0 on success, -errno
-  // otherwise.
-  static int DestroyModule(Module *m, bool erase = true);
-  static void DestroyAllModules();
-
-  static const std::map<std::string, Module *> &all_modules();
-
-  static std::string GenerateDefaultName(const std::string &class_name,
-                                         const std::string &default_template);
-
-  // Connects two modules (`to` and `from`) together in `module_graph_`.
-  static bool AddEdge(const std::string &from, const std::string &to);
-
-  // Disconnects two modules (`to` and `from`) together in `module_graph_`.
-  static bool RemoveEdge(const std::string &from, const std::string &to);
-
- private:
-  // Updates the parents of modules with tasks by traversing `module_graph_` and
-  // ignoring all modules that are not tasks.
-  static bool UpdateTaskGraph();
-
-  // Finds the next module that implements a task, and updates it's parents
-  // accordingly.
-  static bool FindNextTask(const std::string &node_name,
-                           const std::string &parent_name,
-                           std::unordered_set<std::string> *visited);
-
-  // A graph of all the modules in the current pipeline.
-  static std::unordered_map<std::string, Node> module_graph_;
-
-  // All modules that are tasks in the current pipeline.
-  static std::unordered_set<std::string> tasks_;
-
-  static std::map<std::string, Module *> all_modules_;
 };
 
 class ModuleTask;

--- a/core/module.h
+++ b/core/module.h
@@ -98,7 +98,7 @@ struct Command {
 using Commands = std::vector<struct Command>;
 
 // A class for managing modules of 'a particular type'.
-// It creates new modules and forwarding module-specific commands
+// Creates new modules and forwards module-specific commands.
 class ModuleBuilder {
  public:
   ModuleBuilder(
@@ -129,8 +129,7 @@ class ModuleBuilder {
       bool reset = false);
   static const std::map<std::string, ModuleBuilder> &all_module_builders();
 
-  /* returns a pointer to the created module.
-   * if error, returns nullptr and *perr is set */
+  /* returns a pointer to the created module */
   Module *CreateModule(const std::string &name,
                        bess::metadata::Pipeline *pipeline) const;
 

--- a/core/module.h
+++ b/core/module.h
@@ -204,7 +204,6 @@ class ModuleBuilder {
 // A static class for managing module graphs
 class ModuleGraph {
  public:
-
   // Return true if any module from the builder exists
   static bool ExistModuleClass(const ModuleBuilder *);
 

--- a/core/module_bench.cc
+++ b/core/module_bench.cc
@@ -28,6 +28,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "module.h"
+#include "module_graph.h"
 
 #include <benchmark/benchmark.h>
 #include <glog/logging.h>

--- a/core/module_bench.cc
+++ b/core/module_bench.cc
@@ -92,14 +92,14 @@ class ModuleFixture : public benchmark::Fixture {
     Module *last;
 
     src_ = builder_src.CreateModule("src0", &bess::metadata::default_pipeline);
-    ModuleBuilder::AddModule(src_);
+    ModuleGraph::AddModule(src_);
 
     last = src_;
 
     for (int i = 0; i < chain_length; i++) {
       Module *relay = builder_relay.CreateModule(
           "relay" + std::to_string(i), &bess::metadata::default_pipeline);
-      ModuleBuilder::AddModule(relay);
+      ModuleGraph::AddModule(relay);
 
       relays.push_back(relay);
       int ret = last->ConnectModules(0, relay, 0);
@@ -109,7 +109,7 @@ class ModuleFixture : public benchmark::Fixture {
   }
 
   void TearDown(benchmark::State &) override {
-    ModuleBuilder::DestroyAllModules();
+    ModuleGraph::DestroyAllModules();
   }
 
   Module *src_;

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -96,7 +96,7 @@ const std::map<std::string, Module *> &ModuleGraph::GetAllModules() {
   return all_modules_;
 }
 
-bool ModuleGraph::ExistModuleClass(const ModuleBuilder *builder) {
+bool ModuleGraph::HasModuleOfClass(const ModuleBuilder *builder) {
   for (auto const &e : all_modules_) {
     if (e.second->module_builder() == builder) {
       return true;

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
@@ -38,8 +38,6 @@ std::map<std::string, Module *> ModuleGraph::all_modules_;
 std::unordered_map<std::string, Node> ModuleGraph::module_graph_;
 std::unordered_set<std::string> ModuleGraph::tasks_;
 
-// Finds the next module that implements a task, and updates it's parents
-// accordingly.
 bool ModuleGraph::FindNextTask(const std::string &node_name,
                                const std::string &parent_name,
                                std::unordered_set<std::string> *visited) {
@@ -80,8 +78,6 @@ bool ModuleGraph::FindNextTask(const std::string &node_name,
   return true;
 }
 
-// Updates the parents of modules with tasks by traversing `module_graph_` and
-// ignoring all modules that are not tasks.
 bool ModuleGraph::UpdateTaskGraph() {
   for (auto const &task : tasks_) {
     std::unordered_set<std::string> visited;

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -1,0 +1,233 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "module_graph.h"
+
+#include <glog/logging.h>
+
+#include "module.h"
+
+std::map<std::string, Module *> ModuleGraph::all_modules_;
+std::unordered_map<std::string, Node> ModuleGraph::module_graph_;
+std::unordered_set<std::string> ModuleGraph::tasks_;
+
+// Finds the next module that implements a task, and updates it's parents
+// accordingly.
+bool ModuleGraph::FindNextTask(const std::string &node_name,
+                               const std::string &parent_name,
+                               std::unordered_set<std::string> *visited) {
+  visited->insert(node_name);
+  // While traversing the module graph, if `node` is in the task graph and is
+  // not `parent`, then it must be  the child of `parent`.
+  if (node_name != parent_name && tasks_.find(node_name) != tasks_.end()) {
+    auto parent_it = all_modules_.find(parent_name);
+    auto node_it = all_modules_.find(node_name);
+    if (parent_it == all_modules_.end() || node_it == all_modules_.end()) {
+      return false;
+    }
+
+    Module *node = node_it->second;
+    Module *parent = parent_it->second;
+    for (Module *it : node->parent_tasks_) {
+      if (it == parent) {
+        return true;
+      }
+    }
+    node->parent_tasks_.push_back(parent);
+    return true;
+  }
+
+  auto node_it = module_graph_.find(node_name);
+  if (node_it == module_graph_.end()) {
+    return false;
+  }
+
+  for (auto &child_name : node_it->second.children()) {
+    if (visited->count(child_name) > 0) {
+      continue;
+    }
+    if (!FindNextTask(child_name, parent_name, visited)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Updates the parents of modules with tasks by traversing `module_graph_` and
+// ignoring all modules that are not tasks.
+bool ModuleGraph::UpdateTaskGraph() {
+  for (auto const &task : tasks_) {
+    std::unordered_set<std::string> visited;
+    if (!FindNextTask(task, task, &visited)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const std::map<std::string, Module *> &ModuleGraph::GetAllModules() {
+  return all_modules_;
+}
+
+bool ModuleGraph::ExistModuleClass(const ModuleBuilder *builder) {
+  for (auto const &e : all_modules_) {
+    if (e.second->module_builder() == builder) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ModuleGraph::AddEdge(const std::string &from, const std::string &to) {
+  auto from_it = module_graph_.find(from);
+  if (from_it == module_graph_.end() || module_graph_.count(to) == 0) {
+    return false;
+  }
+  from_it->second.AddChild(to);
+  return UpdateTaskGraph();
+}
+
+bool ModuleGraph::RemoveEdge(const std::string &from, const std::string &to) {
+  auto from_node = module_graph_.find(from);
+  if (from_node == module_graph_.end() || module_graph_.count(to) == 0) {
+    return false;
+  }
+
+  from_node->second.RemoveChild(to);
+
+  // We need to regenerate the task graph.
+  for (auto const &task : tasks_) {
+    auto it = all_modules_.find(task);
+    if (it != all_modules_.end()) {
+      it->second->parent_tasks_.clear();
+    }
+  }
+  return UpdateTaskGraph();
+}
+
+bool ModuleGraph::AddModule(Module *m) {
+  if (m->is_task_) {
+    if (!tasks_.insert(m->name()).second) {
+      return false;
+    }
+  }
+
+  bool module_added = all_modules_.insert({m->name(), m}).second;
+  if (!module_added) {
+    return false;
+  }
+
+  return module_graph_
+      .emplace(std::piecewise_construct, std::forward_as_tuple(m->name()),
+               std::forward_as_tuple(m))
+      .second;
+}
+
+int ModuleGraph::DestroyModule(Module *m, bool erase) {
+  int ret;
+  m->DeInit();
+
+  // disconnect from upstream modules.
+  for (size_t i = 0; i < m->igates_.size(); i++) {
+    ret = m->DisconnectModulesUpstream(i);
+    if (ret) {
+      return ret;
+    }
+  }
+
+  // disconnect downstream modules
+  for (size_t i = 0; i < m->ogates_.size(); i++) {
+    ret = m->DisconnectModules(i);
+    if (ret) {
+      return ret;
+    }
+  }
+
+  m->DestroyAllTasks();
+  m->DeregisterAllAttributes();
+
+  if (erase) {
+    all_modules_.erase(m->name());
+  }
+
+  module_graph_.erase(m->name());
+  if (m->is_task_) {
+    tasks_.erase(m->name());
+  }
+
+  delete m;
+  return 0;
+}
+
+void ModuleGraph::DestroyAllModules() {
+  int ret;
+  for (auto it = all_modules_.begin(); it != all_modules_.end();) {
+    auto it_next = std::next(it);
+    ret = DestroyModule(it->second, false);
+    if (ret) {
+      LOG(ERROR) << "Error destroying module '" << it->first
+                 << "' (errno = " << ret << ")";
+    } else {
+      all_modules_.erase(it);
+    }
+    it = it_next;
+  }
+}
+
+std::string ModuleGraph::GenerateDefaultName(
+    const std::string &class_name, const std::string &default_template) {
+  std::string name_template;
+
+  if (default_template == "") {
+    std::ostringstream ss;
+    char last_char = '\0';
+    for (auto t : class_name) {
+      if (last_char != '\0' && islower(last_char) && isupper(t))
+        ss << '_';
+
+      ss << char(tolower(t));
+      last_char = t;
+    }
+    name_template = ss.str();
+  } else {
+    name_template = default_template;
+  }
+
+  for (int i = 0;; i++) {
+    std::ostringstream ss;
+    ss << name_template << i;
+    std::string name = ss.str();
+
+    if (!all_modules_.count(name))
+      return name;
+  }
+
+  promise_unreachable();
+}

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -113,4 +113,9 @@ class ModuleGraph {
   static std::map<std::string, Module *> all_modules_;
 };
 
+/*!
+ * Update information about what workers are accessing what module.
+ */
+void propagate_active_worker();
+
 #endif

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
@@ -68,6 +68,7 @@ class Node {
   DISALLOW_COPY_AND_ASSIGN(Node);
 };
 
+// Manages a global graph of modules
 class ModuleGraph {
  public:
   // Return true if any module from the builder exists
@@ -97,8 +98,8 @@ class ModuleGraph {
   // ignoring all modules that are not tasks.
   static bool UpdateTaskGraph();
 
-  // Finds the next module that implements a task, and updates it's parents
-  // accordingly.
+  // Finds the next module that implements a task along the pipeline.
+  // If if find any, then the current task becomes the parent of the next task.
   static bool FindNextTask(const std::string &node_name,
                            const std::string &parent_name,
                            std::unordered_set<std::string> *visited);

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -71,7 +71,7 @@ class Node {
 class ModuleGraph {
  public:
   // Return true if any module from the builder exists
-  static bool ExistModuleClass(const ModuleBuilder *);
+  static bool HasModuleOfClass(const ModuleBuilder *);
 
   // Add a module to the collection. Returns true on success, false otherwise.
   static bool AddModule(Module *m);

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -1,0 +1,116 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_MODULE_GRAPH_H_
+#define BESS_MODULE_GRAPH_H_
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "utils/common.h"
+
+class Module;
+class ModuleBuilder;
+
+// Represents a node in `module_graph_`.
+class Node {
+ public:
+  // Creates a new Node that represents `module_`.
+  Node(Module *module) : module_(module), children_() {}
+
+  // Add a child to the node.
+  bool AddChild(const std::string &child) {
+    return children_.insert(child).second;
+  }
+
+  // Remove a child from the node.
+  void RemoveChild(const std::string &child) { children_.erase(child); }
+
+  const Module *module() const { return module_; }
+  const std::unordered_set<std::string> &children() const { return children_; }
+
+ private:
+  // Module that this Node represents.
+  Module *module_;
+
+  // Children of `module_` in the pipeline.
+  std::unordered_set<std::string> children_;
+
+  DISALLOW_COPY_AND_ASSIGN(Node);
+};
+
+class ModuleGraph {
+ public:
+  // Return true if any module from the builder exists
+  static bool ExistModuleClass(const ModuleBuilder *);
+
+  // Add a module to the collection. Returns true on success, false otherwise.
+  static bool AddModule(Module *m);
+
+  // Remove a module from the collection. Returns 0 on success, -errno
+  // otherwise.
+  static int DestroyModule(Module *m, bool erase = true);
+  static void DestroyAllModules();
+
+  static const std::map<std::string, Module *> &GetAllModules();
+
+  static std::string GenerateDefaultName(const std::string &class_name,
+                                         const std::string &default_template);
+
+  // Connects two modules (`to` and `from`) together in `module_graph_`.
+  static bool AddEdge(const std::string &from, const std::string &to);
+
+  // Disconnects two modules (`to` and `from`) together in `module_graph_`.
+  static bool RemoveEdge(const std::string &from, const std::string &to);
+
+ private:
+  // Updates the parents of modules with tasks by traversing `module_graph_` and
+  // ignoring all modules that are not tasks.
+  static bool UpdateTaskGraph();
+
+  // Finds the next module that implements a task, and updates it's parents
+  // accordingly.
+  static bool FindNextTask(const std::string &node_name,
+                           const std::string &parent_name,
+                           std::unordered_set<std::string> *visited);
+
+  // A graph of all the modules in the current pipeline.
+  static std::unordered_map<std::string, Node> module_graph_;
+
+  // All modules that are tasks in the current pipeline.
+  static std::unordered_set<std::string> tasks_;
+
+  // All modules
+  static std::map<std::string, Module *> all_modules_;
+};
+
+#endif

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -106,7 +106,7 @@ int create_acme(const char *name, Module **m) {
     mod_name = name;
   } else {
     mod_name = ModuleGraph::GenerateDefaultName(builder.class_name(),
-                                                  builder.name_template());
+                                                builder.name_template());
   }
 
   *m = builder.CreateModule(mod_name, &bess::metadata::default_pipeline);

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -88,7 +88,7 @@ class ModuleTester : public ::testing::Test {
 
   virtual void SetUp() {}
 
-  virtual void TearDown() { ModuleBuilder::DestroyAllModules(); }
+  virtual void TearDown() { ModuleGraph::DestroyAllModules(); }
 
   AcmeModule_class AcmeModule_singleton;
   AcmeModuleWithTask_class AcmeModuleWithTask_singleton;
@@ -100,12 +100,12 @@ int create_acme(const char *name, Module **m) {
 
   std::string mod_name;
   if (name) {
-    if (ModuleBuilder::all_modules().count(name)) {
+    if (ModuleGraph::all_modules().count(name)) {
       return EEXIST;
     }
     mod_name = name;
   } else {
-    mod_name = ModuleBuilder::GenerateDefaultName(builder.class_name(),
+    mod_name = ModuleGraph::GenerateDefaultName(builder.class_name(),
                                                   builder.name_template());
   }
 
@@ -117,7 +117,7 @@ int create_acme(const char *name, Module **m) {
   CommandResponse ret = (*m)->InitWithGenericArg(arg);
   EXPECT_EQ(42, ret.error().code());
 
-  if (!ModuleBuilder::AddModule(*m)) {
+  if (!ModuleGraph::AddModule(*m)) {
     return 1;
   }
 
@@ -133,7 +133,7 @@ int create_acme_with_task(const char *name, Module **m) {
   const ModuleBuilder &builder =
       ModuleBuilder::all_module_builders().find("AcmeModuleWithTask")->second;
 
-  if (ModuleBuilder::all_modules().count(name)) {
+  if (ModuleGraph::all_modules().count(name)) {
     return EEXIST;
   }
 
@@ -144,7 +144,7 @@ int create_acme_with_task(const char *name, Module **m) {
   CommandResponse ret = (*m)->InitWithGenericArg(arg);
   EXPECT_EQ(0, ret.error().code());
 
-  if (!ModuleBuilder::AddModule(*m)) {
+  if (!ModuleGraph::AddModule(*m)) {
     return 1;
   }
 
@@ -197,9 +197,9 @@ TEST_F(ModuleTester, CreateModuleWithName) {
 
   EXPECT_EQ(0, create_acme("bar", &m1));
   ASSERT_NE(nullptr, m1);
-  EXPECT_EQ(1, ModuleBuilder::all_modules().size());
+  EXPECT_EQ(1, ModuleGraph::all_modules().size());
   EXPECT_EQ(EEXIST, create_acme("bar", &m2));
-  EXPECT_EQ(1, ModuleBuilder::all_modules().count("bar"));
+  EXPECT_EQ(1, ModuleGraph::all_modules().count("bar"));
 }
 
 // Check that module builders create modules with generated names
@@ -208,12 +208,12 @@ TEST_F(ModuleTester, CreateModuleGenerateName) {
 
   EXPECT_EQ(0, create_acme(nullptr, &m));
   ASSERT_NE(nullptr, m);
-  EXPECT_EQ(1, ModuleBuilder::all_modules().size());
-  EXPECT_EQ(1, ModuleBuilder::all_modules().count("acme_module0"));
+  EXPECT_EQ(1, ModuleGraph::all_modules().size());
+  EXPECT_EQ(1, ModuleGraph::all_modules().count("acme_module0"));
   EXPECT_EQ(0, create_acme(nullptr, &m));
   ASSERT_NE(nullptr, m);
-  EXPECT_EQ(2, ModuleBuilder::all_modules().size());
-  EXPECT_EQ(1, ModuleBuilder::all_modules().count("acme_module1"));
+  EXPECT_EQ(2, ModuleGraph::all_modules().size());
+  EXPECT_EQ(1, ModuleGraph::all_modules().count("acme_module1"));
 }
 
 TEST_F(ModuleTester, RunCommand) {
@@ -263,20 +263,20 @@ TEST_F(ModuleTester, ResetModules) {
     EXPECT_EQ(0, create_acme(nullptr, &m));
     ASSERT_NE(nullptr, m);
   }
-  EXPECT_EQ(10, ModuleBuilder::all_modules().size());
+  EXPECT_EQ(10, ModuleGraph::all_modules().size());
 
-  ModuleBuilder::DestroyAllModules();
-  EXPECT_EQ(0, ModuleBuilder::all_modules().size());
+  ModuleGraph::DestroyAllModules();
+  EXPECT_EQ(0, ModuleGraph::all_modules().size());
 }
 
 TEST(ModuleBuilderTest, GenerateDefaultNameTemplate) {
-  std::string name1 = ModuleBuilder::GenerateDefaultName("FooBar", "foo");
+  std::string name1 = ModuleGraph::GenerateDefaultName("FooBar", "foo");
   EXPECT_EQ("foo0", name1);
 
-  std::string name2 = ModuleBuilder::GenerateDefaultName("FooBar", "");
+  std::string name2 = ModuleGraph::GenerateDefaultName("FooBar", "");
   EXPECT_EQ("foo_bar0", name2);
 
-  std::string name3 = ModuleBuilder::GenerateDefaultName("FooABCBar", "");
+  std::string name3 = ModuleGraph::GenerateDefaultName("FooABCBar", "");
   EXPECT_EQ("foo_abcbar0", name3);
 }
 
@@ -325,7 +325,7 @@ TEST_F(ModuleTester, GenerateTCGraph) {
   t4->SignalUnderload();
   ASSERT_EQ(0, t1->children_overload());
 
-  ModuleBuilder::DestroyModule(t1, true);
+  ModuleGraph::DestroyModule(t1, true);
   EXPECT_EQ(0, t2->parent_tasks().size());
   EXPECT_EQ(0, t3->parent_tasks().size());
   EXPECT_EQ(0, t4->parent_tasks().size());

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -28,6 +28,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "module.h"
+#include "module_graph.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -100,7 +101,7 @@ int create_acme(const char *name, Module **m) {
 
   std::string mod_name;
   if (name) {
-    if (ModuleGraph::all_modules().count(name)) {
+    if (ModuleGraph::GetAllModules().count(name)) {
       return EEXIST;
     }
     mod_name = name;
@@ -133,7 +134,7 @@ int create_acme_with_task(const char *name, Module **m) {
   const ModuleBuilder &builder =
       ModuleBuilder::all_module_builders().find("AcmeModuleWithTask")->second;
 
-  if (ModuleGraph::all_modules().count(name)) {
+  if (ModuleGraph::GetAllModules().count(name)) {
     return EEXIST;
   }
 
@@ -197,9 +198,9 @@ TEST_F(ModuleTester, CreateModuleWithName) {
 
   EXPECT_EQ(0, create_acme("bar", &m1));
   ASSERT_NE(nullptr, m1);
-  EXPECT_EQ(1, ModuleGraph::all_modules().size());
+  EXPECT_EQ(1, ModuleGraph::GetAllModules().size());
   EXPECT_EQ(EEXIST, create_acme("bar", &m2));
-  EXPECT_EQ(1, ModuleGraph::all_modules().count("bar"));
+  EXPECT_EQ(1, ModuleGraph::GetAllModules().count("bar"));
 }
 
 // Check that module builders create modules with generated names
@@ -208,12 +209,12 @@ TEST_F(ModuleTester, CreateModuleGenerateName) {
 
   EXPECT_EQ(0, create_acme(nullptr, &m));
   ASSERT_NE(nullptr, m);
-  EXPECT_EQ(1, ModuleGraph::all_modules().size());
-  EXPECT_EQ(1, ModuleGraph::all_modules().count("acme_module0"));
+  EXPECT_EQ(1, ModuleGraph::GetAllModules().size());
+  EXPECT_EQ(1, ModuleGraph::GetAllModules().count("acme_module0"));
   EXPECT_EQ(0, create_acme(nullptr, &m));
   ASSERT_NE(nullptr, m);
-  EXPECT_EQ(2, ModuleGraph::all_modules().size());
-  EXPECT_EQ(1, ModuleGraph::all_modules().count("acme_module1"));
+  EXPECT_EQ(2, ModuleGraph::GetAllModules().size());
+  EXPECT_EQ(1, ModuleGraph::GetAllModules().count("acme_module1"));
 }
 
 TEST_F(ModuleTester, RunCommand) {
@@ -263,10 +264,10 @@ TEST_F(ModuleTester, ResetModules) {
     EXPECT_EQ(0, create_acme(nullptr, &m));
     ASSERT_NE(nullptr, m);
   }
-  EXPECT_EQ(10, ModuleGraph::all_modules().size());
+  EXPECT_EQ(10, ModuleGraph::GetAllModules().size());
 
   ModuleGraph::DestroyAllModules();
-  EXPECT_EQ(0, ModuleGraph::all_modules().size());
+  EXPECT_EQ(0, ModuleGraph::GetAllModules().size());
 }
 
 TEST(ModuleBuilderTest, GenerateDefaultNameTemplate) {

--- a/core/task.cc
+++ b/core/task.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "task.h"
+
+#include <unordered_set>
+
+#include "module.h"
+
+// Called when the leaf that owns this task is destroyed.
+void Task::Detach() {
+  if (module_task_) {
+    module_task_->SetTC(nullptr);
+  }
+}
+
+// Called when the leaf that owns this task is created.
+void Task::Attach(bess::LeafTrafficClass<Task> *c) {
+  if (module_task_) {
+    module_task_->SetTC(c);
+  }
+}
+
+struct task_result Task::operator()(void) const {
+  return module_->RunTask(arg_);
+}
+
+/*!
+ * Compute constraints for the pipeline starting at this task.
+ */
+placement_constraint Task::GetSocketConstraints() const {
+  if (module_) {
+    std::unordered_set<const Module *> visited;
+    return module_->ComputePlacementConstraints(&visited);
+  } else {
+    return UNCONSTRAINED_SOCKET;
+  }
+}
+
+/*!
+ * Add a worker to the set of workers that call this task.
+ */
+void Task::AddActiveWorker(int wid) const {
+  if (module_) {
+    module_->AddActiveWorker(wid, module_task_);
+  }
+}

--- a/core/task.cc
+++ b/core/task.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //

--- a/core/task.h
+++ b/core/task.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //

--- a/core/task.h
+++ b/core/task.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_TASK_H_
+#define BESS_TASK_H_
+
+#include <string>
+
+struct task_result {
+  bool block;
+  uint32_t packets;
+  uint64_t bits;
+};
+
+typedef uint16_t task_id_t;
+typedef uint64_t placement_constraint;
+
+class Module;
+class ModuleTask;
+
+namespace bess {
+template <typename CallableTask>
+class LeafTrafficClass;
+}  // namespace bess
+
+// Functor used by a leaf in a Worker's Scheduler to run a task in a module.
+class Task {
+ public:
+  // When this task is scheduled it will execute 'm' with 'arg'.  When the
+  // associated leaf is created/destroyed, 'module_task' will be updated.
+  Task(Module *m, void *arg, ModuleTask *module_task)
+      : module_(m), arg_(arg), module_task_(module_task) {}
+
+  // Called when the leaf that owns this task is destroyed.
+  void Detach();
+
+  // Called when the leaf that owns this task is created.
+  void Attach(bess::LeafTrafficClass<Task> *c);
+
+  struct task_result operator()(void) const;
+
+  /*!
+   * Compute constraints for the pipeline starting at this task.
+   */
+  placement_constraint GetSocketConstraints() const;
+
+  /*!
+   * Add a worker to the set of workers that call this task.
+   */
+  void AddActiveWorker(int wid) const;
+
+  Module *module() const { return module_; }
+
+  ModuleTask *module_task() const { return module_task_; }
+
+ private:
+  // Used by operator().
+  Module *module_;
+  void *arg_;
+
+  // Used to notify a module that a leaf is being created/destroyed.
+  ModuleTask *module_task_;
+};
+
+// Stores the arguments of a task created by a module.
+class ModuleTask {
+ public:
+  // Doesn't take ownership of 'arg' and 'c'.  'c' can be null and it
+  // can be changed later with SetTC()
+  ModuleTask(void *arg, bess::LeafTrafficClass<Task> *c) : arg_(arg), c_(c) {}
+
+  ~ModuleTask() {}
+
+  void *arg() { return arg_; }
+
+  void SetTC(bess::LeafTrafficClass<Task> *c) { c_ = c; }
+
+  bess::LeafTrafficClass<Task> *GetTC() { return c_; }
+
+ private:
+  void *arg_;  // Auxiliary value passed to Module::RunTask().
+  bess::LeafTrafficClass<Task> *c_;  // Leaf TC associated with this task.
+};
+
+#endif  // BESS_TASK_H_

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -62,11 +62,6 @@ Worker *volatile workers[Worker::kMaxWorkers];
 
 using bess::TrafficClassBuilder;
 using namespace bess::traffic_class_initializer_types;
-using bess::PriorityTrafficClass;
-using bess::WeightedFairTrafficClass;
-using bess::RoundRobinTrafficClass;
-using bess::RateLimitTrafficClass;
-using bess::LeafTrafficClass;
 
 std::list<std::pair<int, bess::TrafficClass *>> orphan_tcs;
 
@@ -407,15 +402,15 @@ WorkerPauser::WorkerPauser() {
   if (is_any_worker_running()) {
     for (int wid = 0; wid < Worker::kMaxWorkers; wid++) {
       if (is_worker_running(wid)) {
-	workers_paused_.push_back(wid);
-	VLOG(1) << "*** Pausing Worker " << wid << " ***";
-	pause_worker(wid);
-	}
+        workers_paused_.push_back(wid);
+        VLOG(1) << "*** Pausing Worker " << wid << " ***";
+        pause_worker(wid);
+      }
     }
   }
 }
 
-WorkerPauser:: ~WorkerPauser() {
+WorkerPauser::~WorkerPauser() {
   for (int wid : workers_paused_) {
     resume_worker(wid);
     VLOG(1) << "*** Worker " << wid << " Resumed ***";


### PR DESCRIPTION
This PR doesn't change any functionality, but refactor the existing `module.h` and `module.cc` files as they are integrating too much functionality in a file. Once these changes are approved, then I can make change the internal scheduling logic.

Major changes are
- Get global info about `module_graphs` out of `ModuleBuilder` class
- Get `Task/ModuleTask` out of `module.h` 