### PR TITLE
Make BESS easier to test without root

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -85,8 +85,8 @@ class BESSCLI(cli.CLI):
         return [self]
 
     def _handle_broken_connection(self):
-        host = self.bess.peer[0]
-        if host == 'localhost' or self.bess.peer[0].startswith('127.'):
+        peer = self.bess.peer
+        if peer.startswith('localhost') or peer.startswith('127.'):
             self._print_crashlog()
         self.bess.disconnect()
 
@@ -99,8 +99,8 @@ class BESSCLI(cli.CLI):
             raise self.HandledError()
 
         except self.bess.RPCError as e:
-            self.err('RPC failed to {}:{} - {}'.format(
-                self.bess.peer[0], self.bess.peer[1], str(e)))
+            self.err('RPC failed to  - {}'.format(
+                self.bess.peer, str(e)))
 
             self._handle_broken_connection()
             raise self.HandledError()
@@ -136,7 +136,7 @@ class BESSCLI(cli.CLI):
 
     def get_prompt(self):
         if self.bess.is_connected():
-            return '%s:%d $ ' % self.bess.peer
+            return '{} $ '.format(self.bess.peer)
 
         if self.bess.is_connection_broken():
             self._handle_broken_connection()

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -395,13 +395,9 @@ def get_var_attrs(cli, var_token, partial_word):
             var_type = 'opts'
             var_desc = 'bess daemon command-line options (see "bessd -h")'
 
-        elif var_token == '[HOST]':
-            var_type = 'host'
-            var_desc = 'host address'
-
-        elif var_token == '[TCP_PORT]':
-            var_type = 'int'
-            var_desc = 'TCP port'
+        elif var_token == '[GRPC_URL]':
+            var_type = 'filename'
+            var_desc = 'gRPC url'
 
         elif var_token == '[PAUSE_WORKERS]':
             var_type = 'pause_workers'
@@ -595,15 +591,12 @@ def debug(cli, flag):
     cli.bess.set_debug(flag == 'enable')
 
 
-@cmd('daemon connect [HOST] [TCP_PORT]', 'Connect to BESS daemon')
-def daemon_connect(cli, host, port):
+@cmd('daemon connect [GRPC_URL]', 'Connect to BESS daemon')
+def daemon_connect(cli, grpc_url):
     kwargs = {}
 
-    if host:
-        kwargs['host'] = host
-
-    if port:
-        kwargs['port'] = port
+    if grpc_url:
+        kwargs['grpc_url'] = grpc_url
 
     cli.bess.connect(**kwargs)
 

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -60,7 +60,6 @@
 #include "shared_obj.h"
 #include "traffic_class.h"
 #include "utils/ether.h"
-#include "utils/format.h"
 #include "utils/time.h"
 #include "worker.h"
 
