### PR TITLE
Task to context

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -221,8 +221,6 @@ PROTOCFLAGS += --cpp_out=./pb --grpc_out=./pb --plugin=protoc-gen-grpc=$(PROTOC_
 # Use MODULE_SRCS below, which filters them out, when that's important.
 DRIVERS := $(foreach dir,drivers $(DRIVER_PLUGINS),$(wildcard $(dir)/*.cc))
 MODULES := $(foreach dir,modules,$(wildcard $(dir)/*.cc))
-#MODULES := $(foreach dir,modules $(MODULE_PLUGINS),$(wildcard $(dir)/*.cc))
-MODULES := modules/source.cc modules/sink.cc modules/random_split.cc modules/bypass.cc
 UTILS := $(foreach dir,utils $(UTIL_PLUGINS),$(wildcard $(dir)/*.cc))
 GATE_HOOK_SRCS := $(foreach dir,gate_hooks $(GATE_HOOK_PLUGINS),$(wildcard $(dir)/*.cc))
 GATE_HOOKS_H := $(foreach dir,gate_hooks $(GATE_HOOK_PLUGINS),$(wildcard $(dir)/*.h))

--- a/core/Makefile
+++ b/core/Makefile
@@ -221,6 +221,8 @@ PROTOCFLAGS += --cpp_out=./pb --grpc_out=./pb --plugin=protoc-gen-grpc=$(PROTOC_
 # Use MODULE_SRCS below, which filters them out, when that's important.
 DRIVERS := $(foreach dir,drivers $(DRIVER_PLUGINS),$(wildcard $(dir)/*.cc))
 MODULES := $(foreach dir,modules,$(wildcard $(dir)/*.cc))
+#MODULES := $(foreach dir,modules $(MODULE_PLUGINS),$(wildcard $(dir)/*.cc))
+MODULES := modules/source.cc modules/sink.cc modules/random_split.cc modules/bypass.cc
 UTILS := $(foreach dir,utils $(UTIL_PLUGINS),$(wildcard $(dir)/*.cc))
 GATE_HOOK_SRCS := $(foreach dir,gate_hooks $(GATE_HOOK_PLUGINS),$(wildcard $(dir)/*.cc))
 GATE_HOOKS_H := $(foreach dir,gate_hooks $(GATE_HOOK_PLUGINS),$(wildcard $(dir)/*.h))

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -307,7 +307,7 @@ static ::Port* create_port(const std::string& name, const PortBuilder& driver,
   p->queue_size[PACKET_DIR_OUT] = size_out_q;
 
   // DPDK functions may be called, so be prepared
-  ctx.SetNonWorker();
+  current_worker.SetNonWorker();
 
   CommandResponse ret = p->InitWithGenericArg(arg);
 
@@ -1098,7 +1098,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     // DPDK functions may be called, so be prepared
-    ctx.SetNonWorker();
+    current_worker.SetNonWorker();
 
     pb_error_t* error = response->mutable_error();
     Module* module =
@@ -1411,7 +1411,7 @@ class BESSControlImpl final : public BESSControl::Service {
     WorkerPauser wp;
 
     // DPDK functions may be called, so be prepared
-    ctx.SetNonWorker();
+    current_worker.SetNonWorker();
 
     *response = hook->RunCommand(request->cmd(), rh.arg());
     return Status::OK;
@@ -1556,7 +1556,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     // DPDK functions may be called, so be prepared
-    ctx.SetNonWorker();
+    current_worker.SetNonWorker();
 
     Module* m = it->second;
     *response = m->RunCommand(request->cmd(), request->arg());

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -216,7 +216,7 @@ void init_dpdk(const ::std::string &prog_name, int mb_per_socket,
   // FIXME: This is a temporary fix. If a new worker thread is allocated on the
   //        same core, background threads should migrate to another core.
   int default_core = determine_default_core();
-  ctx.SetNonWorker();
+  current_worker.SetNonWorker();
 
   init_eal(prog_name.c_str(), mb_per_socket, multi_instance, no_huge,
            default_core);

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -183,7 +183,7 @@ int UnixSocketPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
     return 0;
   }
 
-  uint64_t now_ns = ctx.current_ns();
+  uint64_t now_ns = current_worker.current_tsc();
   if (now_ns - last_idle_ns_ < min_rx_interval_ns_) {
     return 0;
   }

--- a/core/module.cc
+++ b/core/module.cc
@@ -135,12 +135,12 @@ CommandResponse Module::Init(const bess::pb::EmptyArg &) {
 
 void Module::DeInit() {}
 
-struct task_result Module::RunTask(const Task *, bess::PacketBatch *, void *) {
+struct task_result Module::RunTask(Context *, bess::PacketBatch *, void *) {
   CHECK(0);  // You must override this function
   return task_result();
 }
 
-void Module::ProcessBatch(const Task *, bess::PacketBatch *) {
+void Module::ProcessBatch(Context *, bess::PacketBatch *) {
   CHECK(0);  // You must override this function
 }
 

--- a/core/module.h
+++ b/core/module.h
@@ -45,7 +45,6 @@
 #include "message.h"
 #include "metadata.h"
 #include "packet.h"
-#include "scheduler.h"
 
 using bess::gate_idx_t;
 
@@ -54,6 +53,26 @@ using bess::gate_idx_t;
 #define MAX_TASKS_PER_MODULE 32
 #define UNCONSTRAINED_SOCKET ((0x1ull << MAX_NUMA_NODE) - 1)
 
+struct Context {
+  // Set by task scheduler, read by modules
+  uint64_t current_tsc;
+  uint64_t current_ns;
+  int wid;
+  Task *task;
+
+  // Set by module scheduler, read by a task scheduler
+  uint64_t silent_drops;
+
+  // Temporary variables to be accessed and updated by module scheduler
+  gate_idx_t current_igate;
+  int gate_with_hook_cnt = 0;
+  int gate_without_hook_cnt = 0;
+  gate_idx_t gate_with_hook[bess::PacketBatch::kMaxBurst];
+  gate_idx_t gate_without_hook[bess::PacketBatch::kMaxBurst];
+};
+
+using module_cmd_func_t =
+    pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 using module_init_func_t =
     pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 
@@ -194,18 +213,18 @@ class alignas(64) Module {
   // NOTE: this function will be called even if Init() has failed.
   virtual void DeInit();
 
-  // Initiates a new 'task', generating a new workload (a set of packets in
-  // 'batch') and forward the workloads to be processed and forward the workload
-  // to next modules. It can also get per-module specific 'arg' as input.
-  // 'batch' is pre-allocated for efficiency.
+  // Initiates a new task with 'ctx', generating a new workload (a set of
+  // packets in 'batch') and forward the workloads to be processed and forward
+  // the workload to next modules. It can also get per-module specific 'arg'
+  // as input. 'batch' is pre-allocated for efficiency.
   // It returns info about generated workloads, 'task_result'.
-  virtual struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  virtual struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                                      void *arg);
 
-  // Process a set of packets in packet batch with the contexts of 'task'.
-  // A module should handle all packets in a batch properly - 1) forwards to the
-  // next modules, or 2) free
-  virtual void ProcessBatch(const Task *task, bess::PacketBatch *batch);
+  // Process a set of packets in packet batch with the contexts 'ctx'.
+  // A module should handle all packets in a batch properly as follows:
+  // 1) forwards to the next modules, or 2) free
+  virtual void ProcessBatch(Context *ctx, bess::PacketBatch *batch);
 
   // If a derived Module overrides OnEvent and doesn't return  -ENOTSUP for a
   // particular Event `e` it will be invoked for each instance of the derived
@@ -220,12 +239,6 @@ class alignas(64) Module {
 
   static const Commands cmds;
 
-  int gate_with_hook_cnt_ = 0;
-  gate_idx_t gate_with_hook_[bess::PacketBatch::kMaxBurst];
-
-  int gate_without_hook_cnt_ = 0;
-  gate_idx_t gate_without_hook_[bess::PacketBatch::kMaxBurst];
-
   // -------------------------------------------------------------------------
 
  public:
@@ -234,25 +247,24 @@ class alignas(64) Module {
 
   CommandResponse InitWithGenericArg(const google::protobuf::Any &arg);
 
-  // With the contexts of 'task', pass packet batch ('batch') to the next module
+  // With the contexts('ctx'), pass packet batch ('batch') to the next module
   // connected with 'ogate_idx'
-  inline void RunChooseModule(const Task *task, gate_idx_t ogate_idx,
+  inline void RunChooseModule(Context *ctx, gate_idx_t ogate_idx,
                               bess::PacketBatch *batch);
 
-  // With the contexts of 'task', pass packet batch ('batch') to the default
+  // With the contexts('ctx'), pass packet batch ('batch') to the default
   // next module ('ogate_idx' == 0)
-  inline void RunNextModule(const Task *task, bess::PacketBatch *batch);
+  inline void RunNextModule(Context *ctx, bess::PacketBatch *batch);
 
-  // With the contexts of 'task', drop a packet. Dropped packets will be freed.
-  inline void DropPacket(const Task *task, bess::Packet *pkt);
+  // With the contexts('ctx'), drop a packet. Dropped packets will be freed.
+  inline void DropPacket(Context *ctx, bess::Packet *pkt);
 
-  // With the contexts of 'task', emit (forward) a packet ('pkt') to the next
+  // With the contexts('ctx'), emit (forward) a packet ('pkt') to the next
   // module connected with 'ogate'
-  inline void EmitPacket(const Task *task, bess::Packet *pkt,
-                         gate_idx_t ogate_idx = 0);
+  inline void EmitPacket(Context *ctx, bess::Packet *pkt, gate_idx_t ogate = 0);
 
   // Process OGate hooks and forward packet batches into next modules.
-  inline void ProcessOGates(const Task *task);
+  inline void ProcessOGates(Context *ctx);
 
   /*
    * Split a batch into several, one for each ogate
@@ -267,7 +279,7 @@ class alignas(64) Module {
    * */
   [[deprecated(
       "use the new API EmitPacket()/DropPacket() instead")]] inline void
-  RunSplit(const Task *task, const gate_idx_t *ogates,
+  RunSplit(Context *ctx, const gate_idx_t *ogates,
            bess::PacketBatch *mixed_batch);
 
   // Register a task.
@@ -474,13 +486,13 @@ class alignas(64) Module {
   DISALLOW_COPY_AND_ASSIGN(Module);
 };
 
-static inline void deadend(bess::PacketBatch *batch) {
-  ctx.incr_silent_drops(batch->cnt());
+static inline void deadend(Context *ctx, bess::PacketBatch *batch) {
+  ctx->silent_drops += batch->cnt();
   bess::Packet::Free(batch);
   batch->clear();
 }
 
-inline void Module::RunChooseModule(const Task *task, gate_idx_t ogate_idx,
+inline void Module::RunChooseModule(Context *ctx, gate_idx_t ogate_idx,
                                     bess::PacketBatch *batch) {
   bess::OGate *ogate;
 
@@ -489,14 +501,14 @@ inline void Module::RunChooseModule(const Task *task, gate_idx_t ogate_idx,
   }
 
   if (unlikely(ogate_idx >= ogates_.size())) {
-    deadend(batch);
+    deadend(ctx, batch);
     return;
   }
 
   ogate = ogates_[ogate_idx];
 
   if (unlikely(!ogate)) {
-    deadend(batch);
+    deadend(ctx, batch);
     return;
   }
 
@@ -504,28 +516,30 @@ inline void Module::RunChooseModule(const Task *task, gate_idx_t ogate_idx,
     hook->ProcessBatch(batch);
   }
 
-  task->AddToRun(ogate->igate(), batch);
+  ctx->task->AddToRun(ogate->igate(), batch);
 }
 
-inline void Module::RunNextModule(const Task *task, bess::PacketBatch *batch) {
-  RunChooseModule(task, 0, batch);
+inline void Module::RunNextModule(Context *ctx, bess::PacketBatch *batch) {
+  RunChooseModule(ctx, 0, batch);
 }
 
-inline void Module::DropPacket(const Task *task, bess::Packet *pkt) {
-  task->dead_batch()->add(pkt);
-  if (static_cast<size_t>(task->dead_batch()->cnt()) >=
+inline void Module::DropPacket(Context *ctx, bess::Packet *pkt) {
+  ctx->task->dead_batch()->add(pkt);
+  if (static_cast<size_t>(ctx->task->dead_batch()->cnt()) >=
       bess::PacketBatch::kMaxBurst) {
-    deadend(task->dead_batch());
+    deadend(ctx, ctx->task->dead_batch());
   }
 }
 
-inline void Module::EmitPacket(const Task *task, bess::Packet *pkt,
+inline void Module::EmitPacket(Context *ctx, bess::Packet *pkt,
                                gate_idx_t ogate_idx) {
   // Check if valid ogate is set
-  if (unlikely((ogates_.size() <= ogate_idx) || (!ogates_[ogate_idx]))) {
-    DropPacket(task, pkt);
+  if (unlikely(ogates_.size() <= ogate_idx) || unlikely(!ogates_[ogate_idx])) {
+    DropPacket(ctx, pkt);
     return;
   }
+
+  Task *task = ctx->task;
 
   // Put a packet into the ogate
   bess::OGate *ogate = ogates_[ogate_idx];
@@ -536,7 +550,7 @@ inline void Module::EmitPacket(const Task *task, bess::Packet *pkt,
       // Having separate batch to run ogate hooks
       batch = task->AllocPacketBatch();
       task->set_gate_batch(ogate, batch);
-      gate_with_hook_[gate_with_hook_cnt_++] = ogate_idx;
+      ctx->gate_with_hook[ctx->gate_with_hook_cnt++] = ogate_idx;
     } else {
       // If no ogate hooks, just use next igate batch
       batch = task->get_gate_batch(igate);
@@ -547,7 +561,7 @@ inline void Module::EmitPacket(const Task *task, bess::Packet *pkt,
       } else {
         task->set_gate_batch(ogate, task->get_gate_batch(igate));
       }
-      gate_without_hook_[gate_without_hook_cnt_++] = ogate_idx;
+      ctx->gate_without_hook[ctx->gate_without_hook_cnt++] = ogate_idx;
     }
   }
 
@@ -569,10 +583,12 @@ inline void Module::EmitPacket(const Task *task, bess::Packet *pkt,
   batch->add(pkt);
 }
 
-inline void Module::ProcessOGates(const Task *task) {
+inline void Module::ProcessOGates(Context *ctx) {
+  Task *task = ctx->task;
+
   // Running ogate hooks, then add next igate to be scheduled
-  for (int i = 0; i < gate_with_hook_cnt_; i++) {
-    bess::OGate *ogate = ogates_[gate_with_hook_[i]];  // should not be null
+  for (int i = 0; i < ctx->gate_with_hook_cnt; i++) {
+    bess::OGate *ogate = ogates_[ctx->gate_with_hook[i]];  // should not be null
     for (auto &hook : ogate->hooks()) {
       hook->ProcessBatch(task->get_gate_batch(ogate));
     }
@@ -581,16 +597,17 @@ inline void Module::ProcessOGates(const Task *task) {
   }
 
   // Clear packet batch for ogates without hook
-  for (int i = 0; i < gate_without_hook_cnt_; i++) {
-    bess::OGate *ogate = ogates_[gate_without_hook_[i]];  // should not be null
+  for (int i = 0; i < ctx->gate_without_hook_cnt; i++) {
+    bess::OGate *ogate =
+        ogates_[ctx->gate_without_hook[i]];  // should not be null
     task->set_gate_batch(ogate, nullptr);
   }
 
-  gate_with_hook_cnt_ = 0;
-  gate_without_hook_cnt_ = 0;
+  ctx->gate_with_hook_cnt = 0;
+  ctx->gate_without_hook_cnt = 0;
 }
 
-inline void Module::RunSplit(const Task *task, const gate_idx_t *out_gates,
+inline void Module::RunSplit(Context *ctx, const gate_idx_t *out_gates,
                              bess::PacketBatch *mixed_batch) {
   int pkt_cnt = mixed_batch->cnt();
   if (unlikely(pkt_cnt <= 0)) {
@@ -599,12 +616,12 @@ inline void Module::RunSplit(const Task *task, const gate_idx_t *out_gates,
 
   int gate_cnt = ogates_.size();
   if (unlikely(gate_cnt <= 0)) {
-    deadend(mixed_batch);
+    deadend(ctx, mixed_batch);
     return;
   }
 
   for (int i = 0; i < pkt_cnt; i++) {
-    EmitPacket(task, mixed_batch->pkts()[i], out_gates[i]);
+    EmitPacket(ctx, mixed_batch->pkts()[i], out_gates[i]);
   }
 
   mixed_batch->clear();

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -35,6 +35,7 @@
 #include "gate.h"
 #include "gate_hooks/track.h"
 #include "module.h"
+#include "scheduler.h"
 #include "utils/extended_priority_queue.h"
 
 std::map<std::string, Module *> ModuleGraph::all_modules_;

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -203,8 +203,6 @@ void ModuleGraph::UpdateTaskGraph() {
 
   // Do not change order here
 
-  // Do not change order here
-
   CleanTaskGraph();
 
   for (auto const &task : tasks_) {

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -203,6 +203,8 @@ void ModuleGraph::UpdateTaskGraph() {
 
   // Do not change order here
 
+  // Do not change order here
+
   CleanTaskGraph();
 
   for (auto const &task : tasks_) {

--- a/core/module_test.cc
+++ b/core/module_test.cc
@@ -73,8 +73,7 @@ class AcmeModuleWithTask : public Module {
 
   CommandResponse Init(const bess::pb::EmptyArg &) { return CommandResponse(); }
 
-  struct task_result RunTask(const Task *, bess::PacketBatch *,
-                             void *) override {
+  struct task_result RunTask(Context *, bess::PacketBatch *, void *) override {
     return task_result();
   }
 };

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -62,12 +62,12 @@ CommandResponse ACL::CommandClear(const bess::pb::EmptyArg &) {
   return CommandSuccess();
 }
 
-void ACL::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void ACL::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Udp;
 
-  gate_idx_t incoming_gate = task->get_igate();
+  gate_idx_t incoming_gate = ctx->current_igate;
 
   int cnt = batch->cnt();
   for (int i = 0; i < cnt; i++) {
@@ -84,14 +84,14 @@ void ACL::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       if (rule.Match(ip->src, ip->dst, udp->src_port, udp->dst_port)) {
         if (!rule.drop) {
           emitted = true;
-          EmitPacket(task, pkt, incoming_gate);
+          EmitPacket(ctx, pkt, incoming_gate);
         }
         break;  // Stop matching other rules
       }
     }
 
     if (!emitted) {
-      DropPacket(task, pkt);
+      DropPacket(ctx, pkt);
     }
   }
 }

--- a/core/modules/acl.h
+++ b/core/modules/acl.h
@@ -62,7 +62,7 @@ class ACL final : public Module {
 
   CommandResponse Init(const bess::pb::ACLArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::ACLArg &arg);
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/arp_responder.h
+++ b/core/modules/arp_responder.h
@@ -59,7 +59,7 @@ class ArpResponder final : public Module {
 
   static const Commands cmds;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::ArpResponderArg &arg);
 

--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -1206,7 +1206,9 @@ void BPF::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   }
 
   // slow version for general cases
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+
+  for (int i = 0; i < cnt; i++) {
     gate_idx_t gate = 0;  // default gate for unmatched pkts
     bess::Packet *pkt = batch->pkts()[i];
 

--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -1177,7 +1177,7 @@ inline bool BPF::Match(const Filter &filter, u_char *pkt, u_int wirelen,
   return ret != 0;
 }
 
-void BPF::ProcessBatch1Filter(const Task *task, bess::PacketBatch *batch) {
+void BPF::ProcessBatch1Filter(Context *ctx, bess::PacketBatch *batch) {
   const Filter &filter = filters_[0];
 
   int cnt = batch->cnt();
@@ -1187,21 +1187,21 @@ void BPF::ProcessBatch1Filter(const Task *task, bess::PacketBatch *batch) {
 
     if (Match(filter, pkt->head_data<u_char *>(), pkt->total_len(),
               pkt->head_len())) {
-      EmitPacket(task, pkt, filter.gate);
+      EmitPacket(ctx, pkt, filter.gate);
     } else {
-      EmitPacket(task, pkt);
+      EmitPacket(ctx, pkt);
     }
   }
 }
 
-void BPF::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void BPF::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int n_filters = filters_.size();
 
   if (n_filters == 0) {
-    RunNextModule(task, batch);
+    RunNextModule(ctx, batch);
     return;
   } else if (n_filters == 1) {
-    ProcessBatch1Filter(task, batch);
+    ProcessBatch1Filter(ctx, batch);
     return;
   }
 
@@ -1220,7 +1220,7 @@ void BPF::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
         break;
       }
     }
-    EmitPacket(task, pkt, gate);
+    EmitPacket(ctx, pkt, gate);
   }
 }
 

--- a/core/modules/bpf.h
+++ b/core/modules/bpf.h
@@ -51,7 +51,7 @@ class BPF final : public Module {
   CommandResponse Init(const bess::pb::BPFArg &arg);
   void DeInit() override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::BPFArg &arg);
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
@@ -71,7 +71,7 @@ class BPF final : public Module {
 
   static bool Match(const Filter &, u_char *, u_int, u_int);
 
-  void ProcessBatch1Filter(const Task *task, bess::PacketBatch *batch);
+  void ProcessBatch1Filter(Context *ctx, bess::PacketBatch *batch);
 
   std::vector<Filter> filters_;
 };

--- a/core/modules/buffer.cc
+++ b/core/modules/buffer.cc
@@ -35,7 +35,7 @@ void Buffer::DeInit() {
   bess::Packet::Free(buf);
 }
 
-void Buffer::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Buffer::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   bess::PacketBatch *buf = &buf_;
 
   int free_slots = bess::PacketBatch::kMaxBurst - buf->cnt();
@@ -53,10 +53,10 @@ void Buffer::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     p_batch += free_slots;
     left -= free_slots;
 
-    bess::PacketBatch *new_batch = task->AllocPacketBatch();
+    bess::PacketBatch *new_batch = ctx->task->AllocPacketBatch();
     new_batch->Copy(buf);
     buf->clear();
-    RunNextModule(task, new_batch);
+    RunNextModule(ctx, new_batch);
   }
 
   buf->incr_cnt(left);

--- a/core/modules/buffer.h
+++ b/core/modules/buffer.h
@@ -40,7 +40,7 @@ class Buffer final : public Module {
 
   void DeInit() override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   bess::PacketBatch buf_;

--- a/core/modules/bypass.cc
+++ b/core/modules/bypass.cc
@@ -44,7 +44,8 @@ void Bypass::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
   if (cycles_per_byte_) {
     uint64_t total_bytes = 0;
-    for (int i = 0; i < batch->cnt(); i++) {
+    int cnt = batch->cnt();
+    for (int i = 0; i < cnt; i++) {
       total_bytes = batch->pkts()[i]->total_len();
     }
     cycles += cycles_per_byte_ * total_bytes;

--- a/core/modules/bypass.cc
+++ b/core/modules/bypass.cc
@@ -38,7 +38,7 @@ CommandResponse Bypass::Init(const bess::pb::BypassArg &arg) {
   return CommandSuccess();
 }
 
-void Bypass::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Bypass::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   uint64_t start_tsc = rdtsc();
   uint64_t cycles = cycles_per_batch_ + cycles_per_packet_ * batch->cnt();
 
@@ -58,7 +58,7 @@ void Bypass::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       _mm_pause();
     }
   }
-  RunChooseModule(task, task->get_igate(), batch);
+  RunChooseModule(ctx, ctx->current_igate, batch);
 }
 
 ADD_MODULE(Bypass, "bypass", "bypasses packets without any processing")

--- a/core/modules/bypass.h
+++ b/core/modules/bypass.h
@@ -45,7 +45,7 @@ class Bypass final : public Module {
 
   CommandResponse Init(const bess::pb::BypassArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   uint32_t cycles_per_batch_;

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -124,7 +124,8 @@ void DRR::ProcessBatch(const Task*, bess::PacketBatch* batch) {
   int err = 0;
 
   // insert packets in the batch into their corresponding flows
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet* pkt = batch->pkts()[i];
 
     // TODO(joshua): Add support for fragmented packets.

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -120,7 +120,7 @@ CommandResponse DRR::CommandMaxFlowQueueSize(
   return SetMaxFlowQueueSize(arg.max_queue_size());
 }
 
-void DRR::ProcessBatch(const Task*, bess::PacketBatch* batch) {
+void DRR::ProcessBatch(Context *, bess::PacketBatch *batch) {
   int err = 0;
 
   // insert packets in the batch into their corresponding flows
@@ -148,8 +148,7 @@ void DRR::ProcessBatch(const Task*, bess::PacketBatch* batch) {
   }
 }
 
-struct task_result DRR::RunTask(const Task* task, bess::PacketBatch* batch,
-                                void*) {
+struct task_result DRR::RunTask(Context* ctx, bess::PacketBatch* batch, void*) {
   if (children_overload_ > 0) {
     return {
         .block = true, .packets = 0, .bits = 0,
@@ -165,7 +164,7 @@ struct task_result DRR::RunTask(const Task* task, bess::PacketBatch* batch,
   assert(err >= 0);  // TODO(joshua) do proper error checking
 
   if (total_bytes > 0) {
-    RunNextModule(task, batch);
+    RunNextModule(ctx, batch);
   }
 
   // the number of bits inserted into the packet batch

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -161,9 +161,9 @@ class DRR final : public Module {
 
   CommandResponse Init(const bess::pb::DRRArg& arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void* arg) override;
 
   CommandResponse CommandQuantumSize(const bess::pb::DRRQuantumArg& arg);

--- a/core/modules/drr.h
+++ b/core/modules/drr.h
@@ -45,34 +45,34 @@
 using bess::utils::Ipv4Prefix;
 using bess::utils::CuckooMap;
 
-/*
-  * This module implements Deficit Round Robin, a fair queueing algorithm, for
-  * flows. On receiving each packet, they are assigned to a flow's queue based
-  * on their 5 tuple. On running a task, the module goes through the flows in
-  * round robin fashion adding a quantum to their deficit(allocated bytes).
-  * The module will then query each of those flows for packets until their
-  * deficit falls below the next packet's size. After a obtaining a 32
-  * packets(a full batch), the module passes these packets onto the next module.
-  *
-  * based on this:
-  *  https://en.wikipedia.org/wiki/Deficit_round_robin
-  * EXPECTS: Input packets in any format
-  *
-  * MODIFICATIONS: None
-  *
-  * INPUT GATES: 1
-  *
-  * OUTPUT GATES: 1
-  *
-  * PARAMETERS:
-  *    * quantum: the number of bytes allocated to each flow on each round
-  *    * Max Number of flows: max number of flows the module will handle
-  *    * Max Flow Queue Size: the maximum size that any Flows queue can get
-  *          before the module will start dropping the flows packets
-  * COMMANDS
-  *    update quantum: cannot not be done live
-  *    update Max Flow Queue Size: can be done live
-*/
+//
+// This module implements Deficit Round Robin, a fair queueing algorithm, for
+// flows. On receiving each packet, they are assigned to a flow's queue based
+// on their 5 tuple. On running a task, the module goes through the flows in
+// round robin fashion adding a quantum to their deficit(allocated bytes).
+// The module will then query each of those flows for packets until their
+// deficit falls below the next packet's size. After a obtaining a 32
+// packets(a full batch), the module passes these packets onto the next module.
+//
+// based on this:
+//  https://en.wikipedia.org/wiki/Deficit_round_robin
+// EXPECTS: Input packets in any format
+//
+// MODIFICATIONS: None
+//
+// INPUT GATES: 1
+//
+// OUTPUT GATES: 1
+//
+// PARAMETERS:
+//    * quantum: the number of bytes allocated to each flow on each round
+//    * Max Number of flows: max number of flows the module will handle
+//    * Max Flow Queue Size: the maximum size that any Flows queue can get
+//          before the module will start dropping the flows packets
+// COMMANDS
+//    update quantum: cannot not be done live
+//    update Max Flow Queue Size: can be done live
+//
 class DRR final : public Module {
  public:
   // the default max number of flows allowed + 1
@@ -97,23 +97,21 @@ class DRR final : public Module {
     uint8_t protocol;
   };
 
-  /*
-   stores the metrics of the flow, a timer and the queue to store the packets
-   in.
-  */
+  // stores the metrics of the flow, a timer and the queue to store the packets
+  // in.
   struct Flow {
     int deficit;                // the allocated bytes to the flow
     double timer;               // to determine if TTL should be used
     FlowId id;                  // allows the flow to remove itself from the map
-    struct llring* queue;       // queue to store current packets for flow
-    bess::Packet* next_packet;  // buffer to store next packet from the queue.
+    struct llring *queue;       // queue to store current packets for flow
+    bess::Packet *next_packet;  // buffer to store next packet from the queue.
     Flow() : deficit(0), timer(0), id(), next_packet(nullptr){};
     Flow(FlowId new_id)
         : deficit(0), timer(0), id(new_id), next_packet(nullptr){};
     ~Flow() {
       if (queue) {
-        bess::Packet* pkt;
-        while (llring_sc_dequeue(queue, reinterpret_cast<void**>(&pkt)) == 0) {
+        bess::Packet *pkt;
+        while (llring_sc_dequeue(queue, reinterpret_cast<void **>(&pkt)) == 0) {
           bess::Packet::Free(pkt);
         }
 
@@ -129,11 +127,11 @@ class DRR final : public Module {
   // hashes a FlowId
   struct Hash {
     // a similar method to boost's hash_combine in order to combine hashes
-    inline void combine(std::size_t& hash, const unsigned int& val) const {
+    inline void combine(std::size_t &hash, const unsigned int &val) const {
       std::hash<unsigned int> hasher;
       hash ^= hasher(val) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     }
-    bess::utils::HashResult operator()(const FlowId& id) const {
+    bess::utils::HashResult operator()(const FlowId &id) const {
       std::size_t hash = 0;
       combine(hash, id.src_ip);
       combine(hash, id.dst_ip);
@@ -146,7 +144,7 @@ class DRR final : public Module {
 
   // to compare two FlowId for equality in a hash table
   struct EqualTo {
-    bool operator()(const FlowId& id1, const FlowId& id2) const {
+    bool operator()(const FlowId &id1, const FlowId &id2) const {
       bool ips = (id1.src_ip == id2.src_ip) && (id1.dst_ip == id2.dst_ip);
       bool ports =
           (id1.src_port == id2.src_port) && (id1.dst_port == id2.dst_port);
@@ -159,102 +157,82 @@ class DRR final : public Module {
 
   static const Commands cmds;
 
-  CommandResponse Init(const bess::pb::DRRArg& arg);
+  CommandResponse Init(const bess::pb::DRRArg &arg);
 
   void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
-                             void* arg) override;
+                             void *arg) override;
 
-  CommandResponse CommandQuantumSize(const bess::pb::DRRQuantumArg& arg);
+  CommandResponse CommandQuantumSize(const bess::pb::DRRQuantumArg &arg);
   CommandResponse CommandMaxFlowQueueSize(
-      const bess::pb::DRRMaxFlowQueueSizeArg& arg);
+      const bess::pb::DRRMaxFlowQueueSizeArg &arg);
 
  private:
-  /*
-    Sets the quantum: the number of bytes allocated to each flow on every round
-    Takes the size to set the quantum to. Returns 0 on success and error value
-    otherwise.
-  */
+  //  Sets the quantum: the number of bytes allocated to each flow on every
+  //  round
+  //  Takes the size to set the quantum to. Returns 0 on success and error value
+  //  otherwise.
   CommandResponse SetQuantumSize(uint32_t size);
 
-  /*
-    Sets the maximum size that any Flows queue can get before the module will
-    start dropping the flows packets. Takes the maximum size for any Flows
-    queue.
-    Returns 0 on success and error value otherwise.
-  */
+  //  Sets the maximum size that any Flows queue can get before the module will
+  //  start dropping the flows packets. Takes the maximum size for any Flows
+  //  queue.
+  //  Returns 0 on success and error value otherwise.
   CommandResponse SetMaxFlowQueueSize(uint32_t queue_size);
 
-  /*
-    Creates a new larger llring queue of the specifed size and moves over all
-    of the entries from the old queue and frees the old_queue. Takes a pointer
-    to the
-    location of the  current queue, the new size of the queue and integer
-    pointer
-    to set on error. If the integer pointer is set than the return value will be
-    a
-    nullptr. Returns a pointer to the new llring otherwise.
-  */
-  llring* ResizeQueue(llring* old_queue, uint32_t new_size, int* err);
+  //  Creates a new larger llring queue of the specifed size and moves over all
+  //  of the entries from the old queue and frees the old_queue. Takes a pointer
+  //  to the
+  //  location of the  current queue, the new size of the queue and integer
+  //  pointer
+  //  to set on error. If the integer pointer is set than the return value will
+  //  be
+  //  a
+  //  nullptr. Returns a pointer to the new llring otherwise.
+  llring *ResizeQueue(llring *old_queue, uint32_t new_size, int *err);
 
-  /*
-    Puts the packet into the llring queue within the flow. Takes the flow to
-    enqueue the packet into, the packet to enqueue into the flow's queue
-    and integer pointer to be set on error.
-  */
-  void Enqueue(Flow* f, bess::Packet* pkt, int* err);
+  //  Puts the packet into the llring queue within the flow. Takes the flow to
+  //  enqueue the packet into, the packet to enqueue into the flow's queue
+  //  and integer pointer to be set on error.
+  void Enqueue(Flow *f, bess::Packet *pkt, int *err);
 
-  /*
-    Takes a Packet to get a flow id for. Returns the 5 element identifier for
-    the flow that the packet belongs to
-  */
-  FlowId GetId(bess::Packet* pkt);
+  //  Takes a Packet to get a flow id for. Returns the 5 element identifier for
+  //  the flow that the packet belongs to
+  FlowId GetId(bess::Packet *pkt);
 
-  /*
-    Creates a new flow and adds it to the round robin queue. Takes the first pkt
-    to be enqueued in the new flow, the id of the new flow to be created and
-    integer pointer to set on error.
-  */
-  void AddNewFlow(bess::Packet* pkt, FlowId id, int* err);
+  //  Creates a new flow and adds it to the round robin queue. Takes the first
+  //  pkt
+  //  to be enqueued in the new flow, the id of the new flow to be created and
+  //  integer pointer to set on error.
+  void AddNewFlow(bess::Packet *pkt, FlowId id, int *err);
 
-  /*
-    Removes the flow from the hash table and frees all the packets within its
-    queue. Takes the pointer to the flow to remove
-  */
-  void RemoveFlow(Flow* f);
+  //  Removes the flow from the hash table and frees all the packets within its
+  //  queue. Takes the pointer to the flow to remove
+  void RemoveFlow(Flow *f);
 
-  /*
-    Obtain the next batch of packets from the next flows in round robin.
-    Takes a PacketBatch to insert the packets into and integer pointer
-    to set on error. Returns total bytes added to batch.
+  //  Obtain the next batch of packets from the next flows in round robin.
+  //  Takes a PacketBatch to insert the packets into and integer pointer
+  //  to set on error. Returns total bytes added to batch.
+  uint32_t GetNextBatch(bess::PacketBatch *batch, int *err);
 
-  */
-  uint32_t GetNextBatch(bess::PacketBatch* batch, int* err);
+  //  gets the next set of packets from flow given allocated bytes
+  //  Takes the PacketBatch to put the packets into and the flow to get the
+  //  packets
+  //  from and integer pointer to set on error. Returns the total bytes put in
+  //  batch
+  uint32_t GetNextPackets(bess::PacketBatch *batch, Flow *f, int *err);
 
-  /*
-    gets the next set of packets from flow given allocated bytes
-    Takes the PacketBatch to put the packets into and the flow to get the
-    packets
-    from and integer pointer to set on error. Returns the total bytes put in
-    batch
-  */
-  uint32_t GetNextPackets(bess::PacketBatch* batch, Flow* f, int* err);
+  //  gets the next flow from the queue of flows. Returns nullptr if the next
+  //  flow is empty or if the flow is deleted. If there is a an error returns
+  //  an error and sets the integer pointer to error value.
+  Flow *GetNextFlow(int *err);
 
-  /*
-    gets the next flow from the queue of flows. Returns nullptr if the next
-    flow is empty or if the flow is deleted. If there is a an error returns
-    an error and sets the integer pointer to error value.
-   */
-  Flow* GetNextFlow(int* err);
-
-  /*
-    allocates llring queue space and adds the queue to the specified flow with
-    size indicated by slots. Takes the Flow to add the queue, the number
-    of slots for the queue to have and the integer pointer to set on error.
-    Returns a llring queue.
-  */
-  llring* AddQueue(uint32_t slots, int* err);
+  //  allocates llring queue space and adds the queue to the specified flow with
+  //  size indicated by slots. Takes the Flow to add the queue, the number
+  //  of slots for the queue to have and the integer pointer to set on error.
+  //  Returns a llring queue.
+  llring *AddQueue(uint32_t slots, int *err);
 
   // the number of bytes to allocate to each flow in each round.
   uint32_t quantum_;
@@ -267,8 +245,8 @@ class DRR final : public Module {
   uint32_t max_number_flows_;
 
   // state map used to reunite packets with their flow
-  CuckooMap<FlowId, Flow*, Hash, EqualTo> flows_;
-  llring* flow_ring_;   // llring used for round robin.
-  Flow* current_flow_;  // store current flow between batch rounds.
+  CuckooMap<FlowId, Flow *, Hash, EqualTo> flows_;
+  llring *flow_ring_;   // llring used for round robin.
+  Flow *current_flow_;  // store current flow between batch rounds.
 };
 #endif  // BESS_MODULES_DRR_H_

--- a/core/modules/dump.h
+++ b/core/modules/dump.h
@@ -38,7 +38,7 @@ class Dump final : public Module {
  public:
   CommandResponse Init(const bess::pb::DumpArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandSetInterval(const bess::pb::DumpArg &arg);
 

--- a/core/modules/ether_encap.cc
+++ b/core/modules/ether_encap.cc
@@ -51,7 +51,7 @@ CommandResponse EtherEncap::Init(
   return CommandSuccess();
 };
 
-void EtherEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void EtherEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
@@ -77,7 +77,7 @@ void EtherEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     eth->ether_type = ether_type;
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(EtherEncap, "ether_encap",

--- a/core/modules/ether_encap.h
+++ b/core/modules/ether_encap.h
@@ -40,7 +40,7 @@ class EtherEncap final : public Module {
 
   CommandResponse Init(const bess::pb::EtherEncapArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_ETHERENCAP_H_

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -236,7 +236,8 @@ void ExactMatch::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   };
   table_.MakeKeys(batch, buffer_fn, keys);
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
     EmitPacket(task, pkt, table_.Find(keys[i], default_gate));
   }

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -221,7 +221,7 @@ CommandResponse ExactMatch::SetRuntimeConfig(
   return CommandSuccess();
 }
 
-void ExactMatch::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void ExactMatch::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   gate_idx_t default_gate;
   ExactMatchKey keys[bess::PacketBatch::kMaxBurst] __ymm_aligned;
 
@@ -239,7 +239,7 @@ void ExactMatch::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
-    EmitPacket(task, pkt, table_.Find(keys[i], default_gate));
+    EmitPacket(ctx, pkt, table_.Find(keys[i], default_gate));
   }
 }
 

--- a/core/modules/exact_match.h
+++ b/core/modules/exact_match.h
@@ -55,7 +55,7 @@ class ExactMatch final : public Module {
     max_allowed_workers_ = Worker::kMaxWorkers;
   }
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   std::string GetDesc() const override;
 

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -473,8 +473,8 @@ bess::Packet *FlowGen::FillPacket(struct flow *f) {
   return pkt;
 }
 
-void FlowGen::GeneratePackets(bess::PacketBatch *batch) {
-  uint64_t now = ctx.current_ns();
+void FlowGen::GeneratePackets(Context *ctx, bess::PacketBatch *batch) {
+  uint64_t now = ctx->current_ns;
 
   batch->clear();
   const int burst = ACCESS_ONCE(burst_);
@@ -509,7 +509,7 @@ void FlowGen::GeneratePackets(bess::PacketBatch *batch) {
   }
 }
 
-struct task_result FlowGen::RunTask(const Task *task, bess::PacketBatch *batch,
+struct task_result FlowGen::RunTask(Context *ctx, bess::PacketBatch *batch,
                                     void *) {
   if (children_overload_ > 0) {
     return {
@@ -519,8 +519,8 @@ struct task_result FlowGen::RunTask(const Task *task, bess::PacketBatch *batch,
 
   const int pkt_overhead = 24;
 
-  GeneratePackets(batch);
-  RunNextModule(task, batch);
+  GeneratePackets(ctx, batch);
+  RunNextModule(ctx, batch);
 
   uint32_t cnt = batch->cnt();
   return {.block = (cnt == 0),

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -99,7 +99,7 @@ class FlowGen final : public Module {
 
   void DeInit() override;
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void *arg) override;
 
   std::string GetDesc() const override;
@@ -115,7 +115,7 @@ class FlowGen final : public Module {
 
   CommandResponse UpdateBaseAddresses();
   bess::Packet *FillPacket(struct flow *f);
-  void GeneratePackets(bess::PacketBatch *batch);
+  void GeneratePackets(Context *ctx, bess::PacketBatch *batch);
 
   CommandResponse ProcessArguments(const bess::pb::FlowGenArg &arg);
 

--- a/core/modules/generic_decap.cc
+++ b/core/modules/generic_decap.cc
@@ -41,7 +41,7 @@ CommandResponse GenericDecap::Init(const bess::pb::GenericDecapArg &arg) {
   return CommandSuccess();
 }
 
-void GenericDecap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void GenericDecap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   int decap_size = decap_size_;
@@ -50,7 +50,7 @@ void GenericDecap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     batch->pkts()[i]->adj(decap_size);
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(GenericDecap, "generic_decap",

--- a/core/modules/generic_decap.h
+++ b/core/modules/generic_decap.h
@@ -42,7 +42,7 @@ class GenericDecap final : public Module {
 
   CommandResponse Init(const bess::pb::GenericDecapArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   int decap_size_;

--- a/core/modules/generic_encap.cc
+++ b/core/modules/generic_encap.cc
@@ -125,7 +125,7 @@ CommandResponse GenericEncap::Init(const bess::pb::GenericEncapArg &arg) {
   return CommandSuccess();
 }
 
-void GenericEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void GenericEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   int encap_size = encap_size_;
@@ -159,7 +159,7 @@ void GenericEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     bess::utils::CopyInlined(p, headers[i], encap_size);
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(GenericEncap, "generic_encap",

--- a/core/modules/generic_encap.h
+++ b/core/modules/generic_encap.h
@@ -52,7 +52,7 @@ class GenericEncap final : public Module {
 
   CommandResponse Init(const bess::pb::GenericEncapArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   CommandResponse AddFieldOne(const bess::pb::GenericEncapArg_EncapField &field,

--- a/core/modules/hash_lb.cc
+++ b/core/modules/hash_lb.cc
@@ -152,14 +152,15 @@ inline void HashLB::DoProcessBatch<HashLB::Mode::kOther>(
 
   for (size_t i = 0; i < cnt; i++) {
     EmitPacket(task, batch->pkts()[i],
-        gates_[hash_range(hasher_(keys[i]), num_gates_)]);
+               gates_[hash_range(hasher_(keys[i]), num_gates_)]);
   }
 }
 
 template <>
 inline void HashLB::DoProcessBatch<HashLB::Mode::kL2>(
-    const Task *task, bess::PacketBatch *batch)  {
-  for (int i = 0; i < batch->cnt(); i++) {
+    const Task *task, bess::PacketBatch *batch) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *snb = batch->pkts()[i];
     char *head = snb->head_data<char *>();
 
@@ -178,7 +179,8 @@ inline void HashLB::DoProcessBatch<HashLB::Mode::kL3>(
   /* assumes untagged packets */
   const int ip_offset = 14;
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *snb = batch->pkts()[i];
     char *head = snb->head_data<char *>();
 
@@ -198,7 +200,8 @@ inline void HashLB::DoProcessBatch<HashLB::Mode::kL4>(
   const int ip_offset = 14;
   const int l4_offset = ip_offset + 20;
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *snb = batch->pkts()[i];
     char *head = snb->head_data<char *>();
 

--- a/core/modules/hash_lb.h
+++ b/core/modules/hash_lb.h
@@ -55,7 +55,7 @@ class HashLB final : public Module {
 
   std::string GetDesc() const override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandSetMode(const bess::pb::HashLBCommandSetModeArg &arg);
   CommandResponse CommandSetGates(
@@ -66,7 +66,7 @@ class HashLB final : public Module {
   static constexpr Mode kDefaultMode = Mode::kL4;
 
   template <Mode mode>
-  inline void DoProcessBatch(const Task *task, bess::PacketBatch *batch);
+  inline void DoProcessBatch(Context *ctx, bess::PacketBatch *batch);
 
   static constexpr size_t kMaxGates = 16384;
 

--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -34,7 +34,7 @@
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 
-void IPChecksum::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Vlan;
@@ -73,7 +73,7 @@ void IPChecksum::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     ip->checksum = CalculateIpv4Checksum(*ip);
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(IPChecksum, "ip_checksum", "recomputes the IPv4 checksum")

--- a/core/modules/ip_checksum.h
+++ b/core/modules/ip_checksum.h
@@ -39,7 +39,7 @@ class IPChecksum final : public Module {
  public:
   IPChecksum() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_IP_CHECKSUM_H_

--- a/core/modules/ip_encap.cc
+++ b/core/modules/ip_encap.cc
@@ -59,7 +59,7 @@ CommandResponse IPEncap::Init(const bess::pb::IPEncapArg &arg[[maybe_unused]]) {
   return CommandSuccess();
 }
 
-void IPEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void IPEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
@@ -96,7 +96,7 @@ void IPEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
                      be16_t(Ethernet::Type::kIpv4));
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(IPEncap, "ip_encap", "encapsulates packets with an IPv4 header")

--- a/core/modules/ip_encap.h
+++ b/core/modules/ip_encap.h
@@ -40,7 +40,7 @@ class IPEncap final : public Module {
 
   CommandResponse Init(const bess::pb::IPEncapArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_IPENCAP_H_

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -77,7 +77,7 @@ void IPLookup::DeInit() {
   }
 }
 
-void IPLookup::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void IPLookup::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
 
@@ -122,10 +122,10 @@ void IPLookup::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
     rte_lpm_lookupx4(lpm_, ip_addr, next_hops, default_gate);
 
-    EmitPacket(task, batch->pkts()[i], next_hops[0]);
-    EmitPacket(task, batch->pkts()[i + 1], next_hops[1]);
-    EmitPacket(task, batch->pkts()[i + 2], next_hops[2]);
-    EmitPacket(task, batch->pkts()[i + 3], next_hops[3]);
+    EmitPacket(ctx, batch->pkts()[i], next_hops[0]);
+    EmitPacket(ctx, batch->pkts()[i + 1], next_hops[1]);
+    EmitPacket(ctx, batch->pkts()[i + 2], next_hops[2]);
+    EmitPacket(ctx, batch->pkts()[i + 3], next_hops[3]);
   }
 #endif
 
@@ -143,9 +143,9 @@ void IPLookup::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     ret = rte_lpm_lookup(lpm_, ip->dst.value(), &next_hop);
 
     if (ret == 0) {
-      EmitPacket(task, batch->pkts()[i], next_hop);
+      EmitPacket(ctx, batch->pkts()[i], next_hop);
     } else {
-      EmitPacket(task, batch->pkts()[i], default_gate);
+      EmitPacket(ctx, batch->pkts()[i], default_gate);
     }
   }
 }

--- a/core/modules/ip_lookup.h
+++ b/core/modules/ip_lookup.h
@@ -52,7 +52,7 @@ class IPLookup final : public Module {
 
   void DeInit() override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::IPLookupCommandAddArg &arg);
   CommandResponse CommandDelete(const bess::pb::IPLookupCommandDeleteArg &arg);

--- a/core/modules/ipswap.cc
+++ b/core/modules/ipswap.cc
@@ -34,7 +34,7 @@
 #include "utils/ip.h"
 #include "utils/udp.h"
 
-void IPSwap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void IPSwap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Udp;
@@ -71,7 +71,7 @@ void IPSwap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(IPSwap, "ipswap",

--- a/core/modules/ipswap.h
+++ b/core/modules/ipswap.h
@@ -38,7 +38,7 @@ class IPSwap final : public Module {
  public:
   IPSwap() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_IPSWAP_H_

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -590,7 +590,8 @@ void L2Forward::DeInit() {
 void L2Forward::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   gate_idx_t default_gate = ACCESS_ONCE(default_gate_);
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *snb = batch->pkts()[i];
 
     gate_idx_t out_gate;

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -587,7 +587,7 @@ void L2Forward::DeInit() {
   l2_deinit(&l2_table_);
 }
 
-void L2Forward::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void L2Forward::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   gate_idx_t default_gate = ACCESS_ONCE(default_gate_);
 
   int cnt = batch->cnt();
@@ -601,9 +601,9 @@ void L2Forward::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
                       *(snb->head_data<uint64_t *>()) & 0x0000ffffffffffff,
                       &out_gate);
     if (ret != 0) {
-      EmitPacket(task, snb, default_gate);
+      EmitPacket(ctx, snb, default_gate);
     } else {
-      EmitPacket(task, snb, out_gate);
+      EmitPacket(ctx, snb, out_gate);
     }
   }
 }

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -71,7 +71,7 @@ class L2Forward final : public Module {
 
   void DeInit() override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::L2ForwardCommandAddArg &arg);
   CommandResponse CommandDelete(const bess::pb::L2ForwardCommandDeleteArg &arg);

--- a/core/modules/l4_checksum.cc
+++ b/core/modules/l4_checksum.cc
@@ -36,7 +36,7 @@
 #include "../utils/tcp.h"
 #include "../utils/udp.h"
 
-void L4Checksum::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void L4Checksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Tcp;
@@ -69,7 +69,7 @@ void L4Checksum::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     continue;
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(L4Checksum, "l4_checksum",

--- a/core/modules/l4_checksum.h
+++ b/core/modules/l4_checksum.h
@@ -37,7 +37,7 @@
 class L4Checksum final : public Module {
  public:
   L4Checksum() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_L4_CHECKSUM_H_

--- a/core/modules/macswap.cc
+++ b/core/modules/macswap.cc
@@ -32,7 +32,7 @@
 
 #include "../utils/ether.h"
 
-void MACSwap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void MACSwap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
 
   int cnt = batch->cnt();
@@ -46,7 +46,7 @@ void MACSwap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     eth->src_addr = tmp;
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(MACSwap, "macswap", "swaps source/destination MAC addresses")

--- a/core/modules/macswap.h
+++ b/core/modules/macswap.h
@@ -37,7 +37,7 @@ class MACSwap final : public Module {
  public:
   MACSwap() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_MACSWAP_H_

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -109,7 +109,8 @@ void Measure::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
   pkt_cnt_ += batch->cnt();
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     uint64_t pkt_time;
     if (IsTimestamped(batch->pkts()[i], offset, &pkt_time)) {
       uint64_t diff;

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -99,7 +99,7 @@ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
   return CommandSuccess();
 }
 
-void Measure::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Measure::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   // We don't use ctx->current_ns here for better accuracy
   uint64_t now_ns = tsc_to_ns(rdtsc());
   size_t offset = offset_;
@@ -139,7 +139,7 @@ void Measure::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
   mcs_unlock(&lock_, &mynode);
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 template <typename T>

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -54,7 +54,7 @@ class Measure final : public Module {
 
   CommandResponse Init(const bess::pb::MeasureArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandGetSummary(
       const bess::pb::MeasureCommandGetSummaryArg &arg);

--- a/core/modules/merge.cc
+++ b/core/modules/merge.cc
@@ -30,8 +30,8 @@
 
 #include "merge.h"
 
-void Merge::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
-  RunNextModule(task, batch);
+void Merge::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(Merge, "merge", "All input gates go out of a single output gate")

--- a/core/modules/merge.h
+++ b/core/modules/merge.h
@@ -39,7 +39,7 @@ class Merge final : public Module {
 
   static const gate_idx_t kNumIGates = MAX_GATES;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_MERGE_H_

--- a/core/modules/mpls_pop.cc
+++ b/core/modules/mpls_pop.cc
@@ -48,7 +48,7 @@ MPLSPop::MPLSPop()
   max_allowed_workers_ = Worker::kMaxWorkers;
 }
 
-void MPLSPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void MPLSPop::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
@@ -58,7 +58,7 @@ void MPLSPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
     if (eth->ether_type != be16_t(Ethernet::Type::kMpls)) {
       // non MPLS packets are sent to different output gate
-      EmitPacket(task, pkt, 1);
+      EmitPacket(ctx, pkt, 1);
       continue;
     }
 
@@ -78,7 +78,7 @@ void MPLSPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       eth_new->dst_addr = dst_addr;
       eth_new->ether_type = next_ether_type_;
     }
-    EmitPacket(task, pkt, 0);
+    EmitPacket(ctx, pkt, 0);
   }
 }
 

--- a/core/modules/mpls_pop.cc
+++ b/core/modules/mpls_pop.cc
@@ -61,7 +61,6 @@ void MPLSPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       EmitPacket(task, pkt, 1);
       continue;
     }
-    EmitPacket(task, pkt, 0);
 
     // TODO(gsagie) save the MPLS label as metadata
     // Mpls *mpls = reinterpret_cast<Mpls *>(eth_header + 1);
@@ -79,6 +78,7 @@ void MPLSPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       eth_new->dst_addr = dst_addr;
       eth_new->ether_type = next_ether_type_;
     }
+    EmitPacket(task, pkt, 0);
   }
 }
 

--- a/core/modules/mpls_pop.h
+++ b/core/modules/mpls_pop.h
@@ -46,7 +46,7 @@ class MPLSPop final : public Module {
 
   MPLSPop();  // constructor
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandSet(const bess::pb::MplsPopArg &arg);
 

--- a/core/modules/mttest.cc
+++ b/core/modules/mttest.cc
@@ -86,10 +86,10 @@ CommandResponse MetadataTest::Init(const bess::pb::MetadataTestArg &arg) {
   return CommandSuccess();
 }
 
-void MetadataTest::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void MetadataTest::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   /* This module simply passes packets from input gate X down
    * to output gate X (the same gate index) */
-  RunChooseModule(task, task->get_igate(), batch);
+  RunChooseModule(ctx, ctx->current_igate, batch);
 }
 
 ADD_MODULE(MetadataTest, "mt_test", "Dynamic metadata test module")

--- a/core/modules/mttest.h
+++ b/core/modules/mttest.h
@@ -44,7 +44,7 @@ class MetadataTest final : public Module {
 
   CommandResponse Init(const bess::pb::MetadataTestArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   CommandResponse AddAttributes(

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -323,10 +323,10 @@ inline void Stamp(Ipv4 *ip, void *l4, const Endpoint &before,
 }
 
 template <NAT::Direction dir>
-inline void NAT::DoProcessBatch(const Task *task, bess::PacketBatch *batch) {
+inline void NAT::DoProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   static gate_idx_t ogate_idx = static_cast<gate_idx_t>(dir);
   int cnt = batch->cnt();
-  uint64_t now = ctx.current_ns();
+  uint64_t now = ctx->current_ns;
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
@@ -341,7 +341,7 @@ inline void NAT::DoProcessBatch(const Task *task, bess::PacketBatch *batch) {
     std::tie(valid_protocol, before) = ExtractEndpoint(ip, l4, dir);
 
     if (!valid_protocol) {
-      DropPacket(task, pkt);
+      DropPacket(ctx, pkt);
       continue;
     }
 
@@ -349,7 +349,7 @@ inline void NAT::DoProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
     if (hash_item == nullptr) {
       if (dir != kForward || !(hash_item = CreateNewEntry(before, now))) {
-        DropPacket(task, pkt);
+        DropPacket(ctx, pkt);
         continue;
       }
     }
@@ -360,17 +360,17 @@ inline void NAT::DoProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
 
     Stamp<dir>(ip, l4, before, hash_item->second.endpoint);
-    EmitPacket(task, pkt, ogate_idx);
+    EmitPacket(ctx, pkt, ogate_idx);
   }
 }
 
-void NAT::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
-  gate_idx_t incoming_gate = task->get_igate();
+void NAT::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+  gate_idx_t incoming_gate = ctx->current_igate;
 
   if (incoming_gate == 0) {
-    DoProcessBatch<kForward>(task, batch);
+    DoProcessBatch<kForward>(ctx, batch);
   } else {
-    DoProcessBatch<kReverse>(task, batch);
+    DoProcessBatch<kReverse>(ctx, batch);
   }
 }
 

--- a/core/modules/nat.h
+++ b/core/modules/nat.h
@@ -148,7 +148,7 @@ class NAT final : public Module {
   CommandResponse GetRuntimeConfig(const bess::pb::EmptyArg &arg);
   CommandResponse SetRuntimeConfig(const bess::pb::EmptyArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   // returns the number of active NAT entries (flows)
   std::string GetDesc() const override;
@@ -166,7 +166,7 @@ class NAT final : public Module {
   HashTable::Entry *CreateNewEntry(const Endpoint &internal, uint64_t now);
 
   template <Direction dir>
-  void DoProcessBatch(const Task *task, bess::PacketBatch *batch);
+  void DoProcessBatch(Context *ctx, bess::PacketBatch *batch);
 
   std::vector<be32_t> ext_addrs_;
 

--- a/core/modules/noop.cc
+++ b/core/modules/noop.cc
@@ -35,12 +35,12 @@ CommandResponse NoOP::Init(const bess::pb::EmptyArg &) {
 
   tid = RegisterTask(nullptr);
   if (tid == INVALID_TASK_ID)
-    return CommandFailure(ENOMEM, "Task creation failed");
+    return CommandFailure(ENOMEM, "Context creation failed");
 
   return CommandSuccess();
 }
 
-struct task_result NoOP::RunTask(const Task *, bess::PacketBatch *, void *) {
+struct task_result NoOP::RunTask(Context *, bess::PacketBatch *, void *) {
   return {.block = false, .packets = 0, .bits = 0};
 }
 

--- a/core/modules/noop.h
+++ b/core/modules/noop.h
@@ -39,7 +39,7 @@ class NoOP final : public Module {
   NoOP() : Module() { is_task_ = true; };
   CommandResponse Init(const bess::pb::EmptyArg &arg);
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void *arg) override;
 
   static const gate_idx_t kNumIGates = 0;

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -70,7 +70,7 @@ CommandResponse PortInc::Init(const bess::pb::PortIncArg &arg) {
     task_id_t tid = RegisterTask((void *)(uintptr_t)qid);
 
     if (tid == INVALID_TASK_ID) {
-      return CommandFailure(ENOMEM, "Task creation failed");
+      return CommandFailure(ENOMEM, "Context creation failed");
     }
   }
 
@@ -99,7 +99,7 @@ std::string PortInc::GetDesc() const {
                              port_->port_builder()->class_name().c_str());
 }
 
-struct task_result PortInc::RunTask(const Task *task, bess::PacketBatch *batch,
+struct task_result PortInc::RunTask(Context *ctx, bess::PacketBatch *batch,
                                     void *arg) {
   if (children_overload_ > 0) {
     return {.block = true, .packets = 0, .bits = 0};
@@ -141,7 +141,7 @@ struct task_result PortInc::RunTask(const Task *task, bess::PacketBatch *batch,
     p->queue_stats[PACKET_DIR_INC][qid].bytes += received_bytes;
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 
   return {.block = false,
           .packets = cnt,

--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -50,7 +50,7 @@ class PortInc final : public Module {
 
   void DeInit() override;
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void *arg) override;
 
   std::string GetDesc() const override;

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -85,10 +85,10 @@ std::string PortOut::GetDesc() const {
                              port_->port_builder()->class_name().c_str());
 }
 
-void PortOut::ProcessBatch(const Task *, bess::PacketBatch *batch) {
+void PortOut::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   Port *p = port_;
 
-  const queue_t qid = worker_queues_[ctx.wid()];
+  const queue_t qid = worker_queues_[ctx->wid];
 
   uint64_t sent_bytes = 0;
   int sent_pkts = 0;

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -47,7 +47,7 @@ class PortOut final : public Module {
 
   void DeInit() override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   int OnEvent(bess::Event e) override;
 

--- a/core/modules/queue.cc
+++ b/core/modules/queue.cc
@@ -139,7 +139,7 @@ std::string Queue::GetDesc() const {
 }
 
 /* from upstream */
-void Queue::ProcessBatch(const Task *, bess::PacketBatch *batch) {
+void Queue::ProcessBatch(Context *, bess::PacketBatch *batch) {
   int queued =
       llring_mp_enqueue_burst(queue_, (void **)batch->pkts(), batch->cnt());
   if (backpressure_ && llring_count(queue_) > high_water_) {
@@ -156,7 +156,7 @@ void Queue::ProcessBatch(const Task *, bess::PacketBatch *batch) {
 }
 
 /* to downstream */
-struct task_result Queue::RunTask(const Task *task, bess::PacketBatch *batch,
+struct task_result Queue::RunTask(Context *ctx, bess::PacketBatch *batch,
                                   void *) {
   if (children_overload_ > 0) {
     return {
@@ -189,7 +189,7 @@ struct task_result Queue::RunTask(const Task *task, bess::PacketBatch *batch,
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 
   if (backpressure_ && llring_count(queue_) < low_water_) {
     SignalUnderload();

--- a/core/modules/queue.h
+++ b/core/modules/queue.h
@@ -58,9 +58,9 @@ class Queue : public Module {
 
   void DeInit() override;
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void *arg) override;
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   std::string GetDesc() const override;
 

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -61,7 +61,7 @@ CommandResponse QueueInc::Init(const bess::pb::QueueIncArg &arg) {
   node_constraints_ = port_->GetNodePlacementConstraint();
   tid = RegisterTask((void *)(uintptr_t)qid_);
   if (tid == INVALID_TASK_ID)
-    return CommandFailure(ENOMEM, "Task creation failed");
+    return CommandFailure(ENOMEM, "Context creation failed");
 
   int ret = port_->AcquireQueues(reinterpret_cast<const module *>(this),
                                  PACKET_DIR_INC, &qid_, 1);
@@ -84,7 +84,7 @@ std::string QueueInc::GetDesc() const {
                              port_->port_builder()->class_name().c_str());
 }
 
-struct task_result QueueInc::RunTask(const Task *task, bess::PacketBatch *batch,
+struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
                                      void *arg) {
   Port *p = port_;
 
@@ -123,7 +123,7 @@ struct task_result QueueInc::RunTask(const Task *task, bess::PacketBatch *batch,
     p->queue_stats[PACKET_DIR_INC][qid].bytes += received_bytes;
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 
   return {.block = false,
           .packets = cnt,

--- a/core/modules/queue_inc.h
+++ b/core/modules/queue_inc.h
@@ -46,7 +46,7 @@ class QueueInc final : public Module {
   CommandResponse Init(const bess::pb::QueueIncArg &arg);
   void DeInit() override;
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void *arg) override;
 
   std::string GetDesc() const override;

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -73,7 +73,7 @@ std::string QueueOut::GetDesc() const {
                              port_->port_builder()->class_name().c_str());
 }
 
-void QueueOut::ProcessBatch(const Task *, bess::PacketBatch *batch) {
+void QueueOut::ProcessBatch(Context *, bess::PacketBatch *batch) {
   Port *p = port_;
 
   const queue_t qid = qid_;

--- a/core/modules/queue_out.h
+++ b/core/modules/queue_out.h
@@ -45,7 +45,7 @@ class QueueOut final : public Module {
 
   void DeInit() override;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   std::string GetDesc() const override;
 

--- a/core/modules/random_split.cc
+++ b/core/modules/random_split.cc
@@ -99,7 +99,7 @@ CommandResponse RandomSplit::CommandSetGates(
   return CommandSuccess();
 }
 
-void RandomSplit::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void RandomSplit::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   if (ngates_ <= 0) {
     bess::Packet::Free(batch);
     return;
@@ -109,9 +109,9 @@ void RandomSplit::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
     if (rng_.GetReal() > drop_rate_) {
-      EmitPacket(task, pkt, gates_[rng_.GetRange(ngates_)]);
+      EmitPacket(ctx, pkt, gates_[rng_.GetRange(ngates_)]);
     } else {
-      DropPacket(task, pkt);
+      DropPacket(ctx, pkt);
     }
   }
 }

--- a/core/modules/random_split.cc
+++ b/core/modules/random_split.cc
@@ -105,7 +105,8 @@ void RandomSplit::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     return;
   }
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
     if (rng_.GetReal() > drop_rate_) {
       EmitPacket(task, pkt, gates_[rng_.GetRange(ngates_)]);

--- a/core/modules/random_split.h
+++ b/core/modules/random_split.h
@@ -52,7 +52,7 @@ class RandomSplit final : public Module {
   CommandResponse CommandSetGates(
       const bess::pb::RandomSplitCommandSetGatesArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   Random rng_;  // Random number generator

--- a/core/modules/random_update.cc
+++ b/core/modules/random_update.cc
@@ -113,7 +113,7 @@ CommandResponse RandomUpdate::CommandClear(const bess::pb::EmptyArg &) {
   return CommandSuccess();
 }
 
-void RandomUpdate::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void RandomUpdate::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   for (size_t i = 0; i < num_vars_; i++) {
@@ -132,7 +132,7 @@ void RandomUpdate::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(RandomUpdate, "rupdate", "updates packet data with random values")

--- a/core/modules/random_update.h
+++ b/core/modules/random_update.h
@@ -49,7 +49,7 @@ class RandomUpdate final : public Module {
 
   CommandResponse Init(const bess::pb::RandomUpdateArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::RandomUpdateArg &arg);
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -65,7 +65,8 @@ CommandResponse Replicate::CommandSetGates(
 }
 
 void Replicate::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     bess::Packet *tocopy = batch->pkts()[i];
     for (int j = 1; j < ngates_; j++) {
       bess::Packet *newpkt = bess::Packet::copy(tocopy);

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -64,17 +64,17 @@ CommandResponse Replicate::CommandSetGates(
   return CommandSuccess();
 }
 
-void Replicate::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Replicate::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
   for (int i = 0; i < cnt; i++) {
     bess::Packet *tocopy = batch->pkts()[i];
     for (int j = 1; j < ngates_; j++) {
       bess::Packet *newpkt = bess::Packet::copy(tocopy);
       if (newpkt) {
-        EmitPacket(task, newpkt, gates_[j]);
+        EmitPacket(ctx, newpkt, gates_[j]);
       }
     }
-    EmitPacket(task, tocopy, 0);
+    EmitPacket(ctx, tocopy, 0);
   }
 }
 

--- a/core/modules/replicate.h
+++ b/core/modules/replicate.h
@@ -46,7 +46,7 @@ class Replicate final : public Module {
 
   CommandResponse Init(const bess::pb::ReplicateArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   /*!
    * Sets the number of output gates.

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -123,14 +123,14 @@ inline void Rewrite::DoRewrite(bess::PacketBatch *batch) {
   next_turn_ = jump_[start + cnt];
 }
 
-void Rewrite::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Rewrite::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   if (num_templates_ == 1) {
     DoRewriteSingle(batch);
   } else if (num_templates_ > 1) {
     DoRewrite(batch);
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(Rewrite, "rewrite", "replaces entire packet data")

--- a/core/modules/rewrite.h
+++ b/core/modules/rewrite.h
@@ -52,7 +52,7 @@ class Rewrite final : public Module {
 
   CommandResponse Init(const bess::pb::RewriteArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::RewriteArg &arg);
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/round_robin.cc
+++ b/core/modules/round_robin.cc
@@ -105,7 +105,8 @@ void RoundRobin::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   }
 
   if (per_packet_) {
-    for (int i = 0; i < batch->cnt(); i++) {
+    int cnt = batch->cnt();
+    for (int i = 0; i < cnt; i++) {
       bess::Packet *pkt = batch->pkts()[i];
       EmitPacket(task, pkt, gates_[current_gate_]);
       if (++current_gate_ >= ngates_) {

--- a/core/modules/round_robin.cc
+++ b/core/modules/round_robin.cc
@@ -98,7 +98,7 @@ CommandResponse RoundRobin::CommandSetGates(
   return CommandSuccess();
 }
 
-void RoundRobin::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void RoundRobin::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   if (ngates_ <= 0) {
     bess::Packet::Free(batch);
     return;
@@ -108,7 +108,7 @@ void RoundRobin::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     int cnt = batch->cnt();
     for (int i = 0; i < cnt; i++) {
       bess::Packet *pkt = batch->pkts()[i];
-      EmitPacket(task, pkt, gates_[current_gate_]);
+      EmitPacket(ctx, pkt, gates_[current_gate_]);
       if (++current_gate_ >= ngates_) {
         current_gate_ = 0;
       }
@@ -118,7 +118,7 @@ void RoundRobin::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     if (++current_gate_ >= ngates_) {
       current_gate_ = 0;
     }
-    RunChooseModule(task, gate, batch);
+    RunChooseModule(ctx, gate, batch);
   }
 }
 

--- a/core/modules/round_robin.h
+++ b/core/modules/round_robin.h
@@ -72,7 +72,7 @@ class RoundRobin final : public Module {
 
   CommandResponse Init(const bess::pb::RoundRobinArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   /*!
    * Switches the RoundRobin module between "batch" vs "packet" scheduling.

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -215,7 +215,7 @@ inline void SetMetadata::DoProcessBatch(bess::PacketBatch *batch,
   }
 }
 
-void SetMetadata::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void SetMetadata::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   for (size_t i = 0; i < attrs_.size(); i++) {
     const struct Attr *attr = &attrs_[i];
     mt_offset_t mt_offset = attr_offset(i);
@@ -231,7 +231,7 @@ void SetMetadata::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(SetMetadata, "setattr", "Set metadata attributes to packets")

--- a/core/modules/set_metadata.h
+++ b/core/modules/set_metadata.h
@@ -58,7 +58,7 @@ class SetMetadata final : public Module {
 
   CommandResponse Init(const bess::pb::SetMetadataArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   enum class Mode { FromPacket, FromValue };

--- a/core/modules/sink.cc
+++ b/core/modules/sink.cc
@@ -30,7 +30,7 @@
 
 #include "sink.h"
 
-void Sink::ProcessBatch(const Task *, bess::PacketBatch *batch) {
+void Sink::ProcessBatch(Context *, bess::PacketBatch *batch) {
   bess::Packet::Free(batch);
 }
 

--- a/core/modules/sink.h
+++ b/core/modules/sink.h
@@ -39,7 +39,7 @@ class Sink final : public Module {
 
   static const gate_idx_t kNumOGates = 0;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_SINK_H_

--- a/core/modules/source.cc
+++ b/core/modules/source.cc
@@ -80,7 +80,7 @@ CommandResponse Source::CommandSetPktSize(
   return CommandSuccess();
 }
 
-struct task_result Source::RunTask(const Task *task, bess::PacketBatch *batch,
+struct task_result Source::RunTask(Context *ctx, bess::PacketBatch *batch,
                                    void *) {
   if (children_overload_ > 0) {
     return {
@@ -94,7 +94,7 @@ struct task_result Source::RunTask(const Task *task, bess::PacketBatch *batch,
 
   uint32_t cnt = bess::Packet::Alloc(batch->pkts(), burst, pkt_size);
   batch->set_cnt(cnt);
-  RunNextModule(task, batch);  // it's fine to call this function with cnt==0
+  RunNextModule(ctx, batch);  // it's fine to call this function with cnt==0
 
   return {.block = (cnt == 0),
           .packets = cnt,

--- a/core/modules/source.h
+++ b/core/modules/source.h
@@ -44,7 +44,7 @@ class Source final : public Module {
 
   CommandResponse Init(const bess::pb::SourceArg &arg);
 
-  struct task_result RunTask(const Task *task, bess::PacketBatch *batch,
+  struct task_result RunTask(Context *ctx, bess::PacketBatch *batch,
                              void *arg) override;
 
   CommandResponse CommandSetBurst(

--- a/core/modules/split.cc
+++ b/core/modules/split.cc
@@ -61,7 +61,7 @@ CommandResponse Split::Init(const bess::pb::SplitArg &arg) {
   return CommandSuccess();
 }
 
-void Split::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Split::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::be64_t;
 
   int cnt = batch->cnt();
@@ -72,14 +72,14 @@ void Split::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       bess::Packet *pkt = batch->pkts()[i];
       uint64_t val = get_attr_with_offset<be64_t>(offset, pkt).value();
       val = (val >> shift_) & mask_;
-      EmitPacket(task, pkt, val);
+      EmitPacket(ctx, pkt, val);
     }
   } else {
     for (int i = 0; i < cnt; i++) {
       bess::Packet *pkt = batch->pkts()[i];
       uint64_t val = (pkt->head_data<be64_t *>(offset_))->value();
       val = (val >> shift_) & mask_;
-      EmitPacket(task, pkt, val);
+      EmitPacket(ctx, pkt, val);
     }
   }
 }

--- a/core/modules/split.h
+++ b/core/modules/split.h
@@ -44,7 +44,7 @@ class Split final : public Module {
 
   CommandResponse Init(const bess::pb::SplitArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   uint64_t mask_;

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -70,7 +70,7 @@ CommandResponse Timestamp::Init(const bess::pb::TimestampArg &arg) {
   return CommandSuccess();
 }
 
-void Timestamp::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Timestamp::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   // We don't use ctx->current_ns here for better accuracy
   uint64_t now_ns = tsc_to_ns(rdtsc());
   size_t offset = offset_;
@@ -80,7 +80,7 @@ void Timestamp::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     timestamp_packet(batch->pkts()[i], offset, now_ns);
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(Timestamp, "timestamp",

--- a/core/modules/timestamp.cc
+++ b/core/modules/timestamp.cc
@@ -75,7 +75,8 @@ void Timestamp::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   uint64_t now_ns = tsc_to_ns(rdtsc());
   size_t offset = offset_;
 
-  for (int i = 0; i < batch->cnt(); i++) {
+  int cnt = batch->cnt();
+  for (int i = 0; i < cnt; i++) {
     timestamp_packet(batch->pkts()[i], offset, now_ns);
   }
 

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -43,7 +43,7 @@ class Timestamp final : public Module {
 
   CommandResponse Init(const bess::pb::TimestampArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   size_t offset_;

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -43,7 +43,7 @@ CommandResponse Update::Init(const bess::pb::UpdateArg &arg) {
   return CommandAdd(arg);
 }
 
-void Update::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void Update::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   for (size_t i = 0; i < num_fields_; i++) {
@@ -62,7 +62,7 @@ void Update::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 CommandResponse Update::CommandAdd(const bess::pb::UpdateArg &arg) {

--- a/core/modules/update.h
+++ b/core/modules/update.h
@@ -48,7 +48,7 @@ class Update final : public Module {
 
   CommandResponse Init(const bess::pb::UpdateArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   CommandResponse CommandAdd(const bess::pb::UpdateArg &arg);
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);

--- a/core/modules/update_ttl.cc
+++ b/core/modules/update_ttl.cc
@@ -37,7 +37,7 @@
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 
-void UpdateTTL::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void UpdateTTL::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {
@@ -51,9 +51,9 @@ void UpdateTTL::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       // We use constant numbers here for efficiency.
       ip->checksum = bess::utils::UpdateChecksum16(ip->checksum, 2, 1);
       ip->ttl -= 1;
-      EmitPacket(task, pkt);
+      EmitPacket(ctx, pkt);
     } else {
-      DropPacket(task, pkt);
+      DropPacket(ctx, pkt);
     }
   }
 }

--- a/core/modules/update_ttl.h
+++ b/core/modules/update_ttl.h
@@ -38,7 +38,7 @@
 class UpdateTTL final : public Module {
  public:
   UpdateTTL() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_UPDATE_TTL_H_

--- a/core/modules/url_filter.h
+++ b/core/modules/url_filter.h
@@ -119,7 +119,7 @@ class UrlFilter final : public Module {
 
   CommandResponse Init(const bess::pb::UrlFilterArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   std::string GetDesc() const override;
 

--- a/core/modules/vlan_pop.cc
+++ b/core/modules/vlan_pop.cc
@@ -32,7 +32,7 @@
 
 #include "../utils/ether.h"
 
-void VLANPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void VLANPop::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::be16_t;
   using bess::utils::Ethernet;
 
@@ -54,7 +54,7 @@ void VLANPop::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(VLANPop, "vlan_pop", "removes 802.1Q/802.11ad VLAN tag")

--- a/core/modules/vlan_pop.h
+++ b/core/modules/vlan_pop.h
@@ -37,7 +37,7 @@ class VLANPop final : public Module {
  public:
   VLANPop() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VLANPOP_H_

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -57,7 +57,7 @@ CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
 }
 
 // the behavior is undefined if a packet is already double tagged
-void VLANPush::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void VLANPush::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 
   be32_t vlan_tag = vlan_tag_;
@@ -83,7 +83,7 @@ void VLANPush::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     }
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 std::string VLANPush::GetDesc() const {

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -56,7 +56,7 @@ CommandResponse VLANPush::CommandSetTci(const bess::pb::VLANPushArg &arg) {
   return CommandSuccess();
 }
 
-/* the behavior is undefined if a packet is already double tagged */
+// the behavior is undefined if a packet is already double tagged
 void VLANPush::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
   int cnt = batch->cnt();
 

--- a/core/modules/vlan_push.h
+++ b/core/modules/vlan_push.h
@@ -46,7 +46,7 @@ class VLANPush final : public Module {
 
   CommandResponse Init(const bess::pb::VLANPushArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   std::string GetDesc() const override;
 

--- a/core/modules/vlan_split.cc
+++ b/core/modules/vlan_split.cc
@@ -32,7 +32,7 @@
 
 #include "../utils/ether.h"
 
-void VLANSplit::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void VLANSplit::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::be16_t;
   using bess::utils::Ethernet;
 
@@ -53,9 +53,9 @@ void VLANSplit::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
       be16_t tci(be16_t::swap(_mm_extract_epi16(eth, 7)));
       eth = _mm_slli_si128(eth, 4);
       _mm_storeu_si128(reinterpret_cast<__m128i *>(old_head), eth);
-      EmitPacket(task, pkt, tci.value() & 0x0fff);
+      EmitPacket(ctx, pkt, tci.value() & 0x0fff);
     } else {
-      EmitPacket(task, pkt, 0); /* untagged packets go to gate 0 */
+      EmitPacket(ctx, pkt, 0); /* untagged packets go to gate 0 */
     }
   }
 }

--- a/core/modules/vlan_split.h
+++ b/core/modules/vlan_split.h
@@ -39,7 +39,7 @@ class VLANSplit final : public Module {
 
   static const gate_idx_t kNumOGates = 4096;
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VLANSPLIT_H_

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -55,7 +55,7 @@ CommandResponse VXLANDecap::Init(
   return CommandSuccess();
 }
 
-void VXLANDecap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void VXLANDecap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::be32_t;
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
@@ -80,7 +80,7 @@ void VXLANDecap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     pkt->adj(sizeof(*eth) + ip_bytes + sizeof(*udp) + sizeof(*vh));
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(VXLANDecap, "vxlan_decap",

--- a/core/modules/vxlan_decap.h
+++ b/core/modules/vxlan_decap.h
@@ -39,7 +39,7 @@ class VXLANDecap final : public Module {
   VXLANDecap() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
   CommandResponse Init(const bess::pb::VXLANDecapArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 };
 
 #endif  // BESS_MODULES_VXLANDECAP_H_

--- a/core/modules/vxlan_encap.cc
+++ b/core/modules/vxlan_encap.cc
@@ -76,7 +76,7 @@ CommandResponse VXLANEncap::Init(const bess::pb::VXLANEncapArg &arg) {
   return CommandSuccess();
 }
 
-void VXLANEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void VXLANEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Udp;
@@ -119,7 +119,7 @@ void VXLANEncap::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
     set_attr<uint8_t>(this, ATTR_W_IP_PROTO, pkt, Ipv4::Proto::kUdp);
   }
 
-  RunNextModule(task, batch);
+  RunNextModule(ctx, batch);
 }
 
 ADD_MODULE(VXLANEncap, "vxlan_encap",

--- a/core/modules/vxlan_encap.h
+++ b/core/modules/vxlan_encap.h
@@ -46,7 +46,7 @@ class VXLANEncap final : public Module {
 
   CommandResponse Init(const bess::pb::VXLANEncapArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
  private:
   bess::utils::be16_t dstport_;

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -156,7 +156,7 @@ inline gate_idx_t WildcardMatch::LookupEntry(const wm_hkey_t &key,
   return result.ogate;
 }
 
-void WildcardMatch::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
+void WildcardMatch::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   gate_idx_t default_gate;
 
   wm_hkey_t keys[bess::PacketBatch::kMaxBurst] __ymm_aligned;
@@ -198,7 +198,7 @@ void WildcardMatch::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
 
   for (int i = 0; i < cnt; i++) {
     bess::Packet *pkt = batch->pkts()[i];
-    EmitPacket(task, pkt, LookupEntry(keys[i], default_gate));
+    EmitPacket(ctx, pkt, LookupEntry(keys[i], default_gate));
   }
 }
 

--- a/core/modules/wildcard_match.h
+++ b/core/modules/wildcard_match.h
@@ -141,7 +141,7 @@ class WildcardMatch final : public Module {
 
   CommandResponse Init(const bess::pb::WildcardMatchArg &arg);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   std::string GetDesc() const override;
 

--- a/core/modules/worker_split.cc
+++ b/core/modules/worker_split.cc
@@ -62,10 +62,10 @@ CommandResponse WorkerSplit::CommandReset(const bess::pb::WorkerSplitArg &arg) {
   return CommandSuccess();
 }
 
-void WorkerSplit::ProcessBatch(const Task *task, bess::PacketBatch *batch) {
-  int gate = gates_[ctx.wid()];
+void WorkerSplit::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+  int gate = gates_[ctx->wid];
   if (gate >= 0) {
-    RunChooseModule(task, gate, batch);
+    RunChooseModule(ctx, gate, batch);
   }
 }
 

--- a/core/modules/worker_split.h
+++ b/core/modules/worker_split.h
@@ -45,7 +45,7 @@ class WorkerSplit final : public Module {
 
   CommandResponse CommandReset(const bess::pb::WorkerSplitArg &);
 
-  void ProcessBatch(const Task *task, bess::PacketBatch *batch) override;
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
 
   void AddActiveWorker(int wid, const Task *task) override;
 

--- a/core/packet.cc
+++ b/core/packet.cc
@@ -128,10 +128,6 @@ void close_mempool(void) {
   /* Do nothing. Surprisingly, there is no destructor for mempools */
 }
 
-struct rte_mempool *get_pframe_pool() {
-  return pframe_pool[ctx.socket()];
-}
-
 struct rte_mempool *get_pframe_pool_socket(int socket) {
   return pframe_pool[socket];
 }
@@ -153,10 +149,11 @@ static Packet *paddr_to_snb_memchunk(struct rte_mempool_memhdr *chunk,
   return nullptr;
 }
 
-#define check_offset(field)                                                                                                                                                                                                                                                                                                  \
-  do {                                                                                                                                                                                                                                                                                                                \
-    static_assert(offsetof(Packet, field##_) == offsetof(rte_mbuf, field), \
-      "Incompatibility detected between class Packet and struct rte_mbuf"); \
+#define check_offset(field)                                                   \
+  do {                                                                        \
+    static_assert(                                                            \
+        offsetof(Packet, field##_) == offsetof(rte_mbuf, field),              \
+        "Incompatibility detected between class Packet and struct rte_mbuf"); \
   } while (0)
 
 Packet::Packet() {

--- a/core/packet.h
+++ b/core/packet.h
@@ -71,10 +71,10 @@ static inline Packet *__packet_alloc_pool(struct rte_mempool *pool) {
 }
 
 static inline Packet *__packet_alloc() {
-  return reinterpret_cast<Packet *>(rte_pktmbuf_alloc(ctx.pframe_pool()));
+  return reinterpret_cast<Packet *>(
+      rte_pktmbuf_alloc(current_worker.pframe_pool()));
 }
 
-struct rte_mempool *get_pframe_pool();
 struct rte_mempool *get_pframe_pool_socket(int socket);
 
 void init_mempool(void);
@@ -396,8 +396,8 @@ inline size_t Packet::Alloc(Packet **pkts, size_t cnt, uint16_t len) {
   DCHECK_LE(cnt, PacketBatch::kMaxBurst);
 
   // rte_mempool_get_bulk() is all (cnt) or nothing (0)
-  if (rte_mempool_get_bulk(ctx.pframe_pool(), reinterpret_cast<void **>(pkts),
-                           cnt) < 0) {
+  if (rte_mempool_get_bulk(current_worker.pframe_pool(),
+                           reinterpret_cast<void **>(pkts), cnt) < 0) {
     return 0;
   }
 

--- a/core/packet_avx.h
+++ b/core/packet_avx.h
@@ -41,8 +41,8 @@
 
 inline size_t Packet::Alloc(Packet **pkts, size_t cnt, uint16_t len) {
   // rte_mempool_get_bulk() is all (cnt) or nothing (0)
-  if (rte_mempool_get_bulk(ctx.pframe_pool(), reinterpret_cast<void **>(pkts),
-                           cnt) < 0) {
+  if (rte_mempool_get_bulk(current_worker.pframe_pool(),
+                           reinterpret_cast<void **>(pkts), cnt) < 0) {
     return 0;
   }
 

--- a/core/task.h
+++ b/core/task.h
@@ -51,6 +51,7 @@ typedef uint64_t placement_constraint;
 #define MAX_PBATCH_CNT 256
 
 class Module;
+struct Context;
 
 namespace bess {
 class LeafTrafficClass;
@@ -159,9 +160,6 @@ class Task {
 
   Module *module() const { return module_; }
 
-  gate_idx_t get_igate() const { return current_igate_; }
-  void set_current_igate(gate_idx_t idx) const { current_igate_ = idx; }
-
   bess::PacketBatch *dead_batch() const { return &dead_batch_; }
 
   bess::PacketBatch *get_gate_batch(bess::Gate *gate) const {
@@ -174,7 +172,7 @@ class Task {
 
   bess::LeafTrafficClass *GetTC() const { return c_; }
 
-  struct task_result operator()(void) const;
+  struct task_result operator()(Context *ctx) const;
 
   // Compute constraints for the pipeline starting at this task.
   placement_constraint GetSocketConstraints() const;

--- a/core/task.h
+++ b/core/task.h
@@ -31,6 +31,7 @@
 #ifndef BESS_TASK_H_
 #define BESS_TASK_H_
 
+#include <queue>
 #include <string>
 
 #include "gate.h"
@@ -121,7 +122,7 @@ class Task {
   // Called when the leaf that owns this task is created.
   void Attach(bess::LeafTrafficClass *c);
 
-  inline void AddToRun(bess::IGate *ig, bess::PacketBatch *batch) const {
+  void AddToRun(bess::IGate *ig, bess::PacketBatch *batch) const {
     if (next_gate_ == nullptr &&
         !ig->mergeable()) {  // optimization for chained
       next_gate_ = ig;

--- a/core/task.h
+++ b/core/task.h
@@ -129,14 +129,15 @@ class Task {
       next_batch_ = batch;
     } else {
       bess::PacketBatch *ibatch = get_gate_batch(ig);
-      if (ibatch && (static_cast<size_t>(ibatch->cnt() + batch->cnt()) <
+      if (ibatch && (static_cast<size_t>(ibatch->cnt() + batch->cnt()) <=
                      bess::PacketBatch::kMaxBurst)) {
         // merge two batches
-        get_gate_batch(ig)->add(batch);
+        ibatch->add(batch);
+      } else {
+        // set the input as new batch
+        set_gate_batch(ig, batch);
+        igates_to_run_.emplace(ig, batch);
       }
-      // set the input as new batch
-      set_gate_batch(ig, batch);
-      igates_to_run_.emplace(ig, batch);
     }
   }
 

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -603,7 +603,7 @@ class LeafTrafficClass final : public TrafficClass {
     TrafficClass::UnblockTowardsRootSetBlocked(tsc, false);
   }
 
-  const Task *task() const { return task_; }
+  Task *task() const { return task_; }
 
   void FinishAndAccountTowardsRoot(SchedWakeupQueue *wakeup_queue,
                                    [[maybe_unused]] TrafficClass *child,

--- a/core/traffic_class_bench.cc
+++ b/core/traffic_class_bench.cc
@@ -48,11 +48,11 @@ namespace {
 
 class DummyModule : public Module {
  public:
-  struct task_result RunTask(const Task *, bess::PacketBatch *,
+  struct task_result RunTask(Context *, bess::PacketBatch *,
                              void *arg) override;
 };
 
-[[gnu::noinline]] struct task_result DummyModule::RunTask(const Task *,
+[[gnu::noinline]] struct task_result DummyModule::RunTask(Context *,
                                                           bess::PacketBatch *,
                                                           void *) {
   return {.block = false, .packets = 0, .bits = 0};
@@ -109,7 +109,8 @@ class TCWeightedFair : public benchmark::Fixture {
 BENCHMARK_DEFINE_F(TCWeightedFair, TCScheduleOnceCount)
 (benchmark::State &state) {
   while (state.KeepRunning()) {
-    s_->ScheduleOnce();
+    Context ctx = {};
+    s_->ScheduleOnce(&ctx);
   }
   state.SetItemsProcessed(state.iterations());
   state.SetComplexityN(state.range(0));
@@ -119,7 +120,8 @@ BENCHMARK_DEFINE_F(TCWeightedFair, TCScheduleOnceCount)
 BENCHMARK_DEFINE_F(TCWeightedFair, TCScheduleOnceCycle)
 (benchmark::State &state) {
   while (state.KeepRunning()) {
-    s_->ScheduleOnce();
+    Context ctx = {};
+    s_->ScheduleOnce(&ctx);
   }
   state.SetItemsProcessed(state.iterations());
   state.SetComplexityN(state.range(0));
@@ -204,7 +206,8 @@ class TCRoundRobin : public benchmark::Fixture {
 
 BENCHMARK_DEFINE_F(TCRoundRobin, TCScheduleOnce)(benchmark::State &state) {
   while (state.KeepRunning()) {
-    s_->ScheduleOnce();
+    Context ctx = {};
+    s_->ScheduleOnce(&ctx);
   }
   state.SetItemsProcessed(state.iterations());
   state.SetComplexityN(state.range(0));

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -300,7 +300,7 @@ void *Worker::Run(void *_arg) {
 
   current_tsc_ = rdtsc();
 
-  pframe_pool_ = bess::get_pframe_pool();
+  pframe_pool_ = bess::get_pframe_pool_socket(socket_);
   DCHECK(pframe_pool_);
 
   status_ = WORKER_PAUSING;

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -69,7 +69,7 @@ using bess::ResumeHookFactory;
 std::list<std::pair<int, bess::TrafficClass *>> orphan_tcs;
 
 // See worker.h
-__thread Worker ctx;
+__thread Worker current_worker;
 
 struct thread_arg {
   int wid;
@@ -327,8 +327,8 @@ void *Worker::Run(void *_arg) {
 }
 
 void *run_worker(void *_arg) {
-  CHECK_EQ(memcmp(&ctx, new Worker(), sizeof(Worker)), 0);
-  return ctx.Run(_arg);
+  CHECK_EQ(memcmp(&current_worker, new Worker(), sizeof(Worker)), 0);
+  return current_worker.Run(_arg);
 }
 
 void launch_worker(int wid, int core,

--- a/core/worker.h
+++ b/core/worker.h
@@ -142,7 +142,7 @@ class Worker {
 // NOTE: Do not use "thread_local" here. It requires a function call every time
 // it is accessed. Use __thread instead, which incurs minimal runtime overhead.
 // For this, g++ requires Worker to have a trivial constructor and destructor.
-extern __thread Worker ctx;
+extern __thread Worker current_worker;
 
 // the following traits are not supported in g++ 4.x
 #if __GNUC__ >= 5


### PR DESCRIPTION
With this PR, modules do not access directly into the thread-local storage, but modules can access the current execution contexts 'Context *' such as task, worker id,  current cycles/time, etc.

!! This PR should be merged with #739. This requires changing module interface as well. So I would recommend deferring merging #739 until this PR is approved and is ready to merge.