### PR TITLE
Fix starvation of the RX path in UnixSocketPort

### DIFF
--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -28,7 +28,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <glog/logging.h>
 #include <poll.h>
 #include <signal.h>
@@ -39,7 +38,6 @@
 #include "unix_socket.h"
 
 #define SIG_THREAD_EXIT SIGUSR2
-
 
 void UnixSocketPort::AcceptThread() {
   sigset_t sigset;
@@ -112,7 +110,7 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
   if (arg.min_rx_interval_ns() < 0) {
     min_rx_interval_ns_ = 0;
   } else {
-    min_rx_interval_ns_ = arg.min_rx_interval_ns() ? : kDefaultMinRxInterval;
+    min_rx_interval_ns_ = arg.min_rx_interval_ns() ?: kDefaultMinRxInterval;
   }
 
   listen_fd_ = socket(AF_UNIX, SOCK_SEQPACKET, 0);
@@ -161,9 +159,7 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
     return CommandFailure(errno, "sigaction(SIG_THREAD_EXIT) failed");
   }
 
-  accept_thread_ = std::thread([this]() {
-      this->AcceptThread();
-    });
+  accept_thread_ = std::thread([this]() { this->AcceptThread(); });
 
   return CommandSuccess();
 }

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -38,14 +38,6 @@
 
 #include "unix_socket.h"
 
-// TODO(barath): Clarify these comments.
-// Only one client can be connected at the same time.  Polling sockets is quite
-// exprensive, so we throttle the polling rate.  (by checking sockets once every
-// RECV_TICKS schedules)
-
-// TODO: Revise this once the interrupt mode is  implemented.
-
-#define RECV_SKIP_TICKS 256
 #define SIG_THREAD_EXIT SIGUSR2
 
 
@@ -111,12 +103,16 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
   int num_txq = num_queues[PACKET_DIR_OUT];
   int num_rxq = num_queues[PACKET_DIR_INC];
 
-  size_t addrlen;
-
   int ret;
 
   if (num_txq > 1 || num_rxq > 1) {
     return CommandFailure(EINVAL, "Cannot have more than 1 queue per RX/TX");
+  }
+
+  if (arg.min_rx_interval_ns() < 0) {
+    min_rx_interval_ns_ = 0;
+  } else {
+    min_rx_interval_ns_ = arg.min_rx_interval_ns() ? : kDefaultMinRxInterval;
   }
 
   listen_fd_ = socket(AF_UNIX, SOCK_SEQPACKET, 0);
@@ -135,7 +131,7 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
   }
 
   // This doesn't include the trailing null character.
-  addrlen = sizeof(addr_.sun_family) + strlen(addr_.sun_path);
+  size_t addrlen = sizeof(addr_.sun_family) + strlen(addr_.sun_path);
 
   // Non-abstract socket address?
   if (addr_.sun_path[0] != '@') {
@@ -157,7 +153,6 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
     return CommandFailure(errno, "listen() failed");
   }
 
-
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = AcceptThreadHandler;
@@ -165,7 +160,6 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
     DeInit();
     return CommandFailure(errno, "sigaction(SIG_THREAD_EXIT) failed");
   }
