### PR TITLE
Do not use tab characters for conditionals

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -54,9 +54,9 @@ CXXCOMPILER := $(shell expr $(word 1, $(shell $(CXX) --version)) : '\(clang\|g++
 CXXVERSION := $(shell $(CXX) -dumpversion)
 
 ifeq "$(CXXCOMPILER)" "g++"
-ifneq "$(shell printf '$(CXXVERSION)\n5' | sort -V | head -n1)" "5"
-$(error g++ 5 or higher is required. Use container_build.py if newer g++ is not available.)
-endif
+  ifneq "$(shell printf '$(CXXVERSION)\n5' | sort -V | head -n1)" "5"
+    $(error g++ 5 or higher is required. Use container_build.py if newer g++ is not available.)
+  endif
 endif
 
 HAS_PKG_CONFIG := $(shell command -v $(PKG_CONFIG) 2>&1 >/dev/null && echo yes || echo no)
@@ -66,17 +66,14 @@ RTE_TARGET ?= $(shell uname -m)-native-linuxapp-gcc
 DPDK_LIB ?= dpdk
 
 ifneq ($(wildcard $(RTE_SDK)/$(RTE_TARGET)/*),)
-	DPDK_INC_DIR := $(RTE_SDK)/$(RTE_TARGET)/include
-	DPDK_LIB_DIR := $(RTE_SDK)/$(RTE_TARGET)/lib
+  DPDK_INC_DIR := $(RTE_SDK)/$(RTE_TARGET)/include
+  DPDK_LIB_DIR := $(RTE_SDK)/$(RTE_TARGET)/lib
 else ifneq ($(wildcard $(RTE_SDK)/build/*),)
-	# if the user didn't do "make install" for DPDK
-	DPDK_INC_DIR := $(RTE_SDK)/build/include
-	DPDK_LIB_DIR := $(RTE_SDK)/build/lib
-else ifeq ($(words $(MAKECMDGOALS)),1)
-	ifneq ($(MAKECMDGOALS),clean)
-	$(error DPDK is not available. \
-		Make sure $(abspath $(RTE_SDK)) is available and built)
-	endif
+  # if the user didn't do "make install" for DPDK
+  DPDK_INC_DIR := $(RTE_SDK)/build/include
+  DPDK_LIB_DIR := $(RTE_SDK)/build/lib
+else ifneq ($(MAKECMDGOALS),clean)
+  $(error DPDK is not available. Make sure $(abspath $(RTE_SDK)) is available and built)
 endif
 
 # We always want these libraries to be dynamically linked even when the
@@ -94,9 +91,9 @@ NO_PKG_CONFIG_LIBS := -lglog -lgflags -lprotobuf -lgrpc++ -lunwind -lz
 NO_PKG_CONFIG_LIBS_INDIRECT := -lgrpc -lssl -lcrypto -llzma
 
 ifeq ($(HAS_PKG_CONFIG), yes)
-    PKG_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_DEPS))
+  PKG_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_DEPS))
 else
-    PKG_CFLAGS :=
+  PKG_CFLAGS :=
 endif
 
 # Plugins get to look in $COREDIR through -I $(COREDIR).  Let them also
@@ -113,68 +110,68 @@ endif
 COREDIR := $(abspath .)
 CXXARCHFLAGS ?= -march=native
 CXXFLAGS += -std=c++14 -g3 -ggdb3 $(CXXARCHFLAGS) \
-	    -isystem $(DPDK_INC_DIR) -isystem $(COREDIR) \
-	    -isystem $(dir $<).. -isystem $(COREDIR)/modules \
-	    -D_GNU_SOURCE \
-	    -Werror \
-	    -Wall -Wextra -Wcast-align $(PKG_CFLAGS)
+            -isystem $(DPDK_INC_DIR) -isystem $(COREDIR) \
+            -isystem $(dir $<).. -isystem $(COREDIR)/modules \
+            -D_GNU_SOURCE \
+            -Werror \
+            -Wall -Wextra -Wcast-align $(PKG_CFLAGS)
 
 PERMISSIVE := -Wno-unused-parameter -Wno-missing-field-initializers \
-	      -Wno-unused-private-field
+              -Wno-unused-private-field
 
 # -Wshadow should not be used for g++ 4.x, as it has too many false positives
 ifeq "$(shell expr $(CXXCOMPILER) = g++ \& $(CXXVERSION) \< 50000)" "0"
-	CXXFLAGS += -Wshadow
+  CXXFLAGS += -Wshadow
 endif
 
 # Disable GNU_UNIQUE symbol for g++
 ifeq "$(shell expr $(CXXCOMPILER) = g++)" "1"
-	CXXFLAGS += -fno-gnu-unique
+  CXXFLAGS += -fno-gnu-unique
 endif
 
 LDFLAGS += -rdynamic -L$(DPDK_LIB_DIR) -Wl,-rpath=$(DPDK_LIB_DIR) -pthread
 ifdef BESS_LINK_DYNAMIC
-    LIBS_ALL_SHARED = -Wl,-call_shared
-    LIBS_DL_SHARED =
-    ifeq ($(HAS_PKG_CONFIG), yes)
-      PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_DEPS))
-    else
-      PKG_LIBS := $(NO_PKG_CONFIG_LIBS)
-    endif
+  LIBS_ALL_SHARED = -Wl,-call_shared
+  LIBS_DL_SHARED =
+  ifeq ($(HAS_PKG_CONFIG), yes)
+    PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_DEPS))
+  else
+    PKG_LIBS := $(NO_PKG_CONFIG_LIBS)
+  endif
 else # Used static libraries
-    LIBS_ALL_SHARED =
-    LIBS_DL_SHARED = -Wl,-call_shared
-    LDFLAGS += -static-libstdc++
-    ifeq ($(HAS_PKG_CONFIG), yes)
-      PKG_LIBS := $(shell $(PKG_CONFIG) --static --libs $(PKG_CONFIG_DEPS))
-      # One of our pkg-config dependency might depend on a library that
-      # we want to dynamically link no matter what.  Filter those out
-      # to avoid including them into the static linking section.
-      PKG_LIBS := $(filter-out $(ALWAYS_DYN_LIBS), $(PKG_LIBS))
-    else
-      PKG_LIBS := $(NO_PKG_CONFIG_LIBS) $(NO_PKG_CONFIG_LIBS_INDIRECT)
-    endif
+  LIBS_ALL_SHARED =
+  LIBS_DL_SHARED = -Wl,-call_shared
+  LDFLAGS += -static-libstdc++
+  ifeq ($(HAS_PKG_CONFIG), yes)
+    PKG_LIBS := $(shell $(PKG_CONFIG) --static --libs $(PKG_CONFIG_DEPS))
+    # One of our pkg-config dependency might depend on a library that
+    # we want to dynamically link no matter what.  Filter those out
+    # to avoid including them into the static linking section.
+    PKG_LIBS := $(filter-out $(ALWAYS_DYN_LIBS), $(PKG_LIBS))
+  else
+    PKG_LIBS := $(NO_PKG_CONFIG_LIBS) $(NO_PKG_CONFIG_LIBS_INDIRECT)
+  endif
 endif
 
 LIBS += -Wl,-non_shared \
-	-Wl,--whole-archive -l$(DPDK_LIB) -Wl,--no-whole-archive \
-	$(LIBS_ALL_SHARED) \
-	$(PKG_LIBS) $(ALWAYS_LIBS) \
-	$(LIBS_DL_SHARED) \
-	$(ALWAYS_DYN_LIBS)
+        -Wl,--whole-archive -l$(DPDK_LIB) -Wl,--no-whole-archive \
+        $(LIBS_ALL_SHARED) \
+        $(PKG_LIBS) $(ALWAYS_LIBS) \
+        $(LIBS_DL_SHARED) \
+        $(ALWAYS_DYN_LIBS)
 
 ifdef SANITIZE
-	CXXFLAGS += -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer
-	LDFLAGS += -fsanitize=address -fsanitize=undefined
+  CXXFLAGS += -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer
+  LDFLAGS += -fsanitize=address -fsanitize=undefined
 endif
 
 ifdef COVERAGE
-	CXXFLAGS += --coverage -O0
-	LDFLAGS += --coverage
+  CXXFLAGS += --coverage -O0
+  LDFLAGS += --coverage
 else ifdef DEBUG
-	CXXFLAGS += -O0
+  CXXFLAGS += -O0
 else
-	CXXFLAGS += -Ofast -DNDEBUG
+  CXXFLAGS += -Ofast -DNDEBUG
 endif
 
 -include extra*.mk
@@ -269,25 +266,25 @@ BENCH_EXEC := $(BENCH_OBJS:%.o=%)
 
 MODULE_SRCS := $(filter-out $(TEST_SRCS) $(BENCH_SRCS), $(MODULES))
 MODULE_OBJS := $(addprefix modules/,$(patsubst %.cc,%.o, \
-		 $(notdir $(MODULE_SRCS))))
+                 $(notdir $(MODULE_SRCS))))
 
 PLUGIN_MODULE_OBJS := $(addprefix modules/,$(patsubst %.cc,%.o, \
-		 $(notdir $(PLUGIN_MODULES))))
+                 $(notdir $(PLUGIN_MODULES))))
 MODULE_LIBS := $(PLUGIN_MODULE_OBJS:.o=.so)
 
 ifdef MODULE_LINK_DYNAMIC
-	MODULE_LIBS += $(MODULE_OBJS:.o=.so)
+  MODULE_LIBS += $(MODULE_OBJS:.o=.so)
 endif
 
 GATE_HOOK_OBJS := $(addprefix gate_hooks/,$(patsubst %.cc,%.o, \
-		    $(notdir $(GATE_HOOK_SRCS))))
+                    $(notdir $(GATE_HOOK_SRCS))))
 RESUME_HOOK_OBJS := $(addprefix resume_hooks/,$(patsubst %.cc,%.o, \
-		      $(notdir $(RESUME_HOOK_SRCS))))
+                      $(notdir $(RESUME_HOOK_SRCS))))
 
 # We don't (yet?) make shared objects for drivers.
 DRIVER_SRCS := $(filter-out $(TEST_SRCS) $(BENCH_SRCS), $(DRIVERS))
 DRIVER_OBJS := $(addprefix drivers/,$(patsubst %.cc,%.o, \
-		 $(notdir $(DRIVER_SRCS))))
+                 $(notdir $(DRIVER_SRCS))))
 
 UTIL_SRCS := $(filter-out $(TEST_SRCS) $(BENCH_SRCS), $(UTILS))
 UTIL_OBJS := $(addprefix utils/,$(patsubst %.cc,%.o,$(notdir $(UTIL_SRCS))))
@@ -298,7 +295,7 @@ HEADERS := $(wildcard *.h utils/*.h) $(DRIVER_H) $(GATE_HOOKS_H) $(RESUME_HOOKS_
 OBJS := $(SRCS:.cc=.o) $(DRIVER_OBJS) $(UTIL_OBJS) $(GATE_HOOK_OBJS) $(RESUME_HOOK_OBJS)
 
 ifndef MODULE_LINK_DYNAMIC
-	OBJS += $(MODULE_OBJS)
+  OBJS += $(MODULE_OBJS)
 endif
 
 EXEC := bessd
@@ -361,132 +358,132 @@ $(2): $(3)
 	$$(eval _TYPE := $$(strip $(1)))
 	$$(eval _CMD := $$(strip $(4)))
 	@if [ $$(VERBOSE) -eq 0 ]; then \
-		printf "%-11s %s\n" "[$$(_TYPE)]" "$$@"; \
+	  printf "%-11s %s\n" "[$$(_TYPE)]" "$$@"; \
 	else \
-		printf "%-11s %s\n" "[$$(_TYPE)]" "$$(_CMD)"; \
+	  printf "%-11s %s\n" "[$$(_TYPE)]" "$$(_CMD)"; \
 	fi
 	@if ! $$(_CMD); then \
-		echo "Error: \033[0;31m$$@"; \
-		echo "\033[0;33m$$(_CMD)\033[0m"; \
-		false; \
+	  echo "Error: \033[0;31m$$@"; \
+	  echo "\033[0;33m$$(_CMD)\033[0m"; \
+	  false; \
 	fi
 endef
 
 $(eval $(call BUILD, \
-	PROTOC, \
-	pb/%.pb.cc pb/%.pb.h pb/%.grpc.pb.cc pb/%.grpc.pb.h, \
-	%.proto, \
-	$(PROTOC) $$< $(PROTOCFLAGS)))
+        PROTOC, \
+        pb/%.pb.cc pb/%.pb.h pb/%.grpc.pb.cc pb/%.grpc.pb.h, \
+        %.proto, \
+        $(PROTOC) $$< $(PROTOCFLAGS)))
 
 $(eval $(call BUILD, \
-	CXX, \
-	pb/%.pb.o, \
-	pb/%.pb.cc, \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $(PERMISSIVE) $$(DEPFLAGS)))
+        CXX, \
+        pb/%.pb.o, \
+        pb/%.pb.cc, \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $(PERMISSIVE) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	DRIVER_CXX, \
-	drivers/%.o, \
-	drivers/%.cc, \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        DRIVER_CXX, \
+        drivers/%.o, \
+        drivers/%.cc, \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	MODULE_CXX, \
-	modules/%.o, \
-	modules/%.cc $(PROTO_HEADERS), \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS) -fPIC))
+        MODULE_CXX, \
+        modules/%.o, \
+        modules/%.cc $(PROTO_HEADERS), \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS) -fPIC))
 
 $(eval $(call BUILD, \
-	UTILS_CXX, \
-	utils/%.o, \
-	utils/%.cc, \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        UTILS_CXX, \
+        utils/%.o, \
+        utils/%.cc, \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	GATEHOOK_CXX, \
-	gate_hooks/%.o, \
-	gate_hooks/%.cc, \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        GATEHOOK_CXX, \
+        gate_hooks/%.o, \
+        gate_hooks/%.cc, \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	RESUMEHOOK_CXX, \
-	resume_hooks/%.o, \
-	resume_hooks/%.cc, \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        RESUMEHOOK_CXX, \
+        resume_hooks/%.o, \
+        resume_hooks/%.cc, \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	MODULE_LD, \
-	%.so, \
-	%.o, \
-	$(CXX) -shared -o $$@ $$^ $(LDFLAGS)))
+        MODULE_LD, \
+        %.so, \
+        %.o, \
+        $(CXX) -shared -o $$@ $$^ $(LDFLAGS)))
 
 $(eval $(call BUILD, \
-	MODULE_TEST_LD, \
-	modules/%_test, \
-	modules/%_test.o modules/%.o gtest-all.o gtest_main.o bess.a, \
-	$(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
+        MODULE_TEST_LD, \
+        modules/%_test, \
+        modules/%_test.o modules/%.o gtest-all.o gtest_main.o bess.a, \
+        $(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
 
 $(eval $(call BUILD, \
-	MODULE_BENCH_LD, \
-	modules/%_bench, \
-	modules/%_bench.o modules/%.o bess.a, \
-	$(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS) -lbenchmark))
+        MODULE_BENCH_LD, \
+        modules/%_bench, \
+        modules/%_bench.o modules/%.o bess.a, \
+        $(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS) -lbenchmark))
 
 $(eval $(call BUILD, \
-	CXX, \
-	%.o, \
-	%.cc $(PROTO_HEADERS), \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        CXX, \
+        %.o, \
+        %.cc $(PROTO_HEADERS), \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	LD, \
-	$(EXEC), \
-	$(OBJS), \
-	$(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
+        LD, \
+        $(EXEC), \
+        $(OBJS), \
+        $(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
 
 $(eval $(call BUILD, \
-	TEST_CXX, \
-	%_test.o, \
-	%_test.cc $(PROTO_HEADERS), \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        TEST_CXX, \
+        %_test.o, \
+        %_test.cc $(PROTO_HEADERS), \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	TEST_LD, \
-	%_test, \
-	%_test.o gtest-all.o gtest_main.o bess.a, \
-	$(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
+        TEST_LD, \
+        %_test, \
+        %_test.o gtest-all.o gtest_main.o bess.a, \
+        $(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
 
 $(eval $(call BUILD, \
-	TEST_LD, \
-	$(TEST_ALL_EXEC), \
-	$(TEST_OBJS) $(MODULE_OBJS) gtest-all.o bess.a, \
-	$(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
+        TEST_LD, \
+        $(TEST_ALL_EXEC), \
+        $(TEST_OBJS) $(MODULE_OBJS) gtest-all.o bess.a, \
+        $(CXX) -o $$@ $$^ $(LDFLAGS) $(LIBS)))
 
 $(eval $(call BUILD, \
-	TEST_CXX, \
-	gtest-all.o, \
-	$(GTEST_DIR)/src/gtest-all.cc, \
-	$(CXX) -o $$@ -c $$< -isystem $(GTEST_DIR) $$(CXXFLAGS) $$(DEPFLAGS)))
+        TEST_CXX, \
+        gtest-all.o, \
+        $(GTEST_DIR)/src/gtest-all.cc, \
+        $(CXX) -o $$@ -c $$< -isystem $(GTEST_DIR) $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	BENCH_CXX, \
-	%_bench.o, \
-	%_bench.cc, \
-	$(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
+        BENCH_CXX, \
+        %_bench.o, \
+        %_bench.cc, \
+        $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
-	BENCH_LD, \
-	%_bench, \
-	%_bench.o bess.a, \
-	$(CXX) -o $$@ $$^ $(LDFLAGS) -lbenchmark $(LIBS)))
+        BENCH_LD, \
+        %_bench, \
+        %_bench.o bess.a, \
+        $(CXX) -o $$@ $$^ $(LDFLAGS) -lbenchmark $(LIBS)))
 
 LIB_OBJS := $(filter-out main.o, $(OBJS))
 
 $(eval $(call BUILD, \
-	AR, \
-	bess.a, \
-	$(LIB_OBJS), \
-	$(AR) rcs $$@ $$^))
+        AR, \
+        bess.a, \
+        $(LIB_OBJS), \
+        $(AR) rcs $$@ $$^))
 
 .PRECIOUS: %.d $(PROTO_HEADERS)
 


### PR DESCRIPTION
This PR replaces tab characters with spaces for all conditionals, as done in #779. Tab characters are supposed to be used only for commands.

@melvinw, could you check if this fixes the build issue you experienced?