### PR TITLE
Gatehookcmds

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -343,12 +343,12 @@ def get_var_attrs(cli, var_token, partial_word):
             var_candidates = complete_filename(partial_word, suffix='.so',
                                                skip_suffix=True)
 
-        elif var_token == '[DIRECTION]':
+        elif var_token in ('[DIRECTION]', 'DIRECTION'):
             var_type = 'dir'
             var_desc = 'gate direction discriminator (default "out")'
             var_candidates = ['in', 'out']
 
-        elif var_token == '[GATE]':
+        elif var_token in ('[GATE]', 'GATE'):
             var_type = 'gate'
             var_desc = 'gate index of a module'
 
@@ -1936,6 +1936,16 @@ def track_module(cli, flag, module_name, direction, gate):
      'Count the packets, batches, and bits on specified or all gates')
 def track_module_bits(cli, flag, module_name, direction, gate):
     _track_module(cli, True, flag, module_name, direction, gate)
+
+# really should support "all gates" but that requires that we
+# iterate over all gates
+
+
+@cmd('track reset MODULE DIRECTION GATE',
+     'Reset counts of packets, batches, and bits on specified gate')
+def track_reset(cli, module_name, direction, gate):
+    cli.bess.run_gate_command('track', module_name, direction, gate, 'reset',
+                              'EmptyArg', {})
 
 
 @cmd('interactive', 'Switch to interactive mode')

--- a/core/commands.h
+++ b/core/commands.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2018, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_COMMANDS_H_
+#define BESS_COMMANDS_H_
+
+#include <vector>
+
+#include "message.h"
+
+// TODO(torek): refactor; instead of "module command" and "gate command"
+// we should just have "command".  The constraint right now is that the
+// commands to a module or gate-hook instance are redirected through
+// the underlying builder (module) or factory (gate-hook), which
+// get in the way here.
+
+class Module;
+namespace bess {
+class GateHook;
+};  // namespace bess
+
+using module_cmd_func_t =
+    pb_func_t<CommandResponse, Module, google::protobuf::Any>;
+using gate_hook_cmd_func_t =
+    pb_func_t<CommandResponse, bess::GateHook, google::protobuf::Any>;
+
+// Describes a single command that can be issued to a module
+// or gate hook (according to cmd_func_t).
+template <typename cmd_func_t>
+struct GenericCommand {
+  enum ThreadSafety { THREAD_UNSAFE = 0, THREAD_SAFE = 1 };
+
+  std::string cmd;
+  std::string arg_type;
+  cmd_func_t func;
+
+  // If set to THREAD_SAFE, workers don't need to be paused in order to run
+  // this command.
+  ThreadSafety mt_safe;
+};
+
+// Command and Commands are specifically *module* commands - these should
+// be ModuleCommand and ModuleCommands, but they got there first.
+using Command = GenericCommand<module_cmd_func_t>;
+using Commands = std::vector<Command>;
+
+using GateHookCommand = GenericCommand<gate_hook_cmd_func_t>;
+using GateHookCommands = std::vector<GateHookCommand>;
+
+#endif  // BESS_COMMANDS_H_

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -79,6 +79,7 @@ CommandResponse Gate::NewGateHook(const GateHookFactory *factory, Gate *gate,
     return init_ret;
   }
   hook->set_arg(arg);
+  hook->set_gate(gate);
   int ret = gate->AddHook(hook);
   if (ret != 0) {
     delete hook;

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -29,6 +29,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "gate.h"
+#include "gate_hooks/track.h"
 
 #include <algorithm>
 #include <map>
@@ -119,6 +120,11 @@ void IGate::RemoveOgate(const OGate *og) {
       return;
     }
   }
