### PR TITLE
Fix a bug that starves all children except an unblocked child in weight_fair TC

### DIFF
--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -336,7 +336,15 @@ class WeightedFairTrafficClass final : public TrafficClass {
     }
 
     int64_t stride;
-    int64_t pass;
+
+    // NOTE: while in the code example in the original Stride Scheduler
+    // [Waldspurgger95] maintains "pass" and "remain" (penalty) separately,
+    // we can safely multiplex these variables in a union since they are never
+    // used at the same time.
+    union {
+      int64_t pass;
+      int64_t remain;
+    };
 
     TrafficClass *c;
   };

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -332,13 +332,13 @@ class WeightedFairTrafficClass final : public TrafficClass {
   struct ChildData {
     bool operator<(const ChildData &right) const {
       // Reversed so that priority_queue is a min priority queue.
-      return right.pass_ < pass_;
+      return right.pass < pass;
     }
 
-    int64_t stride_;
-    int64_t pass_;
+    int64_t stride;
+    int64_t pass;
 
-    TrafficClass *c_;
+    TrafficClass *c;
   };
 
   WeightedFairTrafficClass(const std::string &name, resource_t resource)
@@ -391,7 +391,7 @@ class WeightedFairTrafficClass final : public TrafficClass {
     if (runnable_children_.empty()) {
       return 0;
     } else {
-      return runnable_children_.top().pass_;
+      return runnable_children_.top().pass;
     }
   }
 

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -385,6 +385,16 @@ class WeightedFairTrafficClass final : public TrafficClass {
   }
 
  private:
+  // Returns the pass value of the first child to be scheduled next,
+  // or 0 if there is no runnable child (i.e., the priority queue is empty)
+  int64_t NextPass() const {
+    if (runnable_children_.empty()) {
+      return 0;
+    } else {
+      return runnable_children_.top().pass_;
+    }
+  }
+
   // The resource that we are sharing.
   resource_t resource_;
 

--- a/core/traffic_class_test.cc
+++ b/core/traffic_class_test.cc
@@ -126,7 +126,7 @@ TEST(CreateTree, WeightedFairRootAndLeaf) {
   ASSERT_EQ(0, c->blocked_children().size());
 
   LeafTrafficClass *leaf = static_cast<LeafTrafficClass *>(
-      c->runnable_children().container().front().c_);
+      c->runnable_children().container().front().c);
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 
@@ -245,7 +245,7 @@ TEST(DefaultSchedulerNext, BasicTreeWeightedFair) {
   ASSERT_EQ(0, c->blocked_children().size());
 
   LeafTrafficClass *leaf = static_cast<LeafTrafficClass *>(
-      c->runnable_children().container().front().c_);
+      c->runnable_children().container().front().c);
   ASSERT_NE(nullptr, leaf);
   EXPECT_EQ(leaf->parent(), c);
 


### PR DESCRIPTION
In the current implementation of stride scheduling for weighted fair sharing, the "pass" value of unblocked (joined again) child TCs are initialized to 0. Then only that TC will be scheduled until its pass value has caught up with the that of other TCs. This caused scheduling bug reported in #717.

In addition, a minor bug, where frequently blocked TCs are more scheduled than they should be, has also been fixed (`client->remain` in Fig 3 in [the original paper](http://www.read.seas.harvard.edu/~kohler/class/aosref/waldspurger95stride.pdf))