### PR TITLE
misc sanitizer fixes

### DIFF
--- a/core/lsan.suppress
+++ b/core/lsan.suppress
@@ -5,7 +5,6 @@
 # there are some internal memory leaks in libpcap
 leak:pcap_alloc_pcap_t
 leak:pcap_check_header
-leak:pcap_open_offline_common
 
 # at startup in gtest
 leak:__si_class_type_info::__do_dyncast

--- a/core/lsan.suppress
+++ b/core/lsan.suppress
@@ -2,9 +2,12 @@
 # clang's LeakSanitizer. For more details, see:
 # https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
 
-# there are some internal memory leaks in libpcap
+# there are some internal memory leaks in older versions of libpcap (see:
+# https://github.com/the-tcpdump-group/libpcap/commit/cd46a74cf492). For now
+# suppress leaks from these functions
 leak:pcap_alloc_pcap_t
 leak:pcap_check_header
+leak:pcap_create_common
 
 # at startup in gtest
 leak:__si_class_type_info::__do_dyncast

--- a/core/utils/ip.cc
+++ b/core/utils/ip.cc
@@ -79,7 +79,7 @@ Ipv4Prefix::Ipv4Prefix(const std::string &prefix) {
   } else if (len >= 32) {
     mask = be32_t(0xffffffff);
   } else {
-    mask = be32_t(~((1 << (32 - len)) - 1));
+    mask = be32_t(~((1u << (32 - len)) - 1));
   }
 }
 

--- a/core/utils/tcp_flow_reconstruct_test.cc
+++ b/core/utils/tcp_flow_reconstruct_test.cc
@@ -50,13 +50,13 @@ class TcpFlowReconstructTest : public ::testing::TestWithParam<const char *> {
     std::string tracefile_prefix = "testdata/test-pktcaptures/tcpflow-http-3";
 
     char errbuf[PCAP_ERRBUF_SIZE];
-    pcap_t *handle =
+    handle_ =
         pcap_open_offline((tracefile_prefix + ".pcap").c_str(), errbuf);
-    ASSERT_TRUE(handle != nullptr);
+    ASSERT_TRUE(handle_ != nullptr);
 
     const u_char *pcap_pkt;
     struct pcap_pkthdr pcap_hdr;
-    while ((pcap_pkt = pcap_next(handle, &pcap_hdr)) != nullptr) {
+    while ((pcap_pkt = pcap_next(handle_, &pcap_hdr)) != nullptr) {
       ASSERT_EQ(pcap_hdr.caplen, pcap_hdr.len)
           << "Didn't capture the full packet.";
       Packet *p = new Packet();
@@ -80,6 +80,9 @@ class TcpFlowReconstructTest : public ::testing::TestWithParam<const char *> {
     for (Packet *p : pkts_) {
       delete p;
     }
+    if (handle_) {
+      pcap_close(handle_);
+    }
   }
 
   // The packets of the pcap trace file.
@@ -87,6 +90,8 @@ class TcpFlowReconstructTest : public ::testing::TestWithParam<const char *> {
 
   // The correctly reconstructed raw TCP byte stream.
   std::vector<char> bytestream_;
+
+  pcap_t *handle_;
 };
 
 // Tests that the constructor initializes the underlying buffers to the


### PR DESCRIPTION
While building with `clang++-3.9` and `SANITIZE=1`on my machine I found some new complaints from the leak and undefined behavior and leak sanitizers.

undefined behavior:

```
utils/ip.cc:82:39: runtime error: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
    #0 0x185bfd7 in bess::utils::Ipv4Prefix::Ipv4Prefix(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) utils/ip.cc:82:39
    #1 0xb1d68d in (anonymous namespace)::IPTest_PrefixCalc_Test::TestBody() utils/ip_test.cc:97:16
    #2 0x11a70bf in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/src/gtest/src/gtest.cc:2078:10
    #3 0x11a70bf in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/src/gtest/src/gtest.cc:2114
    #4 0x116584c in testing::Test::Run() /usr/src/gtest/src/gtest.cc:2150:5
    #5 0x1167a36 in testing::TestInfo::Run() /usr/src/gtest/src/gtest.cc:2326:11
    #6 0x1169c0d in testing::TestCase::Run() /usr/src/gtest/src/gtest.cc:2444:28
    #7 0x1181bd5 in testing::internal::UnitTestImpl::RunAllTests() /usr/src/gtest/src/gtest.cc:4315:43
    #8 0x11adba8 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/src/gtest/src/gtest.cc:2078:10
    #9 0x11adba8 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/src/gtest/src/gtest.cc:2114
    #10 0x1180229 in testing::UnitTest::Run() /usr/src/gtest/src/gtest.cc:3926:10
    #11 0xa683f0 in RUN_ALL_TESTS() /usr/include/gtest/gtest.h:2288:46
    #12 0xa683f0 in main gtest_main.cc:40
    #13 0x7fc30870d82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #14 0x897aa8 in _start (all_test+0x897aa8)
```

the leak:

```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7cd5e0 in __strdup (/home/ubuntu/bess/core/all_test+0x7cd5e0)
    #1 0x17d99f8 in pcap_create_common (/home/ubuntu/bess/core/all_test+0x17d99f8)
    #2 0x7ffbffffffff  (<unknown module>)
    #3 0xf618af in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.2.0/../../../../include/c++/7.2.0/bits/basic_string.tcc:232:2
```