### PR TITLE
measure module: minor refinements

### DIFF
--- a/bessctl/module_tests/timestamp.py
+++ b/bessctl/module_tests/timestamp.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2018, Nefeli Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the names of the copyright holders nor the names of their
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+from test_utils import *
+
+
+# test both measure and timestamp (can't test them separately)
+class BessTimestampTest(BessModuleTestCase):
+
+    def test_timestamped_and_measured(self):
+        udp = get_udp_packet(sip='172.12.0.3', dip='127.12.0.4')
+        mmod = Measure(latency_ns_resolution=1, latency_ns_max=100000)
+        Source() -> Rewrite(templates=[bytes(udp)]) -> Timestamp() -> \
+            Bypass(cycles_per_batch=100) -> mmod -> Sink()
+        self.bess.resume_all()
+        # Run for .5 seconds to warm up ...
+        time.sleep(0.5)
+        # ... then clear accumulated stats.
+        self.bess.run_module_command(mmod.name, 'clear', 'EmptyArg', {})
+        # Run for 2 more seconds to accumulate real stats.
+        time.sleep(2)
+        self.bess.pause_all()
+        self.assertBessAlive()
+        pct = [0, 25, 50, 99, 100]
+        stats = self.bess.run_module_command(mmod.name, 'get_summary',
+                                             'MeasureCommandGetSummaryArg',
+                                             {'latency_percentiles': pct})
+        # There is no way to know if what the verbosity= argument below
+        # is from here.  Note that stats contains, e.g. (on my laptop VM,
+        # using the default resolution and max values):
+        #
+        # timestamp: 1517529594.72
+        # packets: 64807616
+        # bits: 43550717952
+        # latency = {
+        #   count: 64807616
+        #   min_ns: 400
+        #   avg_ns: 513
+        #   max_ns: 295600
+        #   total_ns: 33273840000
+        #   percentile_values_ns: [400, 500, 500, 500, 295600]
+        #   resolution_ns: 100
+        # }
+        # jitter = {
+        #   count: 3238279
+        #   avg_ns: 15
+        #   max_ns: 295100
+        #   total_ns: 48577800
+        #   resolution_ns: 100
+        # }
+        print()
+        print('min ns =', stats.latency.min_ns)
+        print('avg ns =', stats.latency.avg_ns)
+        # these two should be approximately equal - within about 1%
+        a = stats.latency.avg_ns * stats.latency.count
+        b = stats.latency.total_ns
+        diff = abs(a - b) / float(b) * 100.0
+        self.assertLessEqual(diff, 1.0)
+
+
+suite = unittest.TestLoader().loadTestsFromTestCase(BessTimestampTest)
+results = unittest.TextTestRunner(verbosity=2).run(suite)
+
+if results.failures or results.errors:
+    sys.exit(1)

