### PR TITLE
Only erase members from event_modules PreResume set after iteration done

### DIFF
--- a/core/resume_hook.cc
+++ b/core/resume_hook.cc
@@ -72,12 +72,16 @@ void run_global_resume_hooks(bool run_modules) {
   }
 
   if (run_modules) {
+    std::set<Module *> erase_modules; // Erase modules after completing iteration
     auto &resume_modules = event_modules[Event::PreResume];
     for (Module *m : resume_modules) {
       int ret = m->OnEvent(Event::PreResume);
       if (ret == -ENOTSUP) {
-        resume_modules.erase(m);
+        erase_modules.insert(m);
       }
+    }
+    for (Module *m : erase_modules) {
+      resume_modules.erase(m);
     }
   }
 }

--- a/core/resume_hook.cc
+++ b/core/resume_hook.cc
@@ -72,16 +72,14 @@ void run_global_resume_hooks(bool run_modules) {
   }
 
   if (run_modules) {
-    std::set<Module *> erase_modules; // Erase modules after completing iteration
     auto &resume_modules = event_modules[Event::PreResume];
-    for (Module *m : resume_modules) {
-      int ret = m->OnEvent(Event::PreResume);
+    for (auto it = resume_modules.begin(); it != resume_modules.end(); ) {
+      int ret = (*it)->OnEvent(Event::PreResume);
       if (ret == -ENOTSUP) {
-        erase_modules.insert(m);
+	it = resume_modules.erase(it);
+      } else {
+	it++;
       }
-    }
-    for (Module *m : erase_modules) {
-      resume_modules.erase(m);
     }
   }
 }


### PR DESCRIPTION
It seems that while iterating through a set if you erase a member the iteration may not visit all the
members of the set. Issue found under the following conditions:

```
$ uname -a
Linux bess-ubuntu16 4.4.0-109-generic #132-Ubuntu SMP Tue Jan 9 19:52:39 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

$ g++ --version
g++ (Ubuntu 5.4.1-2ubuntu1~16.04) 5.4.1 20160904
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```


