### PR TITLE
Task graph

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // Copyright (c) 2017, Cloudigo.
 // All rights reserved.
@@ -1227,11 +1228,11 @@ class BESSControlImpl final : public BESSControl::Service {
       ModuleGraph::PropagateActiveWorker();
       if (m1->num_active_workers() || m2->num_active_workers()) {
         WorkerPauser wp;  // Only pause when absolutely required
-        ret = m1->ConnectModules(ogate, m2, igate);
+        ret = ModuleGraph::ConnectModules(m1, ogate, m2, igate);
         goto done;
       }
     }
-    ret = m1->ConnectModules(ogate, m2, igate);
+    ret = ModuleGraph::ConnectModules(m1, ogate, m2, igate);
   done:
     if (ret < 0)
       return return_with_error(response, -ret, "Connection %s:%d->%d:%s failed",
@@ -1262,7 +1263,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
     Module* m = it->second;
 
-    ret = m->DisconnectModule(ogate);
+    ret = ModuleGraph::DisconnectModule(m, ogate);
     if (ret < 0)
       return return_with_error(response, -ret, "Disconnection %s:%d failed",
                                m_name, ogate);

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -665,7 +665,7 @@ class BESSControlImpl final : public BESSControl::Service {
       // is no point in attaching orphans.
       attach_orphans();
     }
-    propagate_active_worker();
+    ModuleGraph::PropagateActiveWorker();
     LOG(INFO) << "Checking scheduling constraints";
     // Check constraints around chains run by each worker. This checks that
     // global constraints are met.
@@ -1224,7 +1224,7 @@ class BESSControlImpl final : public BESSControl::Service {
     m2 = it2->second;
 
     if (is_any_worker_running()) {
-      propagate_active_worker();
+      ModuleGraph::PropagateActiveWorker();
       if (m1->num_active_workers() || m2->num_active_workers()) {
         WorkerPauser wp;  // Only pause when absolutely required
         ret = m1->ConnectModules(ogate, m2, igate);
@@ -1262,7 +1262,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
     Module* m = it->second;
 
-    ret = m->DisconnectModules(ogate);
+    ret = m->DisconnectModule(ogate);
     if (ret < 0)
       return return_with_error(response, -ret, "Disconnection %s:%d failed",
                                m_name, ogate);

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -108,6 +108,10 @@ void Gate::ClearHooks() {
   hooks_.clear();
 }
 
+void IGate::PushOgate(OGate *og) {
+  ogates_upstream_.push_back(og);
+}
+
 void IGate::RemoveOgate(const OGate *og) {
   for (auto it = ogates_upstream_.begin(); it != ogates_upstream_.end(); ++it) {
     if (*it == og) {
@@ -116,4 +120,10 @@ void IGate::RemoveOgate(const OGate *og) {
     }
   }
 }
+
+void OGate::SetIgate(IGate *ig) {
+  igate_ = ig;
+  igate_idx_ = ig->gate_idx();
+}
+
 }  // namespace bess

--- a/core/gate.h
+++ b/core/gate.h
@@ -165,29 +165,7 @@ class Gate {
   DISALLOW_COPY_AND_ASSIGN(Gate);
 };
 
-class IGate;
-
-// A class for output gate. It connects to an input gate of the next module.
-class OGate : public Gate {
- public:
-  OGate(Module *m, gate_idx_t idx, Module *next)
-      : Gate(m, idx), next_(next), igate_(), igate_idx_() {}
-
-  void set_igate(IGate *ig) { igate_ = ig; }
-
-  IGate *igate() const { return igate_; }
-  Module *next() const { return next_; }
-
-  void set_igate_idx(gate_idx_t idx) { igate_idx_ = idx; }
-  gate_idx_t igate_idx() const { return igate_idx_; }
-
- private:
-  Module *next_;          // next module connected with
-  IGate *igate_;          // next igate connected with
-  gate_idx_t igate_idx_;  // cache for igate->gate_idx
-
-  DISALLOW_COPY_AND_ASSIGN(OGate);
-};
+class OGate;
 
 // A class for input gate
 class IGate : public Gate {
@@ -206,6 +184,29 @@ class IGate : public Gate {
   std::vector<OGate *> ogates_upstream_;  // previous ogates connected with
 };
 
+// A class for output gate. It connects to an input gate of the next module.
+class OGate : public Gate {
+ public:
+  OGate(Module *m, gate_idx_t idx, Module *next)
+      : Gate(m, idx), next_(next), igate_(), igate_idx_() {}
+
+  void SetIgate(IGate *ig) {
+    igate_ = ig;
+    igate_idx_ = ig->gate_idx();
+  }
+
+  IGate *igate() const { return igate_; }
+  Module *next() const { return next_; }
+
+  gate_idx_t igate_idx() const { return igate_idx_; }
+
+ private:
+  Module *next_;          // next module connected with
+  IGate *igate_;          // next igate connected with
+  gate_idx_t igate_idx_;  // cache for igate->gate_idx
+
+  DISALLOW_COPY_AND_ASSIGN(OGate);
+};
 }  // namespace bess
 
 template <typename H, typename A>

--- a/core/gate.h
+++ b/core/gate.h
@@ -176,8 +176,7 @@ class IGate : public Gate {
     return ogates_upstream_;
   }
 
-  void PushOgate(OGate *og) { ogates_upstream_.push_back(og); }
-
+  void PushOgate(OGate *og);
   void RemoveOgate(const OGate *og);
 
  private:
@@ -190,10 +189,7 @@ class OGate : public Gate {
   OGate(Module *m, gate_idx_t idx, Module *next)
       : Gate(m, idx), next_(next), igate_(), igate_idx_() {}
 
-  void SetIgate(IGate *ig) {
-    igate_ = ig;
-    igate_idx_ = ig->gate_idx();
-  }
+  void SetIgate(IGate *ig);
 
   IGate *igate() const { return igate_; }
   Module *next() const { return next_; }

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -104,8 +104,7 @@ TEST(HookTest, Track) {
 }
 
 TEST_F(IOGateTest, OGate) {
-  og->set_igate(ig);
-  og->set_igate_idx(0);
+  og->SetIgate(ig);
   ASSERT_EQ(ig, og->igate());
   ASSERT_EQ(0, og->igate_idx());
 }

--- a/core/metadata_test.cc
+++ b/core/metadata_test.cc
@@ -142,7 +142,7 @@ TEST_F(MetadataTest, DisconnectedFails) {
 TEST_F(MetadataTest, SingleAttrSimplePipe) {
   ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, Attribute::AccessMode::kWrite));
   ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, Attribute::AccessMode::kRead));
-  m0->ConnectModules(0, m1, 0);
+  ModuleGraph::ConnectModules(m0, 0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
@@ -158,7 +158,7 @@ TEST_F(MetadataTest, SingleAttrSimplePipeBackwardsFails) {
   ASSERT_EQ(0, m0->AddMetadataAttr("a", 1, Attribute::AccessMode::kRead));
   ASSERT_EQ(0, m1->AddMetadataAttr("a", 1, Attribute::AccessMode::kWrite));
 
-  m0->ConnectModules(0, m1, 0);
+  ModuleGraph::ConnectModules(m0, 0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
@@ -175,7 +175,7 @@ TEST_F(MetadataTest, MultipleAttrSimplePipeNoSpaceFails) {
     ASSERT_EQ(i, m0->AddMetadataAttr(s, sz, Attribute::AccessMode::kWrite));
     ASSERT_EQ(i, m1->AddMetadataAttr(s, sz, Attribute::AccessMode::kRead));
   }
-  m0->ConnectModules(0, m1, 0);
+  ModuleGraph::ConnectModules(m0, 0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
@@ -193,7 +193,7 @@ TEST_F(MetadataTest, MultipeAttrSimplePipe) {
   ASSERT_EQ(1, m1->AddMetadataAttr("b", 3, Attribute::AccessMode::kRead));
   ASSERT_EQ(2, m1->AddMetadataAttr("c", 5, Attribute::AccessMode::kRead));
   ASSERT_EQ(3, m1->AddMetadataAttr("d", 8, Attribute::AccessMode::kRead));
-  m0->ConnectModules(0, m1, 0);
+  ModuleGraph::ConnectModules(m0, 0, m1, 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
@@ -236,16 +236,16 @@ TEST_F(MetadataTest, MultipeAttrComplexPipe) {
   mods[9]->AddMetadataAttr("foo", 2, Attribute::AccessMode::kRead);
   mods[9]->AddMetadataAttr("bar", 2, Attribute::AccessMode::kRead);
 
-  mods[0]->ConnectModules(0, mods[1], 0);
-  mods[1]->ConnectModules(0, mods[2], 0);
-  mods[1]->ConnectModules(1, mods[4], 0);
-  mods[0]->ConnectModules(1, mods[4], 0);
-  mods[3]->ConnectModules(0, mods[4], 0);
-  mods[4]->ConnectModules(0, mods[5], 0);
-  mods[5]->ConnectModules(0, mods[6], 0);
-  mods[7]->ConnectModules(0, mods[6], 0);
-  mods[7]->ConnectModules(1, mods[8], 0);
-  mods[8]->ConnectModules(0, mods[9], 0);
+  ModuleGraph::ConnectModules(mods[0], 0, mods[1], 0);
+  ModuleGraph::ConnectModules(mods[1], 0, mods[2], 0);
+  ModuleGraph::ConnectModules(mods[1], 1, mods[4], 0);
+  ModuleGraph::ConnectModules(mods[0], 1, mods[4], 0);
+  ModuleGraph::ConnectModules(mods[3], 0, mods[4], 0);
+  ModuleGraph::ConnectModules(mods[4], 0, mods[5], 0);
+  ModuleGraph::ConnectModules(mods[5], 0, mods[6], 0);
+  ModuleGraph::ConnectModules(mods[7], 0, mods[6], 0);
+  ModuleGraph::ConnectModules(mods[7], 1, mods[8], 0);
+  ModuleGraph::ConnectModules(mods[8], 0, mods[9], 0);
 
   ASSERT_EQ(0, default_pipeline.ComputeMetadataOffsets());
 
@@ -312,12 +312,12 @@ TEST_F(MetadataTest, ScopeComponentDegreeOrder) {
   m0->AddMetadataAttr("a", 4, Attribute::AccessMode::kWrite);
   m0->AddMetadataAttr("b", 4, Attribute::AccessMode::kWrite);
   m0->AddMetadataAttr("c", 4, Attribute::AccessMode::kWrite);
-  m0->ConnectModules(0, m1, 0);
+  ModuleGraph::ConnectModules(m0, 0, m1, 0);
 
   m1->AddMetadataAttr("a", 4, Attribute::AccessMode::kWrite);
   m1->AddMetadataAttr("b", 4, Attribute::AccessMode::kWrite);
   m1->AddMetadataAttr("c", 4, Attribute::AccessMode::kWrite);
-  m1->ConnectModules(0, m2, 0);
+  ModuleGraph::ConnectModules(m1, 0, m2, 0);
 
   m2->AddMetadataAttr("a", 4, Attribute::AccessMode::kRead);
   m2->AddMetadataAttr("b", 4, Attribute::AccessMode::kRead);
@@ -325,18 +325,18 @@ TEST_F(MetadataTest, ScopeComponentDegreeOrder) {
   m2->AddMetadataAttr("d", 4, Attribute::AccessMode::kWrite);
   m2->AddMetadataAttr("e", 4, Attribute::AccessMode::kWrite);
   m2->AddMetadataAttr("f", 1, Attribute::AccessMode::kWrite);
-  m2->ConnectModules(0, m3, 0);
+  ModuleGraph::ConnectModules(m2, 0, m3, 0);
 
   m3->AddMetadataAttr("d", 4, Attribute::AccessMode::kRead);
   m3->AddMetadataAttr("e", 4, Attribute::AccessMode::kRead);
   m3->AddMetadataAttr("f", 1, Attribute::AccessMode::kRead);
   m3->AddMetadataAttr("g", 4, Attribute::AccessMode::kWrite);
   m3->AddMetadataAttr("h", 2, Attribute::AccessMode::kWrite);
-  m3->ConnectModules(0, m4, 0);
+  ModuleGraph::ConnectModules(m3, 0, m4, 0);
 
   m4->AddMetadataAttr("i", 6, Attribute::AccessMode::kWrite);
   m4->AddMetadataAttr("j", 6, Attribute::AccessMode::kWrite);
-  m4->ConnectModules(0, m5, 0);
+  ModuleGraph::ConnectModules(m4, 0, m5, 0);
 
   m5->AddMetadataAttr("i", 6, Attribute::AccessMode::kRead);
   m5->AddMetadataAttr("j", 6, Attribute::AccessMode::kRead);

--- a/core/module.cc
+++ b/core/module.cc
@@ -347,8 +347,7 @@ int Module::ConnectModules(gate_idx_t ogate_idx, Module *m_next,
   ogate->AddHook(new Track());
   igate->PushOgate(ogate);
 
-  // Update graph
-  return !ModuleGraph::AddEdge(name_, m_next->name_);
+  return 0;
 }
 
 int Module::DisconnectModules(gate_idx_t ogate_idx) {
@@ -370,11 +369,6 @@ int Module::DisconnectModules(gate_idx_t ogate_idx) {
   }
 
   igate = ogate->igate();
-
-  // Remove edge in module graph.
-  if (!ModuleGraph::RemoveEdge(name_, igate->module()->name_)) {
-    return 1;
-  }
 
   /* Does the igate become inactive as well? */
   igate->RemoveOgate(ogate);
@@ -413,11 +407,6 @@ int Module::DisconnectModulesUpstream(gate_idx_t igate_idx) {
     Module *m_prev = ogate->module();
     m_prev->ogates_[ogate->gate_idx()] = nullptr;
     ogate->ClearHooks();
-
-    // Remove edge in module graph
-    if (!ModuleGraph::RemoveEdge(ogate->module()->name_, name_)) {
-      return 1;
-    }
 
     delete ogate;
   }

--- a/core/module.h
+++ b/core/module.h
@@ -287,6 +287,8 @@ class alignas(64) Module {
     return attrs_;
   }
 
+  bool is_task() const { return is_task_; }
+
   const std::vector<const Task *> &tasks() const { return tasks_; }
 
   void set_attr_offset(size_t idx, bess::metadata::mt_offset_t offset) {
@@ -353,6 +355,8 @@ class alignas(64) Module {
   // For testing.
   int children_overload() const { return children_overload_; };
   const std::vector<Module *> &parent_tasks() const { return parent_tasks_; };
+
+  void add_parent_task(Module *task) { parent_tasks_.push_back(task); }
 
   // Signals to parent task(s) that module is overloaded.
   // TODO: SignalOverload and SignalUnderload are only safe if the module is not

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -40,12 +40,12 @@ std::unordered_set<std::string> ModuleGraph::tasks_;
 bool ModuleGraph::changes_made_ = false;
 
 void ModuleGraph::UpdateParentsAs(
-    Module *parent_task, Module *module,
+    Module *task, Module *module,
     std::unordered_set<Module *> &visited_modules) {
   visited_modules.insert(module);
 
   if (module->is_task()) {
-    module->AddParentTask(parent_task);
+    module->AddParentTask(task);
     return;
   } else {
     std::vector<bess::OGate *> ogates = module->ogates();
@@ -57,16 +57,16 @@ void ModuleGraph::UpdateParentsAs(
       if (visited_modules.count(child) != 0) {
         continue;
       }
-      UpdateParentsAs(parent_task, child, visited_modules);
+      UpdateParentsAs(task, child, visited_modules);
     }
   }
 }
 
-void ModuleGraph::UpdateSingleTask(Module *module) {
+void ModuleGraph::UpdateSingleTaskGraph(Module *task_module) {
   std::unordered_set<Module *> visited_modules;
-  visited_modules.insert(module);
+  visited_modules.insert(task_module);
 
-  std::vector<bess::OGate *> ogates = module->ogates();
+  std::vector<bess::OGate *> ogates = task_module->ogates();
   for (size_t i = 0; i < ogates.size(); i++) {
     if (!ogates[i]) {
       break;
@@ -77,7 +77,7 @@ void ModuleGraph::UpdateSingleTask(Module *module) {
       continue;
     }
 
-    UpdateParentsAs(module, child, visited_modules);
+    UpdateParentsAs(task_module, child, visited_modules);
   }
 }
 
@@ -90,7 +90,7 @@ void ModuleGraph::UpdateTaskGraph() {
   for (auto const &task : tasks_) {
     auto it = all_modules_.find(task);
     if (it != all_modules_.end()) {
-      UpdateSingleTask(it->second);
+      UpdateSingleTaskGraph(it->second);
     }
   }
 

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -84,7 +84,7 @@ class ModuleGraph {
  private:
   static void UpdateParentsAs(Module *parent_task, Module *module,
                               std::unordered_set<Module *> &visited_modules);
-  static void UpdateSingleTask(Module *module);
+  static void UpdateSingleTaskGraph(Module *module);
 
   // All modules that are tasks in the current pipeline.
   static std::unordered_set<std::string> tasks_;

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -91,6 +91,9 @@ class ModuleGraph {
 
   // All modules
   static std::map<std::string, Module *> all_modules_;
+
+  // Check if any changes on module graphs
+  static bool changes_made_;
 };
 
 #endif

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -36,9 +36,12 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "gate.h"
 #include "message.h"
 #include "metadata.h"
 #include "utils/common.h"
+
+using bess::gate_idx_t;
 
 class Module;
 class ModuleBuilder;
@@ -60,6 +63,10 @@ class ModuleGraph {
   static void DestroyModule(Module *m, bool erase = true);
   static void DestroyAllModules();
 
+  static int ConnectModules(Module *module, gate_idx_t ogate_idx,
+                            Module *m_next, gate_idx_t igate_idx);
+  static int DisconnectModule(Module *module, gate_idx_t ogate_idx);
+
   static const std::map<std::string, Module *> &GetAllModules();
 
   static std::string GenerateDefaultName(const std::string &class_name,
@@ -75,6 +82,10 @@ class ModuleGraph {
   static void PropagateActiveWorker();
 
  private:
+  static void UpdateParentsAs(Module *parent_task, Module *module,
+                              std::unordered_set<Module *> &visited_modules);
+  static void UpdateSingleTask(Module *module);
+
   // All modules that are tasks in the current pipeline.
   static std::unordered_set<std::string> tasks_;
 

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -50,13 +50,13 @@ class ModuleGraph {
   // Return true if any module from the builder exists
   static bool HasModuleOfClass(const ModuleBuilder *);
 
-  // Creates a module to the graph.
+  // Creates a module.
   static Module *CreateModule(const ModuleBuilder &builder,
                               const std::string &module_name,
                               const google::protobuf::Any &arg,
                               pb_error_t *perr);
 
-  // Removes a module to the graph. Returns 0 on success, -errno
+  // Removes a module. Returns 0 on success, -errno
   // otherwise.
   static int DestroyModule(Module *m, bool erase = true);
   static void DestroyAllModules();
@@ -66,15 +66,11 @@ class ModuleGraph {
   static std::string GenerateDefaultName(const std::string &class_name,
                                          const std::string &default_template);
 
-  // Connects two modules (`to` and `from`) together in `module_graph_`.
-  static bool AddEdge(const std::string &from, const std::string &to);
+  // Updates the parents of tasks
+  static void UpdateTaskGraph();
 
-  // Disconnects two modules (`to` and `from`) together in `module_graph_`.
-  static bool RemoveEdge(const std::string &from, const std::string &to);
-
-  // Updates the parents of modules with tasks by traversing `module_graph_` and
-  // ignoring all modules that are not tasks.
-  static bool UpdateTaskGraph();
+  // Cleans the parents of modules
+  static void CleanTaskGraph();
 
  private:
   // Finds the next module that implements a task along the pipeline.
@@ -82,9 +78,6 @@ class ModuleGraph {
   static bool FindNextTask(const std::string &node_name,
                            const std::string &parent_name,
                            std::unordered_set<std::string> *visited);
-
-  // A graph of all the modules in the current pipeline.
-  static std::unordered_map<std::string, Node *> module_graph_;
 
   // All modules that are tasks in the current pipeline.
   static std::unordered_set<std::string> tasks_;

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -42,7 +42,6 @@
 
 class Module;
 class ModuleBuilder;
-class Node;
 
 // Manages a global graph of modules
 class ModuleGraph {
@@ -58,7 +57,7 @@ class ModuleGraph {
 
   // Removes a module. Returns 0 on success, -errno
   // otherwise.
-  static int DestroyModule(Module *m, bool erase = true);
+  static void DestroyModule(Module *m, bool erase = true);
   static void DestroyAllModules();
 
   static const std::map<std::string, Module *> &GetAllModules();
@@ -72,23 +71,15 @@ class ModuleGraph {
   // Cleans the parents of modules
   static void CleanTaskGraph();
 
- private:
-  // Finds the next module that implements a task along the pipeline.
-  // If if find any, then the current task becomes the parent of the next task.
-  static bool FindNextTask(const std::string &node_name,
-                           const std::string &parent_name,
-                           std::unordered_set<std::string> *visited);
+  // Update information about what workers are accessing what module
+  static void PropagateActiveWorker();
 
+ private:
   // All modules that are tasks in the current pipeline.
   static std::unordered_set<std::string> tasks_;
 
   // All modules
   static std::map<std::string, Module *> all_modules_;
 };
-
-/*!
- * Update information about what workers are accessing what module.
- */
-void propagate_active_worker();
 
 #endif

--- a/core/module_graph.h
+++ b/core/module_graph.h
@@ -42,33 +42,7 @@
 
 class Module;
 class ModuleBuilder;
-
-// Represents a node in `module_graph_`.
-class Node {
- public:
-  // Creates a new Node that represents `module_`.
-  Node(Module *module) : module_(module), children_() {}
-
-  // Add a child to the node.
-  bool AddChild(const std::string &child) {
-    return children_.insert(child).second;
-  }
-
-  // Remove a child from the node.
-  void RemoveChild(const std::string &child) { children_.erase(child); }
-
-  const Module *module() const { return module_; }
-  const std::unordered_set<std::string> &children() const { return children_; }
-
- private:
-  // Module that this Node represents.
-  Module *module_;
-
-  // Children of `module_` in the pipeline.
-  std::unordered_set<std::string> children_;
-
-  DISALLOW_COPY_AND_ASSIGN(Node);
-};
+class Node;
 
 // Manages a global graph of modules
 class ModuleGraph {
@@ -98,11 +72,11 @@ class ModuleGraph {
   // Disconnects two modules (`to` and `from`) together in `module_graph_`.
   static bool RemoveEdge(const std::string &from, const std::string &to);
 
- private:
   // Updates the parents of modules with tasks by traversing `module_graph_` and
   // ignoring all modules that are not tasks.
   static bool UpdateTaskGraph();
 
+ private:
   // Finds the next module that implements a task along the pipeline.
   // If if find any, then the current task becomes the parent of the next task.
   static bool FindNextTask(const std::string &node_name,
@@ -110,7 +84,7 @@ class ModuleGraph {
                            std::unordered_set<std::string> *visited);
 
   // A graph of all the modules in the current pipeline.
-  static std::unordered_map<std::string, Node> module_graph_;
+  static std::unordered_map<std::string, Node *> module_graph_;
 
   // All modules that are tasks in the current pipeline.
   static std::unordered_set<std::string> tasks_;

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -241,7 +241,7 @@ TEST_F(ModuleTester, ConnectModules) {
   ASSERT_NE(nullptr, m1 = create_acme("m1", &perr));
   ASSERT_NE(nullptr, m2 = create_acme("m2", &perr));
 
-  EXPECT_EQ(0, m1->ConnectModules(0, m2, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(m1, 0, m2, 0));
   EXPECT_EQ(1, m1->ogates().size());
   EXPECT_EQ(m2, m1->ogates()[0]->igate()->module());
   EXPECT_EQ(1, m2->igates().size());
@@ -299,12 +299,12 @@ TEST_F(ModuleTester, GenerateTCGraph) {
   ASSERT_NE(nullptr, t2 = create_acme_with_task("t2", &perr));
   ASSERT_NE(nullptr, t3 = create_acme_with_task("t3", &perr));
   ASSERT_NE(nullptr, t4 = create_acme_with_task("t4", &perr));
-  EXPECT_EQ(0, t1->ConnectModules(0, m1, 0));
-  EXPECT_EQ(0, t1->ConnectModules(1, m2, 0));
-  EXPECT_EQ(0, m1->ConnectModules(0, t2, 0));
-  EXPECT_EQ(0, m2->ConnectModules(0, t3, 0));
-  EXPECT_EQ(0, m2->ConnectModules(1, m3, 0));
-  EXPECT_EQ(0, m3->ConnectModules(0, t4, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(t1, 0, m1, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(t1, 1, m2, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(m1, 0, t2, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(m2, 0, t3, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(m2, 1, m3, 0));
+  EXPECT_EQ(0, ModuleGraph::ConnectModules(m3, 0, t4, 0));
 
   ModuleGraph::UpdateTaskGraph();
 

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -306,6 +306,8 @@ TEST_F(ModuleTester, GenerateTCGraph) {
   EXPECT_EQ(0, m2->ConnectModules(1, m3, 0));
   EXPECT_EQ(0, m3->ConnectModules(0, t4, 0));
 
+  ModuleGraph::UpdateTaskGraph();
+
   EXPECT_EQ(0, t1->parent_tasks().size());
   EXPECT_EQ(1, t2->parent_tasks().size());
   EXPECT_EQ(1, t3->parent_tasks().size());
@@ -323,6 +325,9 @@ TEST_F(ModuleTester, GenerateTCGraph) {
   ASSERT_EQ(0, t1->children_overload());
 
   ModuleGraph::DestroyModule(t1, true);
+  ModuleGraph::CleanTaskGraph();
+  ModuleGraph::UpdateTaskGraph();
+
   EXPECT_EQ(0, t2->parent_tasks().size());
   EXPECT_EQ(0, t3->parent_tasks().size());
   EXPECT_EQ(0, t4->parent_tasks().size());

--- a/core/resume_hooks/task_graph.cc
+++ b/core/resume_hooks/task_graph.cc
@@ -1,0 +1,53 @@
+// Copyright (c) 2017, The Regents of the University of California.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "task_graph.h"
+#include "../module_graph.h"
+
+const std::string SetupTaskGraph::kName = "setup_taskgraph";
+
+SetupTaskGraph::SetupTaskGraph() : bess::ResumeHook(kName, kPriority, true) {}
+
+CommandResponse SetupTaskGraph::Init(const bess::pb::EmptyArg &) {
+  return CommandSuccess();
+}
+
+void SetupTaskGraph::Run() {
+  ModuleGraph::UpdateTaskGraph();
+}
+
+ADD_RESUME_HOOK(SetupTaskGraph)
+
+bool __enable_SetupTaskGraph = []() {
+  bool ret = bess::global_resume_hooks.emplace(new SetupTaskGraph()).second;
+  if (!ret) {
+    LOG(ERROR) << "Failed to enable SetupTaskGraph hook by default";
+  }
+  return ret;
+}();

--- a/core/resume_hooks/task_graph.cc
+++ b/core/resume_hooks/task_graph.cc
@@ -39,7 +39,6 @@ CommandResponse SetupTaskGraph::Init(const bess::pb::EmptyArg &) {
 }
 
 void SetupTaskGraph::Run() {
-  ModuleGraph::CleanTaskGraph();
   ModuleGraph::UpdateTaskGraph();
 }
 

--- a/core/resume_hooks/task_graph.cc
+++ b/core/resume_hooks/task_graph.cc
@@ -39,6 +39,7 @@ CommandResponse SetupTaskGraph::Init(const bess::pb::EmptyArg &) {
 }
 
 void SetupTaskGraph::Run() {
+  ModuleGraph::CleanTaskGraph();
   ModuleGraph::UpdateTaskGraph();
 }
 

--- a/core/resume_hooks/task_graph.h
+++ b/core/resume_hooks/task_graph.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, The Regents of the University of California.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_RESUME_HOOKS_TASK_GRAPH_
+#define BESS_RESUME_HOOKS_TASK_GRAPH_
+
+#include "../message.h"
+#include "../resume_hook.h"
+#include "../worker.h"
+
+// SetupTaskGraph computes read/write offsets for packet metadata attributes.
+class SetupTaskGraph final : public bess::ResumeHook {
+ public:
+  SetupTaskGraph();
+
+  CommandResponse Init(const bess::pb::EmptyArg &);
+
+  void Run() override;
+
+  static constexpr uint16_t kPriority = 0;
+  static const std::string kName;
+};
+
+#endif  // BESS_RESUME_HOOKS_TASK_GRAPH_


### PR DESCRIPTION
This PR partly address the issue on #703, issued by @nemethf.


Now the time to start becomes about 6s from 3min 20s.
$ `time bessctl daemon start -- run add_edge`
real        0m6.298s
user        0m1.436s
sys        0m0.388s

This includes many changes in source code including
1. Remove module_graph_ data structure: We don't need to manage multiple module graphs as makes maintenance harder, and higher risks for potential bugs. 
2. Follow up from 1, all the module graphs changes should be maintained at one place - module graphs. No direct module connection/disconnection is not allowed any longer. (and now those are private functions of modules)
3. Makes the generating a task graph as a default resume hook. It does not update the task graph per-connection updates but updates at once right before resume.
4. The resume hooks for updating task graph only regenerate task graphs if there are any changes on module connections. So just resume for updating module parameters or measure some statistics will not trigger task graphs update.

More optimizations would be required. I leave these as a future PR or issues to reduce the overhead of single big PR. (current PR is huge enough)
- A single module connection changes will trigger the whole task graph regeneration. As @nemethf suggested, subgraph update only regarding changes would improve the performance.
- Updating workers per task or checking constraints can also be put as a resume hook. At least, checking constraints and updating workers per task should be managed to the same control flow wherever it is. Now one is contolled by `pybess` and while the other is controlled by `bessd`.
- It would be better if we limit the role of `bessctl.cc` not to directly changes the internal of bessd (such as TC), and migrate logics into the separate classes so that a single file takes the responsibility of regarding all related changes. (TC tree is now managed in `bessctl.cc, module.cc, worker.cc` now)
