### PR TITLE
Upgrade from C++11 to C++14

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -112,7 +112,7 @@ endif
 # -MMD dependency recording (should we use -MD?).
 COREDIR := $(abspath .)
 CXXARCHFLAGS ?= -march=native
-CXXFLAGS += -std=c++11 -g3 -ggdb3 $(CXXARCHFLAGS) \
+CXXFLAGS += -std=c++14 -g3 -ggdb3 $(CXXARCHFLAGS) \
 	    -isystem $(DPDK_INC_DIR) -isystem $(COREDIR) \
 	    -isystem $(dir $<).. -isystem $(COREDIR)/modules \
 	    -D_GNU_SOURCE \


### PR DESCRIPTION
g++ 5, which is our minimum requirement, supports C++14. So why not?