### PR TITLE
Burn cycles for performance tests

### DIFF
--- a/core/modules/bypass.cc
+++ b/core/modules/bypass.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
@@ -30,7 +30,37 @@
 
 #include "bypass.h"
 
+CommandResponse Bypass::Init(const bess::pb::BypassArg &arg) {
+  cycles_per_batch_ = arg.cycles_per_batch();
+  cycles_per_packet_ = arg.cycles_per_packet();
+
+  cycles_per_byte_ = arg.cycles_per_byte();
+  if (cycles_per_byte_ < 0) {
+    return CommandFailure(EINVAL, "Cycles must be equals to/greater than zero");
+  }
+
+  return CommandSuccess();
+}
+
 void Bypass::ProcessBatch(bess::PacketBatch *batch) {
+  uint32_t cur_tsc = ctx.current_tsc();
+  uint32_t cycles = cycles_per_batch_ + cycles_per_packet_ * batch->cnt();
+
+  if (cycles_per_byte_) {
+    uint64_t total_bytes = 0;
+    for (int i = 0; i < batch->cnt(); i++) {
+      total_bytes = batch->pkts()[i]->total_len();
+    }
+    cycles += cycles_per_byte_ * total_bytes;
+  }
+
+  if (cycles) {
+    uint64_t target_tsc = cur_tsc + cycles;
+    // burn cycles until it comsumes target cycles
+    while (rdtsc() < target_tsc) {
+      _mm_pause();
+    }
+  }
   RunChooseModule(get_igate(), batch);
 }
 

--- a/core/modules/bypass.cc
+++ b/core/modules/bypass.cc
@@ -33,11 +33,7 @@
 CommandResponse Bypass::Init(const bess::pb::BypassArg &arg) {
   cycles_per_batch_ = arg.cycles_per_batch();
   cycles_per_packet_ = arg.cycles_per_packet();
-
   cycles_per_byte_ = arg.cycles_per_byte();
-  if (cycles_per_byte_ < 0) {
-    return CommandFailure(EINVAL, "Cycles must be equals to/greater than zero");
-  }
 
   return CommandSuccess();
 }

--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -50,7 +50,7 @@ class Bypass final : public Module {
  private:
   uint32_t cycles_per_batch_;
   uint32_t cycles_per_packet_;
-  double cycles_per_byte_;
+  uint32_t cycles_per_byte_;
 };
 
 #endif  // BESS_MODULES_BYPASS_H_

--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2014-2017, The Regents of the University of California.
 // Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
@@ -42,7 +42,15 @@ class Bypass final : public Module {
   static const gate_idx_t kNumOGates = MAX_GATES;
 
   Bypass() { max_allowed_workers_ = Worker::kMaxWorkers; }
+
+  CommandResponse Init(const bess::pb::BypassArg &arg);
+
   void ProcessBatch(bess::PacketBatch *batch) override;
+
+ private:
+  uint32_t cycles_per_batch_;
+  uint32_t cycles_per_packet_;
+  double cycles_per_byte_;
 };
 
 #endif  // BESS_MODULES_BYPASS_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -450,12 +450,17 @@ message BufferArg {
 }
 
 /**
- * The Bypass module forwards packets without any processing. It requires no parameters to initialize. Bypass is useful primarily for testing and performance evaluation.
+ * The Bypass module forwards packets by emulating pre-defined packet processing overhead.
+ * It burns cpu cycles per_batch, per_packet, and per-bytes.
+ * Bypass is useful primarily for testing and performance evaluation.
  *
  * __Input Gates__: 1
  * __Output Gates__: 1
  */
 message BypassArg {
+  uint32 cycles_per_batch = 1;
+  uint32 cycles_per_packet = 2;
+  double cycles_per_byte = 3;
 }
 
 /**
@@ -527,11 +532,11 @@ message FlowGenArg {
 }
 
 /**
-* The GenericDecap module strips off the first few bytes of data from a packet.
-*
-* __Input Gates__: 1
-* __Ouptut Gates__: 1
-*/
+ * The GenericDecap module strips off the first few bytes of data from a packet.
+ *
+ * __Input Gates__: 1
+ * __Ouptut Gates__: 1
+ */
 message GenericDecapArg {
   uint64 bytes = 1; /// The number of bytes to strip off.
 }
@@ -540,8 +545,8 @@ message GenericDecapArg {
  * The GenericEncap module adds a header to packets passing through it.
  * Takes a list of fields. Each field is either:
  *
- *  1. {'size': X, 'value': Y}		(for constant values)
- *  2. {'size': X, 'attribute': Y}	(for metadata attributes)
+ *  1. {'size': X, 'value': Y}          (for constant values)
+ *  2. {'size': X, 'attribute': Y}      (for metadata attributes)
  *
  * e.g.: GenericEncap([{'size': 4, 'value': 0xdeadbeef},
  *                     {'size': 2, 'attribute': 'foo'},
@@ -1059,8 +1064,8 @@ message ArpResponderArg {
   /**
    * One ARP IP-MAC mapping
    */
-   string ip = 1; // The IP
-   string mac_addr = 2; /// The MAC address
+  string ip = 1; // The IP
+  string mac_addr = 2; /// The MAC address
 }
 
 /**
@@ -1070,8 +1075,8 @@ message ArpResponderArg {
  * __Output Gates__: 2
  */
 message MplsPopArg {
-   bool remove_eth_header = 1; // Remove ETH header with the pop
-   uint32 next_eth_type = 2; /// The next ETH type to set
+  bool remove_eth_header = 1; // Remove ETH header with the pop
+  uint32 next_eth_type = 2; /// The next ETH type to set
 }
 
 /**

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -460,7 +460,7 @@ message BufferArg {
 message BypassArg {
   uint32 cycles_per_batch = 1;
   uint32 cycles_per_packet = 2;
-  double cycles_per_byte = 3;
+  uint32 cycles_per_byte = 3;
 }
 
 /**


### PR DESCRIPTION
This PR is following up for #693, module benchmarks.

Now, `Bypass` burns CPU cycles for per-batch, per-packet, and per-byte. In this way, we can see how much per-batch cost can be amortized by merging back batches after splitting.