-
 
   accept_thread_ = std::thread([this]() {
       this->AcceptThread();
@@ -195,25 +189,25 @@ int UnixSocketPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
   DCHECK_EQ(qid, 0);
 
   if (client_fd == kNotConnectedFd) {
+    last_idle_ns_ = 0;
     return 0;
   }
 
-  if (recv_skip_cnt_) {
-    recv_skip_cnt_--;
+  uint64_t now_ns = ctx.current_ns();
+  if (now_ns - last_idle_ns_ < min_rx_interval_ns_) {
     return 0;
   }
 
   int received = 0;
   while (received < cnt) {
     bess::Packet *pkt = static_cast<bess::Packet *>(bess::Packet::Alloc());
-    int ret;
 
     if (!pkt) {
       break;
     }
 
     // Datagrams larger than 2KB will be truncated.
-    ret = recv(client_fd, pkt->data(), SNBUF_DATA, 0);
+    int ret = recv(client_fd, pkt->data(), SNBUF_DATA, 0);
 
     if (ret > 0) {
       pkt->append(ret);
@@ -237,9 +231,7 @@ int UnixSocketPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
     break;
   }
 
-  if (received == 0) {
-    recv_skip_cnt_ = RECV_SKIP_TICKS;
-  }
+  last_idle_ns_ = (received == 0) ? now_ns : 0;
 
   return received;
 }

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -80,10 +80,10 @@ class UnixSocketPort final : public Port {
   static const uint64_t kDefaultMinRxInterval = 50000;  // 50 microsec
 
   /*!
-  * Calling recv() system call is expensive so we may not want to invoke it
-  * too frequently. min_rx_interval_ns_ is a configurable parameter to throttle
-  * the polling rate.
-  */
+   * Calling recv() system call is expensive so we may not want to invoke it
+   * too frequently. min_rx_interval_ns_ is a configurable parameter to throttle
+   * the rate of busy-wait polling.
+   */
   uint64_t min_rx_interval_ns_;
   uint64_t last_idle_ns_;
 

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -43,13 +43,14 @@
 
 /*!
  * This driver binds a port to a UNIX socket to communicate with a local
- * process.
+ * process. Only one client can be connected at the same time.
  */
 class UnixSocketPort final : public Port {
  public:
   UnixSocketPort()
       : Port(),
-        recv_skip_cnt_(),
+        min_rx_interval_ns_(),
+        last_idle_ns_(),
         accept_thread_stop_req_(false),
         listen_fd_(kNotConnectedFd),
         addr_(),
@@ -59,7 +60,7 @@ class UnixSocketPort final : public Port {
    * Initialize the port, ie, open the socket.
    *
    * PARAMETERS:
-   * * string path : file name to bind the socket ti.
+   * * string path : file name to bind the socket to.
    */
   CommandResponse Init(const bess::pb::UnixSocketPortArg &arg);
 
@@ -68,50 +69,23 @@ class UnixSocketPort final : public Port {
    */
   void DeInit() override;
 
-  /*!
-   * Receives packets from the device.
-   *
-   * PARAMETERS:
-   * * queue_t quid : socket has no notion of queues so this is ignored.
-   * * bess::Packet ** pkts   : buffer to store received packets in to.
-   * * int cnt  : max number of packets to pull.
-   *
-   * EXPECTS:
-   * * Only call this after calling Init with a device.
-   * * Don't call this after calling DeInit().
-   *
-   * RETURNS:
-   * * Total number of packets received (<=cnt)
-   */
+  // Multi-queue is not supported. qid must be 0.
   int RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
-
-  /*!
-   * Sends packets out on the device.
-   *
-   * PARAMETERS:
-   * * queue_t quid : PCAP has no notion of queues so this is ignored.
-   * * bess::Packet ** pkts   : packets to transmit.
-   * * int cnt  : number of packets in pkts to transmit.
-   *
-   * EXPECTS:
-   * * Only call this after calling Init with a device.
-   * * Don't call this after calling DeInit().
-   *
-   * RETURNS:
-   * * Total number of packets sent (<=cnt).
-   */
   int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
  private:
   // Value for a disconnected socket.
   static const int kNotConnectedFd = -1;
 
+  static const uint64_t kDefaultMinRxInterval = 50000;  // 50 microsec
+
   /*!
-  * Calling recv() system call is expensive so we only do it every
-  * RECV_SKIP_TICKS times -- this counter keeps track of how many ticks its been
-  * since we last called recv().
-  * */
-  uint32_t recv_skip_cnt_;
+  * Calling recv() system call is expensive so we may not want to invoke it
+  * too frequently. min_rx_interval_ns_ is a configurable parameter to throttle
+  * the polling rate.
+  */
+  uint64_t min_rx_interval_ns_;
+  uint64_t last_idle_ns_;
 
   /*!
    * Function for the thread accepting and monitoring clients (accept thread).

--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -345,7 +345,7 @@ class ExperimentalScheduler : public Scheduler<CallableTask> {
       now = rdtsc();
 
       if (ret.packets == 0 && ret.block) {
-        constexpr uint64_t kMaxWait = 1ull << 32;
+        constexpr uint64_t kMaxWait = 1ull << 20;
         uint64_t wait = std::min(kMaxWait, leaf->wait_cycles() << 1);
         leaf->set_wait_cycles(wait);
 

--- a/protobuf/ports/port_msg.proto
+++ b/protobuf/ports/port_msg.proto
@@ -45,7 +45,14 @@ message PMDPortArg {
 }
 
 message UnixSocketPortArg {
+  /// Set the first character to "@" in place of \0 for abstract path
+  /// See manpage for unix(7).
   string path = 1;
+
+  /// Minimum RX polling interval for system calls, when *idle*.
+  /// Use a negative number for unthrottled polling. If unspecified or 0,
+  /// it is set to 50,000 (50 microseconds, or 20k polls per second)
+  int64 min_rx_interval_ns = 2;
 }
 
 message ZeroCopyVPortArg {


### PR DESCRIPTION
Due to the cost of system calls, UnixSocketPort had a throttling mechanism for RX busy-wait polling. When the port is idle, `recv()` is invoked every 256 ticks (in other words, scheduling rounds). This behavior becomes problematic when it is used with the experimental scheduler. Since the scheduler slows down idle tasks, when combined with UnixSocketPort's internal mechanism, `recv()` is hardly invoked (every 256 * 2^32 cycles, which translates to a few minutes). This PR makes two changes:

* The maximum exponential backoff of the experimental scheculer is now 2^20 cycles,  reduced from 2^32 cycles.
* UnixSocketPort throttles based on wall-clock time (by default 50us, but configurable), not on tick.

Note: while this throttling feature looks redundant with the role of RateLimit traffic class, it is slightly different. The RX throttling kicks in only when the port is idle. It is rather similar to interrupt coalescing in kernel device drivers.