### PR TITLE
Fix a bug: Sanitizer logs from bessd can be accessible only as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ after_success:
 
 after_failure:
   - more /tmp/bessd.*.INFO.* | cat      # dump all bessd log files
-  - more /tmp/sanitizer* | cat          # dump all sanitizer results
+  - sudo more /tmp/sanitizer* | cat          # dump all sanitizer results
 
 before_deploy:
   - for arch in core2 sandybridge haswell; do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7221472/31568664-81d72626-b02a-11e7-8885-e8565c525548.png)
