### PR TITLE
experimental_scheduler: fix potential segfault

### DIFF
--- a/core/module.cc
+++ b/core/module.cc
@@ -355,6 +355,13 @@ task_id_t Module::RegisterTask(void *arg) {
 void Module::DestroyAllTasks() {
   for (auto task : tasks_) {
     auto c = task->GetTC();
+
+    int wid = c->WorkerId();
+    if (wid >= 0) {
+      bess::Scheduler<Task> *s = workers[wid]->scheduler();
+      s->wakeup_queue().Remove(c);
+    }
+
     CHECK(detach_tc(c));
     delete c;
     delete task;

--- a/core/module.h
+++ b/core/module.h
@@ -570,6 +570,7 @@ class ModuleTask {
   void SetTC(bess::LeafTrafficClass<Task> *c) { c_ = c; }
 
   bess::LeafTrafficClass<Task> *GetTC() { return c_; }
+  const bess::LeafTrafficClass<Task> *GetTC() const { return c_; }
 
  private:
   void *arg_;  // Auxiliary value passed to Module::RunTask().

--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -32,12 +32,12 @@
 #define BESS_SCHEDULER_H_
 
 #include <iostream>
-#include <queue>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "traffic_class.h"
+#include "utils/extended_priority_queue.h"
 #include "worker.h"
 
 namespace bess {
@@ -61,18 +61,23 @@ class SchedWakeupQueue {
     }
   };
 
-  SchedWakeupQueue() : q_(WakeupComp()) {}
+  SchedWakeupQueue() : q_() {}
 
   // Adds the given traffic class to those that are considered blocked.
   void Add(TrafficClass *c) { q_.push(c); }
+
+  // Removes the given traffic class from the blocked list.
+  void Remove(const TrafficClass *c) {
+    const auto del_pred = [&](const TrafficClass *t) { return t == c; };
+    q_.delete_single_element(del_pred);
+  }
 
  private:
   template <typename CallableTasks>
   friend class Scheduler;
 
   // A priority queue of TrafficClasses to wake up ordered by time.
-  std::priority_queue<TrafficClass *, std::vector<TrafficClass *>, WakeupComp>
-      q_;
+  bess::utils::extended_priority_queue<TrafficClass *, WakeupComp> q_;
 };
 
 // The non-instantiable base class for schedulers.  Implements common routines

--- a/core/utils/extended_priority_queue.h
+++ b/core/utils/extended_priority_queue.h
@@ -41,8 +41,9 @@ namespace utils {
 
 // Extends std::priority_queue to support decreasing the key of the top element
 // directly.
-template <typename T>
-class extended_priority_queue : public std::priority_queue<T> {
+template <typename T, typename Cmp = std::less<T>>
+class extended_priority_queue
+    : public std::priority_queue<T, std::vector<T>, Cmp> {
  public:
   T &mutable_top() { return this->c.front(); }
 


### PR DESCRIPTION
Currently the experimental scheduler keeps pointers to the tasks
registered by modules in its WakeUpQueue after they have been deleted.
This could lead to nasty crashes. This commit makes two changes:

- Change Scheduler::WakeUpQueue to use utils/extended_priority_queue
  instead of stl::priority_queue in order to support deletion in the
  middle.

- Change Module::DestroyAllTasks() to remove any references to
  registered tasks from its scheduler's wake up queue.