### PR TITLE
clean up unittests a bit

### DIFF
--- a/bessctl/module_tests/vlan.py
+++ b/bessctl/module_tests/vlan.py
@@ -34,12 +34,8 @@ from test_utils import *
 class BessVlanTest(BessModuleTestCase):
 
     def test_run_vlan(self):
-        if sys.version_info[0] != 2:
-            print(
-                "python3-compatible scapy does not have Dot1AD. Skipping vlan test...")
-        else:
-            self.run_for(VLANSplit(), [0], 3)
-            self.assertBessAlive()
+        self.run_for(VLANSplit(), [0], 3)
+        self.assertBessAlive()
 
     def _vlan_output_test(self, vids, double_tag=False, default_gate=0):
         def gen_vlan_packet(vid):
@@ -84,9 +80,11 @@ class BessVlanTest(BessModuleTestCase):
                 self.assertEquals(len(pkt_outs[default_gate]), 1)
                 self.assertSamePackets(pkt_outs[default_gate][0], q)
 
+    @unittest.skipUnless(hasattr(scapy, 'Dot1AD'), "this scapy lacks Dot1AD")
     def test_vlan_single_tag(self):
         self._vlan_output_test([1, 17, -1, 29, 10, 13, 7])
 
+    @unittest.skipUnless(hasattr(scapy, 'Dot1AD'), "this scapy lacks Dot1AD")
     def test_vlan_double_tag(self):
         self._vlan_output_test([1, 17, -1, 29, 10, 13, 7], True)
 

--- a/bessctl/test_utils.py
+++ b/bessctl/test_utils.py
@@ -171,7 +171,17 @@ class BessModuleTestCase(unittest.TestCase):
 
     def run_pipeline(self, src_module, dst_module, igate, input_pkts,
                      ogates, time_out=3):
-        out_pkts = {}
+        """
+        Runs a pipeline that injects data (input_pkts) at module
+        src_module on input gate igate and collects it at module
+        dst_module on output gates ogates.  Runs the pipeline for
+        at most time_out seconds; stops sooner if and when all the
+        input packets are processed.
+
+        input_pkts may be a single bytestring, or a list of them.
+        """
+        if not isinstance(input_pkts, list):
+            input_pkts = [input_pkts]
 
         self.bess.pause_all()
 
@@ -221,15 +231,15 @@ class BessModuleTestCase(unittest.TestCase):
         if not root_tc:
             raise Exception('Fail to find root tc')
 
+        # Get number of packets processed inside bess.
+        # Send our packets in, then wait for them to also
+        # get processed.
         last = self.bess.get_tc_stats(root_tc.name)
 
         self.bess.resume_all()
 
-        if isinstance(input_pkts, list):
-            for pkt in input_pkts:
-                self.sockets[igate].send(bytes(pkt))
-        else:
-            self.sockets[igate].send(bytes(input_pkts))
+        for pkt in input_pkts:
+            self.sockets[igate].send(bytes(pkt))
 
         duration = 0
         while duration <= time_out:


### PR DESCRIPTION
These three commits should each stand alone - I'm just bundling them together because they happened in sort of reverse order, as part of debugging the vlan race thing.  The first is important, the second doesn't affect any current test, and the third commit has no actual fix in it, it's just some code I had trouble with while debugging, so I rearranged it.

Note that these changes also need the vlan-racy-test fix to be installed for them to work on my laptop. Anyone not hitting the race should be able to run this version without that, though.