### PR TITLE
nat: add get/set arg/state

### DIFF
--- a/bessctl/module_tests/nat.py
+++ b/bessctl/module_tests/nat.py
@@ -102,6 +102,18 @@ class BessNatTest(BessModuleTestCase):
         nat = NAT(ext_addrs=['192.168.1.1'])
         self._test_l4(nat, scapy.ICMP(), '192.168.1.1')
 
+    def test_nat_selfconfig(self):
+        # Send initial conf unsorted, see that it comes back sorted
+        # (note that this is a bit different from other modules
+        # where argument order often matters).
+        iconf = {'ext_addrs': ['0.1.2.3', '192.168.1.1', '3.2.1.0']}
+        nat = NAT(**iconf)
+        iconf['ext_addrs'].sort(key=lambda s: socket.inet_aton(s))
+        arg = pb_conv.protobuf_to_dict(nat.get_initial_arg())
+        expect_config = {}
+        cur_config = pb_conv.protobuf_to_dict(nat.get_runtime_config())
+        assert arg == iconf and cur_config == expect_config
+
 suite = unittest.TestLoader().loadTestsFromTestCase(BessNatTest)
 results = unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -53,6 +53,15 @@ using bess::utils::ChecksumIncrement32;
 using bess::utils::UpdateChecksumWithIncrement;
 using bess::utils::UpdateChecksum16;
 
+const Commands NAT::cmds = {
+    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&NAT::GetInitialArg),
+     Command::THREAD_SAFE},
+    {"get_runtime_config", "EmptyArg", MODULE_CMD_FUNC(&NAT::GetRuntimeConfig),
+     Command::THREAD_SAFE},
+    {"set_runtime_config", "EmptyArg", MODULE_CMD_FUNC(&NAT::SetRuntimeConfig),
+     Command::THREAD_SAFE}};
+
+// TODO(torek): move this to set/get runtime config
 CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
   for (const std::string &ext_addr : arg.ext_addrs()) {
     be32_t addr;
@@ -69,6 +78,25 @@ CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
                           "at least one external IP address must be specified");
   }
 
+  // Sort so that GetInitialArg is predictable and consistent.
+  std::sort(ext_addrs_.begin(), ext_addrs_.end());
+
+  return CommandSuccess();
+}
+
+CommandResponse NAT::GetInitialArg(const bess::pb::EmptyArg &) {
+  bess::pb::NATArg resp;
+  for (auto addr : ext_addrs_) {
+    resp.add_ext_addrs(ToIpv4Address(addr));
+  }
+  return CommandSuccess(resp);
+}
+
+CommandResponse NAT::GetRuntimeConfig(const bess::pb::EmptyArg &) {
+  return CommandSuccess();
+}
+
+CommandResponse NAT::SetRuntimeConfig(const bess::pb::EmptyArg &) {
   return CommandSuccess();
 }
 

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -131,7 +131,12 @@ class NAT final : public Module {
   static const gate_idx_t kNumIGates = 2;
   static const gate_idx_t kNumOGates = 2;
 
+  static const Commands cmds;
+
   CommandResponse Init(const bess::pb::NATArg &arg);
+  CommandResponse GetInitialArg(const bess::pb::EmptyArg &arg);
+  CommandResponse GetRuntimeConfig(const bess::pb::EmptyArg &arg);
+  CommandResponse SetRuntimeConfig(const bess::pb::EmptyArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;
 


### PR DESCRIPTION
Here the set of IP addresses being NAT-ed is all arguments,
rather than all state.  So we don't (yet) define a NATConfig.
This may change if necessary.

---

This PR is mainly for @apanda to look at, as it doesn't have the "move args to config" that @ddiproietto and I talked about.  But we can use it in this form if we decide that's not important after all.