### PR TITLE
build: allow DPDK_REPO, DPDK_TAG to be overidden

### DIFF
--- a/build.py
+++ b/build.py
@@ -46,8 +46,8 @@ DEPS_DIR = '%s/deps' % BESS_DIR
 
 # It's best to use a release tag if possible -- see comments in
 # download_dpdk
-DPDK_REPO = 'http://dpdk.org/git/dpdk'
-DPDK_TAG = 'v17.11'
+DPDK_REPO = os.getenv('DPDK_REPO', 'http://dpdk.org/git/dpdk')
+DPDK_TAG = os.getenv('DPDK_TAG', 'v17.11')
 
 DPDK_VER = 'dpdk-17.11'
 


### PR DESCRIPTION
git://dpdk.org/dpdk seems to be less flakey than http://dpdk.org/git/dpdk and it would be nice to be able to use it when the user's network allows for it.