@@ -1674,12 +1673,11 @@ class BESSControlImpl final : public BESSControl::Service {
 
 bool ApiServer::grpc_cb_set_ = false;
 
-void ApiServer::Listen(const std::string& host, int port) {
+void ApiServer::Listen(const std::string& addr) {
   if (!builder_) {
     builder_ = new grpc::ServerBuilder();
   }
 
-  std::string addr = bess::utils::Format("%s:%d", host.c_str(), port);
   LOG(INFO) << "Server listening on " << addr;
 
   builder_->AddListeningPort(addr, grpc::InsecureServerCredentials());

--- a/core/bessctl.h
+++ b/core/bessctl.h
@@ -38,8 +38,8 @@ class ServerBuilder;
 
 // gRPC server encapsulation. Usage:
 //   ApiServer server;
-//   server.Listen('0.0.0.0', 777);
-//   server.Listen('127.0.0.1', 888);
+//   server.Listen('0.0.0.0:777');
+//   server.Listen('127.0.0.1:888');
 //   server.run();
 class ApiServer {
  public:
@@ -49,8 +49,8 @@ class ApiServer {
   ApiServer(const ApiServer &) = delete;
   ApiServer &operator=(const ApiServer &) = delete;
 
-  // Adds a host:port pair. host can be an ipv6 address.
-  void Listen(const std::string &host, int port);
+  // `addr` is a gRPC url.
+  void Listen(const std::string &addr);
 
   // Runs the API server until it is shutdown by KillBess RPC.
   void Run();

--- a/core/bessd.cc
+++ b/core/bessd.cc
@@ -147,10 +147,12 @@ void ProcessCommandLineArgs() {
 }
 
 void CheckRunningAsRoot() {
-  uid_t euid = geteuid();
-  if (euid != 0) {
-    LOG(ERROR) << "You need root privilege to run the BESS daemon";
-    exit(EXIT_FAILURE);
+  if (!FLAGS_skip_root_check) {
+    uid_t euid = geteuid();
+    if (euid != 0) {
+      LOG(ERROR) << "You need root privilege to run the BESS daemon";
+      exit(EXIT_FAILURE);
+    }
   }
 
   // Great power comes with great responsibility.

--- a/core/main.cc
+++ b/core/main.cc
@@ -39,6 +39,7 @@
 #include "opts.h"
 #include "packet.h"
 #include "port.h"
+#include "utils/format.h"
 #include "version.h"
 
 int main(int argc, char *argv[]) {
@@ -85,7 +86,12 @@ int main(int argc, char *argv[]) {
 
   {
     ApiServer server;
-    server.Listen(FLAGS_b, FLAGS_p);
+    std::string grpc_url = FLAGS_grpc_url;
+    if (grpc_url.empty()) {
+      grpc_url = bess::utils::Format("%s:%d", FLAGS_b.c_str(), FLAGS_p);
+    }
+
+    server.Listen(grpc_url);
 
     // Signal the parent that all initialization has been finished.
     if (!FLAGS_f) {

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -75,12 +75,17 @@ static bool ValidateTCPPort(const char *, int32_t value) {
 
   return true;
 }
+DEFINE_string(grpc_url, "",
+              "Specifies the URL where the BESS gRPC server should listen. "
+              "If non empty, overrides -b and -p options.");
 DEFINE_string(b, kDefaultBindAddr,
               "Specifies the IP address of the interface the BESS gRPC server "
-              "should bind to");
+              "should bind to, if --grpc_url is empty. Deprecated, please use"
+              "--grpc_url instead");
 DEFINE_int32(
     p, kDefaultPort,
-    "Specifies the TCP port on which BESS listens for controller connections");
+    "Specifies the TCP port on which BESS listens for controller connections, "
+    "if --grpc_url is empty. Deprecated, please use --grpc_url instead");
 static const bool _p_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_p, &ValidateTCPPort);
 

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -50,6 +50,8 @@ DEFINE_bool(s, false, "Show TC statistics every second");
 DEFINE_bool(d, false, "Run BESS in debug mode (with debug log messages)");
 DEFINE_bool(a, false, "Allow multiple instances");
 DEFINE_bool(no_huge, false, "Disable hugepages");
+DEFINE_bool(skip_root_check, false,
+            "Skip checking that the process is running as root.");
 DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
               "Load modules from the specified directory");
 

--- a/core/opts.h
+++ b/core/opts.h
@@ -44,6 +44,7 @@ DECLARE_string(b);
 DECLARE_int32(p);
 DECLARE_int32(m);
 DECLARE_bool(no_huge);
+DECLARE_bool(skip_root_check);
 DECLARE_string(modules);
 
 #endif  // BESS_OPTS_H_

--- a/core/opts.h
+++ b/core/opts.h
@@ -42,6 +42,7 @@ DECLARE_bool(a);
 DECLARE_int32(c);
 DECLARE_string(b);
 DECLARE_int32(p);
+DECLARE_string(grpc_url);
 DECLARE_int32(m);
 DECLARE_bool(no_huge);
 DECLARE_bool(skip_root_check);

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -152,6 +152,7 @@ class BESS(object):
         pass
 
     DEF_PORT = 10514
+    DEF_GRPC_URL = "localhost:" + str(DEF_PORT)
     BROKEN_CHANNEL = "AbnormalDisconnection"
 
     def __init__(self):
@@ -182,16 +183,16 @@ class BESS(object):
         else:
             self.status = connectivity
 
-    def connect(self, host='localhost', port=DEF_PORT):
+    def connect(self, grpc_url=DEF_GRPC_URL):
         if self.debug:
-            print('Connecting to %s:%d' % (host, port))
+            print('Connecting to ' + grpc_url)
 
         if self.is_connected():
             raise self.APIError('Already connected')
 
         self.status = None
-        self.peer = (host, port)
-        self.channel = grpc.insecure_channel('%s:%d' % (host, port))
+        self.peer = grpc_url
+        self.channel = grpc.insecure_channel(grpc_url)
         self.channel.subscribe(self._update_status, try_to_connect=True)
         self.stub = service_pb2.BESSControlStub(self.channel)
 
@@ -201,7 +202,7 @@ class BESS(object):
                                self.BROKEN_CHANNEL]:
                 self.disconnect()
                 raise self.APIError(
-                    'Connection to %s:%d failed' % (host, port))
+                    'Connection to {} failed'.format(grpc_url))
             time.sleep(0.1)
 
     # returns no error if already disconnected

--- a/pybess/test_bess.py
+++ b/pybess/test_bess.py
@@ -65,6 +65,7 @@ class TestBESS(unittest.TestCase):
     # Do not use BESS.DEF_PORT (== 10514), as it might be being used by
     # a real bessd process.
     PORT = 19876
+    GRPC_URL = 'localhost:' + str(PORT)
 
     @classmethod
     def setUpClass(cls):
@@ -83,7 +84,7 @@ class TestBESS(unittest.TestCase):
 
     def test_connect(self):
         client = bess.BESS()
-        client.connect(port=self.PORT)
+        client.connect(grpc_url=self.GRPC_URL)
         time.sleep(0.1)
         self.assertEqual(True, client.is_connected())
 
@@ -93,21 +94,21 @@ class TestBESS(unittest.TestCase):
 
     def test_kill(self):
         client = bess.BESS()
-        client.connect(port=self.PORT)
+        client.connect(grpc_url=self.GRPC_URL)
 
         response = client.kill(block=False)
         self.assertEqual(0, response.error.code)
 
     def test_list_modules(self):
         client = bess.BESS()
-        client.connect(port=self.PORT)
+        client.connect(grpc_url=self.GRPC_URL)
 
         response = client.list_modules()
         self.assertEqual(0, response.error.code)
 
     def test_create_port(self):
         client = bess.BESS()
-        client.connect(port=self.PORT)
+        client.connect(grpc_url=self.GRPC_URL)
 
         response = client.create_port('PCAPPort', 'p0', {'dev': 'rnd'})
         self.assertEqual(0, response.error.code)
@@ -139,7 +140,7 @@ class TestBESS(unittest.TestCase):
 
     def test_run_module_command(self):
         client = bess.BESS()
-        client.connect(port=self.PORT)
+        client.connect(grpc_url=self.GRPC_URL)
 
         response = client.run_module_command('m1',
                                              'add',


### PR DESCRIPTION
I'd like to use BESS in a set of tests that could be run in parallel and without root privileges.

* As long as there are no PMD devices and hugepages, bessd should work as non root, so this PR adds a command line flags to skip the root check.

To be able to run in parallel, I'd like each BESS instance to listen on a unix domain socket. gRPC makes it easy to do that, so:

* This commits adds a `--grpc_url` option to bessd. the `-p` and `-b` options are kept for backward compatibility.
* The bessctl `daemon connect` command is changed: it takes a grpc URL instead of the host and the port, to make it more generic. This is _not_ backward compatible