### PR TITLE
Highlight .bess files as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bess  linguist-language=Python


### PR DESCRIPTION
Define a new [Linguist override rule](https://github.com/github/linguist#overrides) to recognize all `.bess` files as
Python files.

This will, as far as I know, only impact github.com.