+}
+
+// Add internally-generated Track() hook to this ogate.
+void OGate::AddTrackHook() {
+  this->AddHook(new Track());
 }
 
 void OGate::SetIgate(IGate *ig) {

--- a/core/gate.h
+++ b/core/gate.h
@@ -202,6 +202,8 @@ class OGate : public Gate {
 
   gate_idx_t igate_idx() const { return igate_idx_; }
 
+  void AddTrackHook();
+
  private:
   Module *next_;          // next module connected with
   IGate *igate_;          // next igate connected with

--- a/core/gate.h
+++ b/core/gate.h
@@ -37,6 +37,7 @@
 #include <grpc++/server.h>
 #include <grpc/grpc.h>
 
+#include "commands.h"
 #include "message.h"
 #include "pktbatch.h"
 #include "utils/common.h"
@@ -59,6 +60,7 @@ static_assert(MAX_GATES < INVALID_GATE, "invalid macro value");
 static_assert(DROP_GATE <= MAX_GATES, "invalid macro value");
 
 class Gate;
+class GateHookFactory;
 
 // Gate hooks allow you to run arbitrary code on the packets flowing through a
 // gate before they get delievered to the upstream module.
@@ -71,7 +73,7 @@ class GateHook {
 
   explicit GateHook(const std::string &name, uint16_t priority = 0,
                     Gate *gate = nullptr)
-      : gate_(gate), name_(name), priority_(priority) {}
+      : gate_(gate), name_(name), priority_(priority), factory_() {}
 
   virtual ~GateHook() {}
 
@@ -89,9 +91,16 @@ class GateHook {
 
   virtual void ProcessBatch(const bess::PacketBatch *) {}
 
+  CommandResponse RunCommand(const std::string &cmd,
+                             const google::protobuf::Any &arg);
+
+  void set_factory(const GateHookFactory *factory) { factory_ = factory; }
+
   bool operator<(const GateHook &rhs) const {
     return std::tie(priority_, name_) < std::tie(rhs.priority_, rhs.name_);
   }
+
+  static const GateHookCommands cmds;
 
  protected:
   Gate *gate_;
@@ -99,6 +108,7 @@ class GateHook {
  private:
   const std::string &name_;
   const uint16_t priority_;
+  const GateHookFactory *factory_;
   google::protobuf::Any arg_;
 
   DISALLOW_COPY_AND_ASSIGN(GateHook);
@@ -108,12 +118,15 @@ class GateHook {
 class GateHookFactory {
  public:
   GateHookFactory(GateHook::constructor_t constructor,
-                  GateHook::init_func_t init_func, const std::string &hook_name)
+                  const GateHookCommands &cmds, GateHook::init_func_t init_func,
+                  const std::string &hook_name)
       : hook_constructor_(constructor),
+        cmds_(cmds),
         hook_init_func_(init_func),
         hook_name_(hook_name) {}
 
   static bool RegisterGateHook(GateHook::constructor_t constructor,
+                               const GateHookCommands &cmds,
                                GateHook::init_func_t init_func,
                                const std::string &hook_name);
 
@@ -123,13 +136,22 @@ class GateHookFactory {
   static const std::map<std::string, GateHookFactory>
       &all_gate_hook_factories();
 
+  CommandResponse RunCommand(GateHook *hook, const std::string &user_cmd,
+                             const google::protobuf::Any &arg) const;
+
  private:
   friend class Gate;
 
   GateHook::constructor_t hook_constructor_;
+  const GateHookCommands cmds_;
   GateHook::init_func_t hook_init_func_;
   std::string hook_name_;
 };
+
+inline CommandResponse GateHook::RunCommand(const std::string &cmd,
+                                            const google::protobuf::Any &arg) {
+  return factory_->RunCommand(this, cmd, arg);
+}
 
 // A class for gate, will be inherited for input gates and output gates
 class Gate {
@@ -213,6 +235,17 @@ class OGate : public Gate {
 };
 }  // namespace bess
 
+template <typename T, typename H>
+static inline gate_hook_cmd_func_t GATE_HOOK_CMD_FUNC(
+    CommandResponse (H::*fn)(const T &)) {
+  return [fn](bess::GateHook *h, const google::protobuf::Any &arg) {
+    T arg_;
+    arg.UnpackTo(&arg_);
+    auto base_fn = std::mem_fn(fn);
+    return base_fn(static_cast<H *>(h), arg_);
+  };
+}
+
 template <typename H, typename A>
 static inline bess::GateHook::init_func_t InitGateHookWithGenericArg(
     CommandResponse (H::*fn)(const bess::Gate *, const A &)) {
@@ -228,6 +261,6 @@ static inline bess::GateHook::init_func_t InitGateHookWithGenericArg(
 #define ADD_GATE_HOOK(_HOOK)                                           \
   bool __gate_hook__##_HOOK = bess::GateHookFactory::RegisterGateHook( \
       std::function<bess::GateHook *()>([]() { return new _HOOK(); }), \
-      InitGateHookWithGenericArg(&_HOOK::Init), _HOOK::kName);
+      _HOOK::cmds, InitGateHookWithGenericArg(&_HOOK::Init), _HOOK::kName);
 
 #endif  // BESS_GATE_H_

--- a/core/gate_hooks/track.cc
+++ b/core/gate_hooks/track.cc
@@ -37,6 +37,10 @@ static const size_t kEthernetOverhead = 24;
 
 const std::string Track::kName = "track";
 
+const GateHookCommands Track::cmds = {{"reset", "EmptyArg",
+                                       GATE_HOOK_CMD_FUNC(&Track::CommandReset),
+                                       GateHookCommand::THREAD_UNSAFE}};
+
 Track::Track()
     : bess::GateHook(Track::kName, Track::kPriority),
       track_bytes_(),
@@ -46,6 +50,13 @@ Track::Track()
 
 CommandResponse Track::Init(const bess::Gate *, const bess::pb::TrackArg &arg) {
   track_bytes_ = arg.bits();
+  return CommandSuccess();
+}
+
+CommandResponse Track::CommandReset(const bess::pb::EmptyArg &) {
+  cnt_ = 0;
+  pkts_ = 0;
+  bytes_ = 0;
   return CommandSuccess();
 }
 

--- a/core/gate_hooks/track.h
+++ b/core/gate_hooks/track.h
@@ -39,6 +39,8 @@ class Track final : public bess::GateHook {
  public:
   Track();
 
+  static const GateHookCommands cmds;
+
   CommandResponse Init(const bess::Gate *, const bess::pb::TrackArg &);
 
   uint64_t cnt() const { return cnt_; }
@@ -50,6 +52,8 @@ class Track final : public bess::GateHook {
   void set_track_bytes(bool track) { track_bytes_ = track; }
 
   void ProcessBatch(const bess::PacketBatch *batch);
+
+  CommandResponse CommandReset(const bess::pb::EmptyArg &);
 
   static constexpr uint16_t kPriority = 0;
   static const std::string kName;

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -48,6 +48,8 @@ class GateTest : public ::testing::Test {
 
   virtual void TearDown() { delete g; }
 
+  int AddHook(GateHook *hook) { return g->AddHook(hook); }
+
   Gate *g;
 };
 
@@ -70,26 +72,26 @@ class IOGateTest : public ::testing::Test {
 };
 
 TEST_F(GateTest, AddExistingHookFails) {
-  ASSERT_EQ(0, g->AddHook(new Track()));
+  ASSERT_EQ(0, AddHook(new Track()));
   GateHook *hook = new Track();
-  ASSERT_EQ(EEXIST, g->AddHook(hook));
+  ASSERT_EQ(EEXIST, AddHook(hook));
   delete hook;
 }
 
 TEST_F(GateTest, HookPriority) {
-  ASSERT_EQ(0, g->AddHook(new Track()));
-  ASSERT_EQ(0, g->AddHook(new Tcpdump()));
+  ASSERT_EQ(0, AddHook(new Track()));
+  ASSERT_EQ(0, AddHook(new Tcpdump()));
   ASSERT_EQ(Track::kName, g->hooks()[0]->name());
 }
 
 TEST_F(GateTest, FindHook) {
   ASSERT_EQ(nullptr, g->FindHook(Track::kName));
-  ASSERT_EQ(0, g->AddHook(new Track()));
+  ASSERT_EQ(0, AddHook(new Track()));
   ASSERT_NE(nullptr, g->FindHook(Track::kName));
 }
 
 TEST_F(GateTest, RemoveHook) {
-  ASSERT_EQ(0, g->AddHook(new Track()));
+  ASSERT_EQ(0, AddHook(new Track()));
   g->RemoveHook(Track::kName);
   ASSERT_EQ(nullptr, g->FindHook(Track::kName));
 }

--- a/core/module.cc
+++ b/core/module.cc
@@ -96,11 +96,7 @@ CommandResponse ModuleBuilder::RunCommand(
     const google::protobuf::Any &arg) const {
   for (auto &cmd : cmds_) {
     if (user_cmd == cmd.cmd) {
-      bool workers_running = false;
-      for (int wid = 0; wid < Worker::kMaxWorkers; wid++) {
-        workers_running |= m->active_workers_[wid] && is_worker_running(wid);
-      }
-      if (cmd.mt_safe != Command::THREAD_SAFE && workers_running) {
+      if (cmd.mt_safe != Command::THREAD_SAFE && m->HasRunningWorker()) {
         return CommandFailure(EBUSY,
                               "There is a running worker and command "
                               "'%s' is not MT safe",

--- a/core/module.h
+++ b/core/module.h
@@ -39,6 +39,7 @@
 #include <utility>
 #include <vector>
 
+#include "commands.h"
 #include "event.h"
 #include "gate.h"
 #include "message.h"
@@ -53,8 +54,6 @@ using bess::gate_idx_t;
 #define MAX_TASKS_PER_MODULE 32
 #define UNCONSTRAINED_SOCKET ((0x1ull << MAX_NUMA_NODE) - 1)
 
-using module_cmd_func_t =
-    pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 using module_init_func_t =
     pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 
@@ -81,21 +80,6 @@ static inline module_init_func_t MODULE_INIT_FUNC(
 }
 
 class Module;
-
-// Describes a single command that can be issued to a module.
-struct Command {
-  enum ThreadSafety { THREAD_UNSAFE = 0, THREAD_SAFE = 1 };
-
-  std::string cmd;
-  std::string arg_type;
-  module_cmd_func_t func;
-
-  // If set to THREAD_SAFE, workers don't need to be paused in order to run
-  // this command.
-  ThreadSafety mt_safe;
-};
-
-using Commands = std::vector<struct Command>;
 
 // A class for managing modules of 'a particular type'.
 // Creates new modules and forwards module-specific commands.

--- a/core/module.h
+++ b/core/module.h
@@ -317,6 +317,16 @@ class alignas(64) Module {
                          [](bool b) { return b; });
   }
 
+  // True if any worker attached to this module is running.
+  inline bool HasRunningWorker() const {
+    for (int wid = 0; wid < Worker::kMaxWorkers; wid++) {
+      if (active_workers_[wid] && is_worker_running(wid)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // Check if we have already seen a task
   inline bool HaveVisitedWorker(const Task *task) const {
     return std::find(visited_tasks_.begin(), visited_tasks_.end(), task) !=

--- a/core/module_graph.cc
+++ b/core/module_graph.cc
@@ -32,7 +32,6 @@
 
 #include <glog/logging.h>
 
-#include "gate_hooks/track.h"
 #include "module.h"
 
 std::map<std::string, Module *> ModuleGraph::all_modules_;
@@ -210,7 +209,7 @@ int ModuleGraph::ConnectModules(Module *module, gate_idx_t ogate_idx,
 
   if (!skip_default_hooks) {
     // Gate tracking is enabled by default
-    module->ogates()[ogate_idx]->AddHook(new Track());
+    module->ogates()[ogate_idx]->AddTrackHook();
   }
 
   return 0;

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -35,9 +35,9 @@
 
 const Commands ACL::cmds = {
     {"add", "ACLArg", MODULE_CMD_FUNC(&ACL::CommandAdd),
-     Command::Command::THREAD_UNSAFE},
+     Command::THREAD_UNSAFE},
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&ACL::CommandClear),
-     Command::Command::THREAD_UNSAFE}};
+     Command::THREAD_UNSAFE}};
 
 CommandResponse ACL::Init(const bess::pb::ACLArg &arg) {
   for (const auto &rule : arg.rules()) {

--- a/core/modules/worker_split.cc
+++ b/core/modules/worker_split.cc
@@ -32,7 +32,7 @@
 
 const Commands WorkerSplit::cmds = {
     {"reset", "WorkerSplitArg", MODULE_CMD_FUNC(&WorkerSplit::CommandReset),
-     Command::Command::THREAD_UNSAFE}};
+     Command::THREAD_UNSAFE}};
 
 CommandResponse WorkerSplit::Init(const bess::pb::WorkerSplitArg &arg) {
   return CommandReset(arg);

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -515,6 +515,11 @@ message ListGateHooksResponse {
   repeated GateHookInfo hooks = 2;
 }
 
+message GateHookCommandRequest {
+  GateHookInfo hook = 1;  // N.B.: this includes the command argument
+  string cmd = 2;
+}
+
 //  -------------------------------------------------------------------------
 //  Resume hooks
 //  -------------------------------------------------------------------------

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -293,6 +293,9 @@ service BESSControl {
   /// Enable/Disable a gate hook.
   rpc ListGateHooks (EmptyRequest) returns (ListGateHooksResponse) {}
 
+  /// Send command to gate hook instance.
+  rpc GateHookCommand (GateHookCommandRequest) returns (CommandResponse) {}
+
   //  -------------------------------------------------------------------------
   //  Resume hooks
   //  -------------------------------------------------------------------------


### PR DESCRIPTION
This is a fairly complicated series of 9 commits that:

 * cleans up a few minor bugs here and there
 * reorganizes the code to instantiate gate hooks
 * adds the concept of a "gate hook command"
 * adds a sample gate hook command ("reset" to the "track" hook)
 * adds code to invoke the track hook reset from bessctl

(but there is no test for this reset, and I should probably write one).

It may make sense to collapse the last three commits into one, but the rest probably should stay independent since they are a good idea whether or not gate hook commands are _also_ a good idea... :smiley_cat: