### PR TITLE
Make task being pointer than reference for LeafTC

### DIFF
--- a/core/module.cc
+++ b/core/module.cc
@@ -154,12 +154,13 @@ void Module::ProcessBatch(bess::PacketBatch *) {
 task_id_t Module::RegisterTask(void *arg) {
   std::string leafname = std::string("!leaf_") + name_ + std::string(":") +
                          std::to_string(tasks_.size());
+  Task *t = new Task(this, arg);
   bess::LeafTrafficClass *c =
       bess::TrafficClassBuilder::CreateTrafficClass<bess::LeafTrafficClass>(
-          leafname, Task(this, arg));
+          leafname, t);
 
   add_tc_to_orphan(c, -1);
-  tasks_.push_back(c->task());
+  tasks_.push_back(t);
   return tasks_.size() - 1;
 }
 

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -527,7 +527,8 @@ void RateLimitTrafficClass::FinishAndAccountTowardsRoot(
 
 LeafTrafficClass::~LeafTrafficClass() {
   TrafficClassBuilder::Clear(this);
-  task_.Detach();
+  task_->Detach();
+  delete task_;
 }
 
 std::unordered_map<std::string, TrafficClass *> TrafficClassBuilder::all_tcs_;

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -557,11 +557,11 @@ class LeafTrafficClass final : public TrafficClass {
  public:
   static const uint64_t kInitialWaitCycles = (1ull << 14);
 
-  explicit LeafTrafficClass(const std::string &name, const Task &task)
+  explicit LeafTrafficClass(const std::string &name, Task *task)
       : TrafficClass(name, POLICY_LEAF, false),
         task_(task),
         wait_cycles_(kInitialWaitCycles) {
-    task_.Attach(this);
+    task_->Attach(this);
   }
 
   ~LeafTrafficClass() override;
@@ -585,7 +585,7 @@ class LeafTrafficClass final : public TrafficClass {
     TrafficClass::UnblockTowardsRootSetBlocked(tsc, false);
   }
 
-  const Task *task() const { return &task_; }
+  const Task *task() const { return task_; }
 
   void FinishAndAccountTowardsRoot(SchedWakeupQueue *wakeup_queue,
                                    [[maybe_unused]] TrafficClass *child,
@@ -599,7 +599,7 @@ class LeafTrafficClass final : public TrafficClass {
   }
 
  private:
-  Task task_;
+  Task *task_;
 
   uint64_t wait_cycles_;
 };
@@ -667,7 +667,7 @@ class TrafficClassBuilder {
 
   struct LeafArgs {
     LeafFakeType dummy;
-    Task task;
+    Task *task;
   };
 
   // These CreateTree(...) functions enable brace-initialized construction of a

--- a/core/traffic_class_bench.cc
+++ b/core/traffic_class_bench.cc
@@ -79,7 +79,7 @@ class TCWeightedFair : public benchmark::Fixture {
       std::string name("class_" + std::to_string(i));
       LeafTrafficClass *c =
           TrafficClassBuilder::CreateTrafficClass<LeafTrafficClass>(
-              name, Task(dummy_, nullptr));
+              name, new Task(dummy_, nullptr));
 
       resource_share_t share = 1;
       CHECK(weighted->AddChild(c, share));
@@ -178,7 +178,7 @@ class TCRoundRobin : public benchmark::Fixture {
       std::string name("class_" + std::to_string(i));
       LeafTrafficClass *c =
           TrafficClassBuilder::CreateTrafficClass<LeafTrafficClass>(
-              name, Task(dummy_, nullptr));
+              name, new Task(dummy_, nullptr));
 
       CHECK(rr->AddChild(c));
     }

--- a/core/traffic_class_test.cc
+++ b/core/traffic_class_test.cc
@@ -57,8 +57,8 @@ class DummyModule : public Module {
 
 // Tests that we can create a leaf node.
 TEST(CreateTree, Leaf) {
-  Task t(nullptr, nullptr);
-  std::unique_ptr<TrafficClass> c(CT("leaf", {LEAF, t}));
+  std::unique_ptr<TrafficClass> c(
+      CT("leaf", {LEAF, new Task(nullptr, nullptr)}));
   ASSERT_NE(nullptr, c.get());
   ASSERT_EQ(1, c->Size());
   EXPECT_EQ(POLICY_LEAF, c->policy());
@@ -68,9 +68,9 @@ TEST(CreateTree, Leaf) {
 
 // Tests that we can create and fetch a priority root node with a leaf under it.
 TEST(CreateTree, PriorityRootAndLeaf) {
-  Task t(nullptr, nullptr);
   std::unique_ptr<TrafficClass> tree(
-      CT("root", {PRIORITY}, {{10, CT("leaf", {LEAF, t})}}));
+      CT("root", {PRIORITY},
+         {{10, CT("leaf", {LEAF, new Task(nullptr, nullptr)})}}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, tree);
@@ -87,7 +87,7 @@ TEST(CreateTree, PriorityRootAndLeaf) {
   ASSERT_EQ(1, TrafficClassBuilder::Find("leaf")->Size());
 
   // We shouldn't be able to add a child with a duplicate priority.
-  TrafficClass *leaf2 = CT("leaf_2", {LEAF, t});
+  TrafficClass *leaf2 = CT("leaf_2", {LEAF, new Task(nullptr, nullptr)});
   ASSERT_FALSE(c->AddChild(leaf2, 10));
 
   // We shouldn't be able to remove a child that does not exist.
@@ -95,7 +95,7 @@ TEST(CreateTree, PriorityRootAndLeaf) {
   delete leaf2;
 
   // A different priority should be fine.
-  TrafficClass *leaf3 = CT("leaf_3", {LEAF, t});
+  TrafficClass *leaf3 = CT("leaf_3", {LEAF, new Task(nullptr, nullptr)});
   ASSERT_TRUE(c->AddChild(leaf3, 2));
   ASSERT_EQ(1, TrafficClassBuilder::Find("leaf_3")->Size());
   ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
@@ -110,9 +110,9 @@ TEST(CreateTree, PriorityRootAndLeaf) {
 // Tests that we can create and fetch a weighted fair root node with a leaf
 // under it.
 TEST(CreateTree, WeightedFairRootAndLeaf) {
-  Task t(nullptr, nullptr);
-  std::unique_ptr<TrafficClass> tree(CT("root", {WEIGHTED_FAIR, RESOURCE_CYCLE},
-                                        {{10, CT("leaf", {LEAF, t})}}));
+  std::unique_ptr<TrafficClass> tree(
+      CT("root", {WEIGHTED_FAIR, RESOURCE_CYCLE},
+         {{10, CT("leaf", {LEAF, new Task(nullptr, nullptr)})}}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, tree);
@@ -130,7 +130,7 @@ TEST(CreateTree, WeightedFairRootAndLeaf) {
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
-  TrafficClass *leaf2 = CT("leaf_2", {LEAF, t});
+  TrafficClass *leaf2 = CT("leaf_2", {LEAF, new Task(nullptr, nullptr)});
   ASSERT_TRUE(c->AddChild(leaf2, 2));
   ASSERT_EQ(1, TrafficClassBuilder::Find("leaf_2")->Size());
   ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
@@ -145,9 +145,9 @@ TEST(CreateTree, WeightedFairRootAndLeaf) {
 // Tests that we can create and fetch a round robin root node with a leaf under
 // it.
 TEST(CreateTree, RoundRobinRootAndLeaf) {
-  Task t(nullptr, nullptr);
   std::unique_ptr<TrafficClass> tree(
-      CT("root", {ROUND_ROBIN}, {{CT("leaf", {LEAF, t})}}));
+      CT("root", {ROUND_ROBIN},
+         {{CT("leaf", {LEAF, new Task(nullptr, nullptr)})}}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, tree);
@@ -163,7 +163,7 @@ TEST(CreateTree, RoundRobinRootAndLeaf) {
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
-  TrafficClass *leaf2 = CT("leaf_2", {LEAF, t});
+  TrafficClass *leaf2 = CT("leaf_2", {LEAF, new Task(nullptr, nullptr)});
   ASSERT_TRUE(c->AddChild(leaf2));
   ASSERT_EQ(1, TrafficClassBuilder::Find("leaf_2")->Size());
   ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
@@ -178,9 +178,9 @@ TEST(CreateTree, RoundRobinRootAndLeaf) {
 // Tests that we can create and fetch a rate limit root node with a leaf under
 // it.
 TEST(CreateTree, RateLimitRootAndLeaf) {
-  Task t(nullptr, nullptr);
-  std::unique_ptr<TrafficClass> tree(CT(
-      "root", {RATE_LIMIT, RESOURCE_CYCLE, 10, 15}, {CT("leaf", {LEAF, t})}));
+  std::unique_ptr<TrafficClass> tree(
+      CT("root", {RATE_LIMIT, RESOURCE_CYCLE, 10, 15},
+         {CT("leaf", {LEAF, new Task(nullptr, nullptr)})}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, tree);
@@ -204,8 +204,9 @@ TEST(CreateTree, RateLimitRootAndLeaf) {
 // Tess that we can create a simple tree and have the scheduler pick the leaf
 // repeatedly.
 TEST(DefaultSchedulerNext, BasicTreePriority) {
-  Task t(nullptr, nullptr);
-  DefaultScheduler s(CT("root", {PRIORITY}, {{10, CT("leaf", {LEAF, t})}}));
+  DefaultScheduler s(
+      CT("root", {PRIORITY},
+         {{10, CT("leaf", {LEAF, new Task(nullptr, nullptr)})}}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, s.root());
@@ -230,9 +231,8 @@ TEST(DefaultSchedulerNext, BasicTreePriority) {
 // Tess that we can create a simple tree and have the scheduler pick the leaf
 // repeatedly.
 TEST(DefaultSchedulerNext, BasicTreeWeightedFair) {
-  Task t(nullptr, nullptr);
   DefaultScheduler s(CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
-                        {{2, CT("leaf", {LEAF, t})}}));
+                        {{2, CT("leaf", {LEAF, new Task(nullptr, nullptr)})}}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, s.root());
@@ -259,8 +259,8 @@ TEST(DefaultSchedulerNext, BasicTreeWeightedFair) {
 // Tess that we can create a simple tree and have the scheduler pick the leaf
 // repeatedly.
 TEST(DefaultSchedulerNext, BasicTreeRoundRobin) {
-  Task t(nullptr, nullptr);
-  DefaultScheduler s(CT("root", {ROUND_ROBIN}, {{CT("leaf", {LEAF, t})}}));
+  DefaultScheduler s(CT("root", {ROUND_ROBIN},
+                        {{CT("leaf", {LEAF, new Task(nullptr, nullptr)})}}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, s.root());
@@ -288,9 +288,8 @@ TEST(DefaultSchedulerNext, BasicTreeRoundRobin) {
 TEST(DefaultSchedulerNext, BasicTreeRateLimit) {
   uint64_t new_limit = 25;
   uint64_t new_burst = 50;
-  Task t(nullptr, nullptr);
   DefaultScheduler s(CT("root", {RATE_LIMIT, RESOURCE_COUNT, 50, 100},
-                        {CT("leaf", {LEAF, t})}));
+                        {CT("leaf", {LEAF, new Task(nullptr, nullptr)})}));
   ASSERT_EQ(2, TrafficClassBuilder::Find("root")->Size());
 
   ASSERT_NE(nullptr, s.root());
@@ -330,7 +329,6 @@ TEST(DefaultSchedulerNext, BasicTreeRateLimit) {
 // Tess that we can create a simple tree and have the scheduler pick the
 // unblocked child repeatedly if one of the children is blocked.
 TEST(DefaultSchedulerNext, TwoLeavesWeightedFairOneBlocked) {
-  Task t(nullptr, nullptr);
   DefaultScheduler s(
       CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
          {{1, CT("rr_1", {ROUND_ROBIN})}, {2, CT("rr_2", {ROUND_ROBIN})}}));
@@ -348,8 +346,8 @@ TEST(DefaultSchedulerNext, TwoLeavesWeightedFairOneBlocked) {
 
   EXPECT_EQ(nullptr, s.Next(rdtsc()));
 
-  LeafTrafficClass *leaf_1 =
-      static_cast<LeafTrafficClass *>(CT("leaf_1", {LEAF, t}));
+  LeafTrafficClass *leaf_1 = static_cast<LeafTrafficClass *>(
+      CT("leaf_1", {LEAF, new Task(nullptr, nullptr)}));
   rr_1->AddChild(leaf_1);
 
   ASSERT_FALSE(rr_1->blocked());
@@ -363,10 +361,9 @@ TEST(DefaultSchedulerNext, TwoLeavesWeightedFairOneBlocked) {
 // leaves in proportion to their weights.
 TEST(DefaultScheduleOnce, TwoLeavesWeightedFair) {
   DummyModule dm;
-  Task t(&dm, nullptr);
-  DefaultScheduler s(
-      CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
-         {{5, CT("leaf_2", {LEAF, t})}, {2, CT("leaf_1", {LEAF, t})}}));
+  DefaultScheduler s(CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
+                        {{5, CT("leaf_2", {LEAF, new Task(&dm, nullptr)})},
+                         {2, CT("leaf_1", {LEAF, new Task(&dm, nullptr)})}}));
   ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
 
   LeafTrafficClass *leaf_1 =
@@ -406,7 +403,6 @@ TEST(DefaultScheduleOnce, TwoLeavesWeightedFair) {
 // (lowest) priority leaf that is unblocked at that time.
 TEST(DefaultScheduleOnce, TwoLeavesPriority) {
   DummyModule dm;
-  Task t(&dm, nullptr);
   DefaultScheduler s(CT("root", {PRIORITY}, {{0, CT("rr_1", {ROUND_ROBIN})},
                                              {1, CT("rr_2", {ROUND_ROBIN})}}));
   ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
@@ -424,8 +420,8 @@ TEST(DefaultScheduleOnce, TwoLeavesPriority) {
   ASSERT_EQ(nullptr, s.Next(rdtsc()));
 
   // Unblock the second rr
-  LeafTrafficClass *leaf_2 =
-      static_cast<LeafTrafficClass *>(CT("leaf_2", {LEAF, t}));
+  LeafTrafficClass *leaf_2 = static_cast<LeafTrafficClass *>(
+      CT("leaf_2", {LEAF, new Task(&dm, nullptr)}));
   rr_2->AddChild(leaf_2);
   ASSERT_FALSE(rr_2->blocked());
 
@@ -436,8 +432,8 @@ TEST(DefaultScheduleOnce, TwoLeavesPriority) {
   ASSERT_EQ(leaf_2, s.Next(rdtsc()));
 
   // Unblock the first rr, which should now get picked.
-  LeafTrafficClass *leaf_1 =
-      static_cast<LeafTrafficClass *>(CT("leaf_1", {LEAF, t}));
+  LeafTrafficClass *leaf_1 = static_cast<LeafTrafficClass *>(
+      CT("leaf_1", {LEAF, new Task(&dm, nullptr)}));
   rr_1->AddChild(leaf_1);
   ASSERT_FALSE(rr_1->blocked());
 
@@ -454,9 +450,9 @@ TEST(DefaultScheduleOnce, TwoLeavesPriority) {
 // leaves round robin.
 TEST(DefaultScheduleOnce, TwoLeavesRoundRobin) {
   DummyModule dm;
-  Task t(&dm, nullptr);
-  DefaultScheduler s(CT("root", {ROUND_ROBIN}, {{CT("leaf_1", {LEAF, t})},
-                                                {CT("leaf_2", {LEAF, t})}}));
+  DefaultScheduler s(CT("root", {ROUND_ROBIN},
+                        {{CT("leaf_1", {LEAF, new Task(&dm, nullptr)})},
+                         {CT("leaf_2", {LEAF, new Task(&dm, nullptr)})}}));
   ASSERT_EQ(3, TrafficClassBuilder::Find("root")->Size());
 
   LeafTrafficClass *leaf_1 =
@@ -491,14 +487,15 @@ TEST(DefaultScheduleOnce, TwoLeavesRoundRobin) {
 // in the hierarchy.
 TEST(DefaultScheduleOnce, LeavesWeightedFairAndRoundRobin) {
   DummyModule dm;
-  Task t(&dm, nullptr);
   DefaultScheduler s(
       CT("root", {WEIGHTED_FAIR, RESOURCE_COUNT},
          {{2, CT("rr_1", {ROUND_ROBIN},
-                 {{CT("leaf_1a", {LEAF, t})}, {CT("leaf_1b", {LEAF, t})}})},
+                 {{CT("leaf_1a", {LEAF, new Task(&dm, nullptr)})},
+                  {CT("leaf_1b", {LEAF, new Task(&dm, nullptr)})}})},
           {5, CT("rr_2", {ROUND_ROBIN},
                  {
-                     {CT("leaf_2a", {LEAF, t})}, {CT("leaf_2b", {LEAF, t})},
+                     {CT("leaf_2a", {LEAF, new Task(&dm, nullptr)})},
+                     {CT("leaf_2b", {LEAF, new Task(&dm, nullptr)})},
                  })}}));
   ASSERT_EQ(7, TrafficClassBuilder::Find("root")->Size());
 
@@ -543,12 +540,12 @@ TEST(DefaultScheduleOnce, LeavesWeightedFairAndRoundRobin) {
 
 // Tests that rate limit nodes get properly blocked and unblocked.
 TEST(RateLimit, BasicBlockUnblock) {
-  Task t(nullptr, nullptr);
-  DefaultScheduler s(CT("root", {ROUND_ROBIN},
-                        {{CT("limit_1", {RATE_LIMIT, RESOURCE_COUNT, 1, 0},
-                             {CT("leaf_1", {LEAF, t})})},
-                         {CT("limit_2", {RATE_LIMIT, RESOURCE_COUNT, 1, 0},
-                             {CT("leaf_2", {LEAF, t})})}}));
+  DefaultScheduler s(
+      CT("root", {ROUND_ROBIN},
+         {{CT("limit_1", {RATE_LIMIT, RESOURCE_COUNT, 1, 0},
+              {CT("leaf_1", {LEAF, new Task(nullptr, nullptr)})})},
+          {CT("limit_2", {RATE_LIMIT, RESOURCE_COUNT, 1, 0},
+              {CT("leaf_2", {LEAF, new Task(nullptr, nullptr)})})}}));
   ASSERT_EQ(5, TrafficClassBuilder::Find("root")->Size());
   RoundRobinTrafficClass *rr =
       static_cast<RoundRobinTrafficClass *>(TrafficClassBuilder::Find("root"));


### PR DESCRIPTION
 - While doing refactoring for intra-task scheduling, the task can have internally malloc()ed data fields, so shallow copy should not work.
 - Using pointer would more make sense when we will extend the Task functionality (e.g., Timer).