### PR TITLE
pybess: Fix _configure_gate_hook()

### DIFF
--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -499,7 +499,7 @@ class BESS(object):
             request.hook.ogate = gate
         else:
             raise self.APIError('direction must be either "out" or "in"')
-        request.arg.Pack(arg)
+        request.hook.arg.Pack(arg)
         return self._request('ConfigureGateHook', request)
 
     def configure_resume_hook(self, hook, arg, enable=True):


### PR DESCRIPTION
The `ConfigureGateHook` protobuf message has changed: update its usage.
This fixes tcpdump in bessctl.

Reported by @gatanu