--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -39,10 +39,10 @@
 
 class Measure final : public Module {
  public:
-  Measure()
+  Measure(uint64_t ns_per_bucket = 1, uint64_t max_ns = 0)
       : Module(),
-        rtt_hist_(kBuckets, kBucketWidth),
-        jitter_hist_(kBuckets, kBucketWidth),
+        rtt_hist_(max_ns / ns_per_bucket, ns_per_bucket),
+        jitter_hist_(max_ns / ns_per_bucket, ns_per_bucket),
         rand_(),
         jitter_sample_prob_(),
         last_rtt_ns_(),
@@ -63,8 +63,8 @@ class Measure final : public Module {
   static const Commands cmds;
 
  private:
-  static const uint64_t kBucketWidth = 100;  // Measure in 100 ns units
-  static const uint64_t kBuckets = 1000000;
+  static const uint64_t kDefaultNsPerBucket = 100;
+  static const uint64_t kDefaultMaxNs = 100'000'000;  // 100 ms
   static constexpr double kDefaultIpDvSampleProb = 0.05;
 
   void Clear();

--- a/core/utils/histogram.h
+++ b/core/utils/histogram.h
@@ -31,6 +31,7 @@
 #ifndef BESS_UTILS_HISTOGRAM_H_
 #define BESS_UTILS_HISTOGRAM_H_
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -134,11 +135,29 @@ class Histogram {
     return ret;
   }
 
+  size_t num_buckets() const { return buckets_.size(); }
+  T bucket_width() const { return bucket_width_; }
+
+  size_t max_num_buckets() const {
+    // This constant is mainly to keep resets to a reasonable speed.
+    const size_t max_buckets = 10'000'000;
+    return std::min(max_buckets, buckets_.max_size());
+  }
+
   // Resets all counters, and the count of such counters.
   // Note that the number of buckets remains unchanged.
   void Reset() {
     count_ = 0;
     std::fill(buckets_.begin(), buckets_.end(), T());
+  }
+
+  // Resize the histogram.  Note that this resets it (i.e., this
+  // does not attempt to redistribute existing counts).
+  void Resize(size_t num_buckets, T bucket_width) {
+    buckets_.clear();
+    buckets_.resize(num_buckets + 1);
+    bucket_width_ = bucket_width;
+    count_ = 0;
   }
 
  private:

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -236,12 +236,18 @@ message MeasureCommandGetSummaryArg {
 
 /**
  * The Measure module function `get_summary()` returns the following values.
+ * Note that the resolution value tells you how grainy the samples are,
+ * e.g., 100 means that anything from 0-99 ns counts as "0",
+ * anything from 100-199 counts as "100", and so on.  The average
+ * is of samples using this graininess, but (being a result of division)
+ * may not be a multiple of the resolution.
  */
 message MeasureCommandGetSummaryResponse {
   message Histogram {
     uint64 count = 1; /// Total # of measured data points, including above_range
     uint64 above_range = 2; /// # of data points for the "too large value" bucket
-    uint64 min_ns = 3;;
+    uint64 resolution_ns = 8; /// resolution of measured data
+    uint64 min_ns = 3;
     uint64 avg_ns = 4;
     uint64 max_ns = 5;
     uint64 total_ns = 6;
@@ -637,15 +643,18 @@ message MACSwapArg {
  * The measure module tracks latencies, packets per second, and other statistics.
  * It should be paired with a Timestamp module, which attaches a timestamp to packets.
  * The measure module will log how long (in nanoseconds) it has been for each packet it received since it was timsestamped.
- * An example of the Measure module in use is in [`bess/bessctl/conf/perftest/latency/bess`](https://github.com/NetSys/bess/blob/master/bessctl/conf/samples/latency.bess).
+ * This module is somewhat experimental and undergoing various changes.
+ * There is a test for the the Measure module in [`bessctl/module_tests/timestamp.py`](https://github.com/NetSys/bess/blob/master/bessctl/module_tests/timestamp.py).
  *
  * __Input Gates__: 1
  * __Output Gates__: 1
  */
 message MeasureArg {
-  int64 warmup = 1; /// How long to wait, in seconds, between starting the module and taking measurements.
+  // int64 warmup = 1; /// removed: instead of warmup delay, user should Clear()
   uint64 offset = 2; /// Where to store the current time within the packet, offset in bytes.
   double jitter_sample_prob = 3; /// How often the module should sample packets for inter-packet arrival measurements (to measure jitter).
+  uint64 latency_ns_max = 4; /// maximum latency expected, in ns (default 0.1 s)
+  uint32 latency_ns_resolution = 5; /// resolution, in ns (default 100)
 }
 
 /**
@@ -953,9 +962,10 @@ message SplitArg {
 }
 
 /**
- * The timestamp module takes no parameters. It inserts the current
+ * The timestamp module takes an offset parameter. It inserts the current
  * time in nanoseconds into the packet, to be used for latency measurements
- * alongside the Measure module.
+ * alongside the Measure module.  The default offset is after an IPv4 UDP
+ * header.
  *
  * __Input Gates__: 1
  * __Output Gates__: 1


### PR DESCRIPTION
Allow more precise control of the measure module histogram.

When returning summaries, include the bucket width (so that
the default width, if you don't specify one, is visible).

Add a module test for timestamp+measure.