### PR TITLE
fix race in unix_socket.cc

### DIFF
--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -81,6 +81,10 @@ void UnixSocketPort::AcceptThread() {
         close(fd);
       } else {
         client_fd_ = fd;
+        if (confirm_connect_) {
+          // Send confirmation that we've accepted their connect().
+          send(fd, "yes", 4, 0);
+        }
       }
 
     } else if (fds[1].revents & (POLLRDHUP | POLLHUP)) {
@@ -112,6 +116,8 @@ CommandResponse UnixSocketPort::Init(const bess::pb::UnixSocketPortArg &arg) {
   } else {
     min_rx_interval_ns_ = arg.min_rx_interval_ns() ?: kDefaultMinRxInterval;
   }
+
+  confirm_connect_ = arg.confirm_connect();
 
   listen_fd_ = socket(AF_UNIX, SOCK_SEQPACKET, 0);
   if (listen_fd_ < 0) {

--- a/core/drivers/unix_socket.h
+++ b/core/drivers/unix_socket.h
@@ -88,6 +88,12 @@ class UnixSocketPort final : public Port {
   uint64_t last_idle_ns_;
 
   /*!
+   * Allow user to detect that the accepting/monitoring thread has
+   * finished its accept() call and that the socket is now connected.
+   */
+  bool confirm_connect_;
+
+  /*!
    * Function for the thread accepting and monitoring clients (accept thread).
    */
   void AcceptThread();

--- a/protobuf/ports/port_msg.proto
+++ b/protobuf/ports/port_msg.proto
@@ -53,6 +53,11 @@ message UnixSocketPortArg {
   /// Use a negative number for unthrottled polling. If unspecified or 0,
   /// it is set to 50,000 (50 microseconds, or 20k polls per second)
   int64 min_rx_interval_ns = 2;
+
+  /// If set, the port driver will send a confirmation once
+  /// the port is connected.  This lets pybess avoid a race during
+  /// testing.  See bessctl/test_utils.py for details.
+  bool confirm_connect = 3;
 }
 
 message ZeroCopyVPortArg {


### PR DESCRIPTION
As unlikely as it seems, the Python tests for bessd are triggering
a race between the unix-socket accept() thread and the vlan test
code running in the Python interpreter.

There is a long comment in bessctl/test_utils.py explaining the race.
On the BESS side, we add a new boolean, `confirm_connect`, to the unix-
socket port, and send a magic number -- the byte-string "yes\0" --
across the socket to indicate that the accept thread has set it all up
for use.