### PR TITLE
minor histogram changes

### DIFF
--- a/core/utils/histogram.h
+++ b/core/utils/histogram.h
@@ -33,18 +33,21 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <vector>
 
 #include <glog/logging.h>
 
-// Class for general purpose histogram. T must be an integral type.
+// Class for general purpose histogram. T generally should be an
+// integral type, though floating point types will also work.
 // A bin b_i corresponds for the range [i * width, (i + 1) * width)
 // (note that it's left-closed and right-open), and (i * width) is used for its
 // representative value.
 template <typename T = uint64_t>
 class Histogram {
  public:
+  static_assert(std::is_arithmetic<T>::value, "Arithmetic type required.");
   struct Summary {
     size_t count;        // # of all samples. If 0, min, max and avg are also 0
     size_t above_range;  // # of samples beyond the histogram range
@@ -131,9 +134,11 @@ class Histogram {
     return ret;
   }
 
+  // Resets all counters, and the count of such counters.
+  // Note that the number of buckets remains unchanged.
   void Reset() {
     count_ = 0;
-    buckets_ = std::vector<size_t>(buckets_.size());
+    std::fill(buckets_.begin(), buckets_.end(), T());
   }
 
  private:


### PR DESCRIPTION
NB: I originally put in a static assert with is_integral, and
then histogram_test.cc failed.  I'm not sure which one we should fix!

---

While examining the measure module I noted a few things
to improve slightly in the histogram code:

 - Comments say that the type must be integral.  It probably should
   be but at least one test uses double, and any arithmetic type
   will work up to the point where it runs out of bits, at least.
   Adjust the comment and assert that the type is arithmetic.  If
   we want to constrain the type to integral, we'll need to fix
   the test.

 - The Reset() function constructs an all-new vector of the type,
   to reset to all-zero values.  We can just memset() the data now
   that we have C++11 which gives us a vector .data() operator,
   since we only run on machines with all-zero-bits = 0 (integral)
   or 0.0 (float/double).