### PR TITLE
Don't color stderr in case of dumb terminals

### DIFF
--- a/bessctl/cli.py
+++ b/bessctl/cli.py
@@ -85,7 +85,7 @@ class CLI(object):
 
         # Colorize output to standard error
         if ferr is None:
-            if sys.stderr.isatty():
+            if os.environ.get('TERM') != 'dumb' and sys.stderr.isatty():
                 self.ferr = ColorizedOutput(sys.stderr, '\033[31m')  # dark red
             else:
                 self.ferr = sys.stderr


### PR DESCRIPTION
This behavior mimics gcc and helps running ("compiling") bess scripts
from Emacs.  See:
https://github.com/gcc-mirror/gcc/blob/7a5024dcd3f8c7a6211f5226f538088ee6126dbc/gcc/diagnostic-color.c#L217