### PR TITLE
Add a command line option to control core dump generation

### DIFF
--- a/core/debug.cc
+++ b/core/debug.cc
@@ -380,13 +380,15 @@ static bool SkipSymbol(char *symbol) {
   if (oops_msg == "")
     oops_msg = DumpStack();
 
-  // Create a crash log file
-  try {
-    std::ofstream fp(P_tmpdir "/bessd_crash.log");
-    fp << oops_msg;
-    fp.close();
-  } catch (...) {
-    // Ignore any errors.
+  // Create a crash log file if we are not dropping a core file.
+  if (!FLAGS_core_dump) {
+    try {
+      std::ofstream fp(P_tmpdir "/bessd_crash.log");
+      fp << oops_msg;
+      fp.close();
+    } catch (...) {
+      // Ignore any errors.
+    }
   }
 
   // Set SIGABRT back to the default to avoid catching the abort used to

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -380,8 +380,8 @@ static bool SkipSymbol(char *symbol) {
   if (oops_msg == "")
     oops_msg = DumpStack();
 
-  // Create a crash log file if we are not dropping a core file.
-  if (!FLAGS_core_dump) {
+  // Create a crash log file if not disabled.
+  if (!FLAGS_no_crashlog) {
     try {
       std::ofstream fp(P_tmpdir "/bessd_crash.log");
       fp << oops_msg;
@@ -391,14 +391,13 @@ static bool SkipSymbol(char *symbol) {
     }
   }
 
-  // Set SIGABRT back to the default to avoid catching the abort used to
-  // generate the core file.
-  struct sigaction sa;
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_handler = SIG_DFL;
-  sigaction(SIGABRT, &sa, 0);
-
   if (FLAGS_core_dump) {
+    // Set SIGABRT back to the default to avoid catching the abort used to
+    // generate the core file.
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_DFL;
+    sigaction(SIGABRT, &sa, 0);
     google::InstallFailureFunction(abort_failure);
   } else {
     google::InstallFailureFunction(exit_failure);

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -52,6 +52,7 @@ DEFINE_bool(a, false, "Allow multiple instances");
 DEFINE_bool(no_huge, false, "Disable hugepages");
 DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
               "Load modules from the specified directory");
+DEFINE_bool(core_dump, false, "Generate a core dump on fatal faults");
 
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -53,6 +53,7 @@ DEFINE_bool(no_huge, false, "Disable hugepages");
 DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
               "Load modules from the specified directory");
 DEFINE_bool(core_dump, false, "Generate a core dump on fatal faults");
+DEFINE_bool(no_crashlog, false, "Disable the generation of a crash log file");
 
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {

--- a/core/opts.h
+++ b/core/opts.h
@@ -45,5 +45,6 @@ DECLARE_int32(p);
 DECLARE_int32(m);
 DECLARE_bool(no_huge);
 DECLARE_string(modules);
+DECLARE_bool(core_dump);
 
 #endif  // BESS_OPTS_H_

--- a/core/opts.h
+++ b/core/opts.h
@@ -46,5 +46,6 @@ DECLARE_int32(m);
 DECLARE_bool(no_huge);
 DECLARE_string(modules);
 DECLARE_bool(core_dump);
+DECLARE_bool(no_crashlog);
 
 #endif  // BESS_OPTS_H_


### PR DESCRIPTION
Add a command line option to force bessd to drop a core file on a fatal condition.
When the this option is set, do not generate /tmp/bessd_crash.log. 