### PR TITLE
Add support for initial buffers to allocate, allocate memory properly with no_huge

### DIFF
--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -135,7 +135,7 @@ static void init_eal(const char *prog_name, int mb_per_socket,
 
   if (no_huge) {
     rte_args.Append({"--no-huge"});
-    rte_args.Append({"-m", std::to_string(mb_per_socket)});
+    rte_args.Append({"-m", std::to_string(mb_per_socket * numa_count)});
   } else {
     std::string opt_socket_mem = std::to_string(mb_per_socket);
     for (int i = 1; i < numa_count; i++) {

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -35,7 +35,6 @@
 
 #include "bessd.h"
 #include "worker.h"
-#include "packet.h"
 
 // Port this BESS instance listens on.
 // Panda came up with this default number
@@ -96,22 +95,17 @@ static const bool _m_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_m, &ValidateMegabytesPerSocket);
 
 static bool ValidateBuffersPerSocket(const char *, int32_t value) {
-  if (value < bess::minimum_try) {
-    LOG(ERROR) << "Invalid buffer count: " << value <<
-      " must be >= " << bess::minimum_try;
+  if (value <= 0) {
+    LOG(ERROR) << "Invalid number of buffers: " << value;
     return false;
   }
-  int32_t check = value;
-  while (check != 1) {
-    if (check % 2 != 0) {
-      LOG(ERROR) << "Number of buffers must be a power of 2: " << value;
-      return false;
-    }
-    check = check / 2;
+  if (value & (value - 1)) {
+    LOG(ERROR) << "Number of buffers must be a power of 2: " << value;
+    return false;
   }
   return true;
 }
-DEFINE_int32(buffers, 262144, "Specifies how many buffers to allocate per socket,"
+DEFINE_int32(buffers, 262144, "Specifies how many packet buffers to allocate per socket,"
 	     " must be a power of 2.");
 static const bool _buffers_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_buffers, &ValidateBuffersPerSocket);

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -93,3 +93,19 @@ static bool ValidateMegabytesPerSocket(const char *, int32_t value) {
 DEFINE_int32(m, 1024, "Specifies how many megabytes to use per socket");
 static const bool _m_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_m, &ValidateMegabytesPerSocket);
+
+static bool ValidateBuffersPerSocket(const char *, int32_t value) {
+  if (value <= 0) {
+    LOG(ERROR) << "Invalid buffer count: " << value;
+    return false;
+  }
+  if (value % 512 != 0) {
+    LOG(ERROR) << "Number of buffers must be a multiple of 512: " << value;
+    return false;
+  }
+  return true;
+}
+DEFINE_int32(buffers, 262144, "Specifies how many buffers to allocate per socket,"
+	     " must be a multiple of 512");
+static const bool _buffers_dummy[[maybe_unused]] =
+    google::RegisterFlagValidator(&FLAGS_buffers, &ValidateBuffersPerSocket);

--- a/core/opts.h
+++ b/core/opts.h
@@ -45,5 +45,6 @@ DECLARE_int32(p);
 DECLARE_int32(m);
 DECLARE_bool(no_huge);
 DECLARE_string(modules);
+DECLARE_int32(buffers);
 
 #endif  // BESS_OPTS_H_

--- a/core/packet.cc
+++ b/core/packet.cc
@@ -71,6 +71,7 @@ static void init_mempool_socket(int sid) {
   int current_try = FLAGS_buffers;
 
   const int num_mempool_cache = 512;
+  const int minimum_try = 16384;
 
   pool_priv.mbuf_data_room_size = SNBUF_HEADROOM + SNBUF_DATA;
   pool_priv.mbuf_priv_size = SNBUF_RESERVE;

--- a/core/packet.cc
+++ b/core/packet.cc
@@ -71,7 +71,6 @@ static void init_mempool_socket(int sid) {
   int current_try = FLAGS_buffers;
 
   const int num_mempool_cache = 512;
-  const int minimum_try = 16384;
 
   pool_priv.mbuf_data_room_size = SNBUF_HEADROOM + SNBUF_DATA;
   pool_priv.mbuf_priv_size = SNBUF_RESERVE;

--- a/core/packet.cc
+++ b/core/packet.cc
@@ -68,11 +68,10 @@ static void packet_init(struct rte_mempool *mp, void *opaque_arg, void *_m,
 static void init_mempool_socket(int sid) {
   struct rte_pktmbuf_pool_private pool_priv;
   char name[256];
+  int current_try = FLAGS_buffers;
 
   const int num_mempool_cache = 512;
-  const int initial_try = 262144;
   const int minimum_try = 16384;
-  int current_try = initial_try;
 
   pool_priv.mbuf_data_room_size = SNBUF_HEADROOM + SNBUF_DATA;
   pool_priv.mbuf_priv_size = SNBUF_RESERVE;

--- a/core/packet.h
+++ b/core/packet.h
@@ -60,6 +60,8 @@ static_assert(SNBUF_SCRATCHPAD_OFF == 320,
 
 namespace bess {
 
+const int minimum_try = 16384; // For packet buffer allocation.
+
 class Packet;
 
 static inline Packet *__packet_alloc_pool(struct rte_mempool *pool) {

--- a/core/packet.h
+++ b/core/packet.h
@@ -60,8 +60,6 @@ static_assert(SNBUF_SCRATCHPAD_OFF == 320,
 
 namespace bess {
 
-const int minimum_try = 16384; // For packet buffer allocation.
-
 class Packet;
 
 static inline Packet *__packet_alloc_pool(struct rte_mempool *pool) {


### PR DESCRIPTION

Add a -buffers argument that specifies the initial number of buffers to allocate per
numa socket.

Properly allocate mb_per_socket when specifying -no-huge by passing
-m (mb_per_socket * numa_count) to rte_eal_init().