### PR TITLE
worker_split: allow custom worker->gate mappings

### DIFF
--- a/bessctl/module_tests/worker_split.py
+++ b/bessctl/module_tests/worker_split.py
@@ -27,12 +27,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import multiprocessing as mp
 from test_utils import *
 
 
 class BessWorkerSplitTest(BessModuleTestCase):
 
-    def test_worker_split(self):
+    def test_worker_split_default(self):
         NUM_WORKERS = 2
 
         for wid in range(NUM_WORKERS):
@@ -61,6 +62,50 @@ class BessWorkerSplitTest(BessModuleTestCase):
                     self.assertEquals(ogate.pkts, 0)
 
             bess.reset_all()
+
+    def test_worker_split_fancy(self):
+        NUM_WORKERS = mp.cpu_count()
+
+        gates = dict()
+        for i in range(NUM_WORKERS):
+            gates[i] = i & 1
+
+        for i in range(NUM_WORKERS):
+            bess.add_worker(wid=i, core=i)
+            bess.add_tc('rl_{}'.format(i), policy='rate_limit', wid=i,
+                        resource='count', limit={'count': 1})
+        bess.pause_all()
+
+        ws::WorkerSplit(worker_gates=gates)
+        ws:0 -> sink0::Sink()
+        ws:1 -> sink1::Sink()
+
+        srcs = [Source() for _ in range(NUM_WORKERS)]
+        for i in range(NUM_WORKERS):
+            srcs[i].attach_task(parent='rl_{}'.format(i))
+            srcs[i] -> ws
+
+        bess.resume_all()
+        time.sleep(3)
+        bess.pause_all()
+
+        odd_pkts = 0
+        even_pkts = 0
+        for i in range(NUM_WORKERS):
+            pkts = bess.get_module_info(srcs[i].name).ogates[0].pkts
+            if i % 2 == 0:
+                even_pkts += pkts
+            else:
+                odd_pkts += pkts
+
+        ws_ogates = bess.get_module_info(ws.name).ogates
+        for ogate in ws_ogates:
+            if ogate.ogate == 0:
+                self.assertEquals(ogate.pkts, odd_pkts)
+            elif ogate.ogate == 1:
+                self.assertEquals(ogate.pkts, odd_pkts)
+
+        bess.reset_all()
 
 suite = unittest.TestLoader().loadTestsFromTestCase(BessWorkerSplitTest)
 results = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/core/modules/worker_split.cc
+++ b/core/modules/worker_split.cc
@@ -30,16 +30,52 @@
 
 #include "worker_split.h"
 
+const Commands WorkerSplit::cmds = {
+    {"reset", "WorkerSplitArg", MODULE_CMD_FUNC(&WorkerSplit::CommandReset),
+     Command::Command::THREAD_UNSAFE}};
+
+CommandResponse WorkerSplit::Init(const bess::pb::WorkerSplitArg &arg) {
+  return CommandReset(arg);
+}
+
+CommandResponse WorkerSplit::CommandReset(const bess::pb::WorkerSplitArg &arg) {
+  if (arg.worker_gates().empty()) {
+    for (int i = 0; i < Worker::kMaxWorkers; i++) {
+      gates_[i] = i;
+    }
+    return CommandSuccess();
+  }
+
+  for (size_t i = 0; i < Worker::kMaxWorkers; i++) {
+    gates_[i] = -1;
+  }
+
+  for (auto it : arg.worker_gates()) {
+    gate_idx_t ogate = it.second;
+    if (ogate >= MAX_GATES) {
+      return CommandFailure(EINVAL, "output gate must be less than %" PRIu16,
+                            MAX_GATES);
+    }
+    gates_[it.first] = ogate;
+  }
+
+  return CommandSuccess();
+}
+
 void WorkerSplit::ProcessBatch(bess::PacketBatch *batch) {
-  RunChooseModule(ctx.wid(), batch);
+  int gate = gates_[ctx.wid()];
+  if (gate >= 0) {
+    RunChooseModule(gate, batch);
+  }
 }
 
 void WorkerSplit::AddActiveWorker(int wid, const Task *t) {
   if (!HaveVisitedWorker(t)) {  // Have not already accounted for worker.
     active_workers_[wid] = true;
     visited_tasks_.push_back(t);
-    // Only propagate workers downstream on ogate `wid`
-    bess::OGate *ogate = ogates()[wid];
+    // Only propagate workers downstream on ogate mapped to `wid`
+    int g = gates_[wid];
+    bess::OGate *ogate = (g < 0) ? nullptr : ogates()[g];
     if (ogate) {
       auto next = static_cast<Module *>(ogate->arg());
       next->AddActiveWorker(wid, t);

--- a/core/modules/worker_split.h
+++ b/core/modules/worker_split.h
@@ -37,11 +37,20 @@ class WorkerSplit final : public Module {
  public:
   static const gate_idx_t kNumOGates = Worker::kMaxWorkers;
 
-  WorkerSplit() { max_allowed_workers_ = kNumOGates; }
+  WorkerSplit() : Module(), gates_() { max_allowed_workers_ = kNumOGates; }
+
+  static const Commands cmds;
+
+  CommandResponse Init(const bess::pb::WorkerSplitArg &);
+
+  CommandResponse CommandReset(const bess::pb::WorkerSplitArg &);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 
   void AddActiveWorker(int wid, const Task *task) override;
+
+ private:
+  int gates_[Worker::kMaxWorkers];
 };
 
 #endif  // BESS_MODULES_WORKERSPLIT_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -1073,3 +1073,22 @@ message MplsPopArg {
    bool remove_eth_header = 1; // Remove ETH header with the pop
    uint32 next_eth_type = 2; /// The next ETH type to set
 }
+
+/**
+ * WorkerSplit splits packets based on the worker calling ProcessBatch(). It has
+ * two modes.
+ * 1) Packets from worker `x` are mapped to output gate `x`. This is the default
+ *    mode.
+ * 2) When the `worker_gates` field is set, packets from a worker `x` are mapped
+ *    to `worker_gates[x]`.  In this mode, packet batches from workers not
+ *    mapped to an output gate will be dropped.
+ *
+ * Calling the `reset` command with an empty `worker_gates` field will revert
+ * WorkerSplit to the default mode.
+ *
+ * __Input Gates__: 1
+ * __Output Gates__: many
+ */
+message WorkerSplitArg {
+  map<uint32, uint32> worker_gates = 1; // ogate -> worker mask
+}


### PR DESCRIPTION
It would be nice if WorkerSplit supported mappings other than f(x) = x.
This would be particularly useful in cases when BESS is configured with
a large number of workers and a module graph with a WorkerSplit module
that has only a few downstream modules. With the current implementation
this would require to a lot of edges from the WorkerSplit to the same
place.  For example, you might want to steer packets from workers on the
same CPU socket towrad the same destination.

To make these sorts of mappings a bit more concise, this commit changes
WorkerSplit to operate in one of two modes:

1) Packets from worker `x` are mapped to output gate `x`. This is the
   default mode.

2) When the `worker_gates` field is set, packets from a worker `x` are
   mapped to `worker_gates[x]`. In this mode, packet batches from
   workers not mapped to an output gate will be dropped.

The default mode(1) is about 2% slower (141Mpps vs 138Mpps) on my 2.1
GHz Xeon E5-2620 v4 after this change.