### PR TITLE
BESSD should not exit(), when failed to load modules

### DIFF
--- a/core/main.cc
+++ b/core/main.cc
@@ -72,8 +72,8 @@ int main(int argc, char *argv[]) {
 
   // Load plugins
   if (!bess::bessd::LoadPlugins(FLAGS_modules)) {
-    PLOG(FATAL) << "LoadPlugins() failed to load from directory: "
-                << FLAGS_modules;
+    PLOG(WARNING) << "LoadPlugins() failed to load from directory: "
+                  << FLAGS_modules;
   }
 
   // TODO(barath): Make these DPDK calls generic, so as to not be so tied to


### PR DESCRIPTION
Bessd doesn't need to exit when faiedl to load external plugins.