### PR TITLE
Add a static NAT module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ install:
   # want to avoid the "ln -s /build/dpdk-17.05 deps" step below
   - sudo apt-get install -y python2.7 python3 python3-pip ruby-dev
   - sudo gem install ffi fpm
-  - pip2 install --user grpcio scapy codecov
-  - pip3 install --user grpcio scapy-python3 coverage
+  - pip2 install --user grpcio==1.10 scapy codecov
+  - pip3 install --user grpcio==1.10 scapy-python3 coverage
   - "[[ ${COVERAGE:-0} == 0 ]] || sudo apt-get install -y g++-5"  # install gcov-5
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - "[[ $TAG_SUFFIX != _32 ]] || sudo apt-get install -y lib32gcc1"

--- a/bessctl/conf/samples/nat.bess
+++ b/bessctl/conf/samples/nat.bess
@@ -47,15 +47,17 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
            gen_packet(scapy.UDP, '172.16.100.1', '12.34.56.78'),
            gen_packet(scapy.TCP, '172.12.55.99', '12.34.56.78'),
            gen_packet(scapy.UDP, '192.168.1.123', '12.34.56.78'),
-          ]
-nat_config = [{'ext_addr': '192.168.0.1'}, {'ext_addr': '192.168.0.2'}]
+           ]
 
-nat::NAT(ext_addrs=nat_config)
+# dynamic NAT configuration
+nat::NAT(ext_addrs=[{'ext_addr': '192.168.0.1'}, {'ext_addr': '192.168.0.2'}])
+Source() -> Rewrite(templates=packets) -> 0:nat:0 -> MACSwap() -> IPSwap() -> 1:nat:1 -> Sink()
 
-# Swap src/dst MAC
-mac::MACSwap()
-
-# Swap src/dst IP addresses / ports
-ip::IPSwap()
-
-Source() -> Rewrite(templates=packets) -> 0:nat:0 -> mac -> ip -> 1:nat:1 -> Sink()
+# static NAT configuration
+static_nat::StaticNAT(pairs=[
+    {'int_range': {'start': '172.16.0.0', 'end': '172.31.255.255'},
+     'ext_range': {'start': '55.1.0.0', 'end': '55.16.255.255'}},
+    {'int_range': {'start': '192.168.0.0', 'end': '192.168.255.255'},
+     'ext_range': {'start': '66.77.0.0', 'end': '66.77.255.255'}},
+])
+Source() -> Rewrite(templates=packets) -> 0:static_nat:0 -> MACSwap() -> IPSwap() -> 1:static_nat:1 -> Sink()

--- a/bessctl/module_tests/nat.py
+++ b/bessctl/module_tests/nat.py
@@ -90,7 +90,7 @@ class BessNatTest(BessModuleTestCase):
         nat = NAT(ext_addrs=nat_config)
         self._test_l4(nat, scapy.UDP(sport=56797, dport=53), '192.168.1.1')
 
-    def test_nat_udp_with_cksum(self):
+    def test_nat_udp_with_zero_cksum(self):
         nat_config = [{'ext_addr': '192.168.1.1'}]
         nat = NAT(ext_addrs=nat_config)
         self._test_l4(

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -324,7 +324,7 @@ inline void Stamp(Ipv4 *ip, void *l4, const Endpoint &before,
 
 template <NAT::Direction dir>
 inline void NAT::DoProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  static gate_idx_t ogate_idx = static_cast<gate_idx_t>(dir);
+  gate_idx_t ogate_idx = static_cast<gate_idx_t>(dir);
   int cnt = batch->cnt();
   uint64_t now = ctx->current_ns;
 
@@ -379,4 +379,4 @@ std::string NAT::GetDesc() const {
   return bess::utils::Format("%zu entries", map_.Count() / 2);
 }
 
-ADD_MODULE(NAT, "nat", "Network address translator")
+ADD_MODULE(NAT, "nat", "Dynamic Network address/port translator")

--- a/core/modules/static_nat.cc
+++ b/core/modules/static_nat.cc
@@ -1,0 +1,189 @@
+// Copyright (c) 2018, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "static_nat.h"
+
+#include "../utils/checksum.h"
+#include "../utils/ether.h"
+#include "../utils/ip.h"
+#include "../utils/tcp.h"
+#include "../utils/udp.h"
+
+const Commands StaticNAT::cmds = {
+    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&StaticNAT::GetInitialArg),
+     Command::THREAD_SAFE},
+    {"get_runtime_config", "EmptyArg",
+     MODULE_CMD_FUNC(&StaticNAT::GetRuntimeConfig), Command::THREAD_SAFE},
+    {"set_runtime_config", "EmptyArg",
+     MODULE_CMD_FUNC(&StaticNAT::SetRuntimeConfig), Command::THREAD_SAFE}};
+
+CommandResponse StaticNAT::Init(const bess::pb::StaticNATArg &arg) {
+  using bess::utils::ParseIpv4Address;
+
+  for (const auto &pb_pair : arg.pairs()) {
+    be32_t int_start, int_end;
+    if (!ParseIpv4Address(pb_pair.int_range().start(), &int_start)) {
+      return CommandFailure(EINVAL, "invalid IP address %s",
+                            pb_pair.int_range().start().c_str());
+    }
+    if (!ParseIpv4Address(pb_pair.int_range().end(), &int_end)) {
+      return CommandFailure(EINVAL, "invalid IP address %s",
+                            pb_pair.int_range().end().c_str());
+    }
+    if (int_start > int_end) {
+      return CommandFailure(EINVAL, "invalid internal IP address range");
+    }
+
+    be32_t ext_start, ext_end;
+    if (!ParseIpv4Address(pb_pair.ext_range().start(), &ext_start)) {
+      return CommandFailure(EINVAL, "invalid IP address %s",
+                            pb_pair.ext_range().start().c_str());
+    }
+    if (!ParseIpv4Address(pb_pair.ext_range().end(), &ext_end)) {
+      return CommandFailure(EINVAL, "invalid IP address %s",
+                            pb_pair.ext_range().end().c_str());
+    }
+    if (ext_start > ext_end) {
+      return CommandFailure(EINVAL, "invalid external IP address range");
+    }
+
+    if (int_end.value() == 0xffffffff || ext_end.value() == 0xffffffff) {
+      return CommandFailure(EINVAL, "cannot map broadcast address");
+    }
+
+    if (int_end - int_start != ext_end - ext_start) {
+      return CommandFailure(EINVAL, "internal/external address ranges differ");
+    }
+
+    pairs_.push_back({.int_addr = int_start.value(),
+                      .ext_addr = ext_start.value(),
+                      .size = int_end.value() - int_start.value() + 1});
+  }
+
+  return CommandSuccess();
+}
+
+CommandResponse StaticNAT::GetInitialArg(const bess::pb::EmptyArg &) {
+  using bess::utils::ToIpv4Address;
+
+  bess::pb::StaticNATArg resp;
+  for (const auto &pair : pairs_) {
+    auto *pb_pair = resp.add_pairs();
+
+    auto *int_range = pb_pair->mutable_int_range();
+    int_range->set_start(ToIpv4Address(be32_t(pair.int_addr)));
+    int_range->set_end(ToIpv4Address(be32_t(pair.int_addr + pair.size)));
+
+    auto *ext_range = pb_pair->mutable_ext_range();
+    ext_range->set_start(ToIpv4Address(be32_t(pair.ext_addr)));
+    ext_range->set_end(ToIpv4Address(be32_t(pair.ext_addr + pair.size)));
+  }
+
+  return CommandSuccess(resp);
+}
+
+CommandResponse StaticNAT::GetRuntimeConfig(const bess::pb::EmptyArg &) {
+  return CommandSuccess();
+}
+
+CommandResponse StaticNAT::SetRuntimeConfig(const bess::pb::EmptyArg &) {
+  return CommandSuccess();
+}
+
+// Updates L3 (and L4, if necessary) checksum
+static inline void UpdateChecksum(bess::utils::Ipv4 *ip, uint32_t incr) {
+  using IpProto = bess::utils::Ipv4::Proto;
+
+  size_t ip_bytes = (ip->header_length) << 2;
+  void *l4 = reinterpret_cast<uint8_t *>(ip) + ip_bytes;
+  IpProto proto = static_cast<IpProto>(ip->protocol);
+
+  ip->checksum = bess::utils::UpdateChecksumWithIncrement(ip->checksum, incr);
+
+  if (proto == IpProto::kTcp) {
+    auto *tcp = static_cast<bess::utils::Tcp *>(l4);
+    tcp->checksum =
+        bess::utils::UpdateChecksumWithIncrement(tcp->checksum, incr);
+  } else if (proto == IpProto::kUdp) {
+    // NOTE: UDP checksum is tricky in two ways:
+    // 1. if the old checksum field was 0 (not set), no need to update
+    // 2. if the updated value is 0, use 0xffff (rfc768)
+    auto *udp = static_cast<bess::utils::Udp *>(l4);
+    if (udp->checksum != 0) {
+      udp->checksum =
+          bess::utils::UpdateChecksumWithIncrement(udp->checksum, incr)
+              ?: 0xffff;
+    }
+  }
+}
+
+template <StaticNAT::Direction dir>
+inline void StaticNAT::DoProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+  gate_idx_t ogate_idx = static_cast<gate_idx_t>(dir);
+  int cnt = batch->cnt();
+
+  for (int i = 0; i < cnt; i++) {
+    bess::Packet *pkt = batch->pkts()[i];
+    auto *eth = pkt->head_data<bess::utils::Ethernet *>();
+    auto *ip = reinterpret_cast<bess::utils::Ipv4 *>(eth + 1);
+
+    be32_t &addr_be = (dir == kForward) ? ip->src : ip->dst;
+    uint32_t addr = addr_be.value();
+
+    for (const auto &pair : pairs_) {
+      uint32_t start_addr = (dir == kForward) ? pair.int_addr : pair.ext_addr;
+      if (start_addr <= addr && addr < start_addr + pair.size) {
+        uint32_t diff = (dir == kForward) ? (pair.ext_addr - pair.int_addr)
+                                          : (pair.int_addr - pair.ext_addr);
+        be32_t new_addr_be = be32_t(addr + diff);
+        UpdateChecksum(ip, bess::utils::ChecksumIncrement32(
+                               addr_be.raw_value(), new_addr_be.raw_value()));
+        addr_be = new_addr_be;
+        break;
+      }
+    }
+
+    // If there is no matching address pair, forward without NAT.
+    // TODO: add an option to redirect unmatched traffic to a specified ogate
+
+    EmitPacket(ctx, pkt, ogate_idx);
+  }
+}
+
+void StaticNAT::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+  gate_idx_t incoming_gate = ctx->current_igate;
+
+  if (incoming_gate == 0) {
+    DoProcessBatch<kForward>(ctx, batch);
+  } else {
+    DoProcessBatch<kReverse>(ctx, batch);
+  }
+}
+
+ADD_MODULE(StaticNAT, "static_nat", "Static network address translator")

--- a/core/modules/static_nat.h
+++ b/core/modules/static_nat.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2018, Nefeli Networks, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_MODULES_STATIC_NAT_H_
+#define BESS_MODULES_STATIC_NAT_H_
+
+#include "../module.h"
+#include "../pb/module_msg.pb.h"
+
+#include <string>
+#include <vector>
+
+#include "../utils/endian.h"
+
+using bess::utils::be16_t;
+using bess::utils::be32_t;
+
+class StaticNAT : public Module {
+ public:
+  enum Direction {
+    kForward = 0,  // internal -> external
+    kReverse = 1,  // external -> internal
+  };
+
+  static const gate_idx_t kNumIGates = 2;
+  static const gate_idx_t kNumOGates = 2;
+
+  static const Commands cmds;
+
+  CommandResponse Init(const bess::pb::StaticNATArg &arg);
+  CommandResponse GetInitialArg(const bess::pb::EmptyArg &arg);
+  CommandResponse GetRuntimeConfig(const bess::pb::EmptyArg &arg);
+  CommandResponse SetRuntimeConfig(const bess::pb::EmptyArg &arg);
+
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
+
+ private:
+  struct NatPair {
+    uint32_t int_addr;  // start address of internal address
+    uint32_t ext_addr;  // start address of external address
+    uint32_t size;      // [start_addr, start_addr + size) will be used
+  };
+
+  template <Direction dir>
+  void DoProcessBatch(Context *ctx, bess::PacketBatch *batch);
+
+  std::vector<NatPair> pairs_;
+};
+
+#endif  // BESS_MODULES_STATIC_NAT_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -677,15 +677,18 @@ message MetadataTestArg {
 }
 
 /**
- * The NAT module implements IPv4 address/port translation, rewriting packet
- * source addresses with external addresses as specified. Currently only
- * supports TCP/UDP/ICMP. Note that address/port in packet payload
- * (e.g., FTP, SIP, RTSP, etc.) are NOT translated.
+ * The NAT module implements Dynamic IPv4 address/port translation,
+ * rewriting packet source addresses with external addresses as specified,
+ * and destination addresses for packets on the reverse direction.
+ * L3/L4 checksums are updated correspondingly.
  * To see an example of NAT in use, see:
  * [`bess/bessctl/conf/samples/nat.bess`](https://github.com/NetSys/bess/blob/master/bessctl/conf/samples/nat.bess)
  *
- * __Input Gates__: 2
- * __Output Gates__: 2
+ * Currently only supports TCP/UDP/ICMP.
+ * Note that address/port in packet payload (e.g., FTP) are NOT translated.
+ *
+ * __Input Gates__: 2 (0 for internal->external, and 1 for external->internal direction)
+ * __Output Gates__: 2 (same as the input gate)
  */
 message NATArg {
   message PortRange {
@@ -698,6 +701,39 @@ message NATArg {
     repeated PortRange port_ranges = 2;
   }
   repeated ExternalAddress ext_addrs = 1; /// list of external IP addresses
+}
+
+/**
+ * Static NAT module implements one-to-one translation of source/destination
+ * IPv4 addresses. No port number is translated.
+ * L3/L4 checksums are updated correspondingly.
+ * To see an example of NAT in use, see:
+ * [`bess/bessctl/conf/samples/nat.bess`](https://github.com/NetSys/bess/blob/master/bessctl/conf/samples/nat.bess)
+ *
+ * Forward direction (from input gate 0 to output gate 0):
+ *  - Source IP address is updated, from internal to external address.
+ * Reverse direction (from input gate 1 to output gate 1):
+ *  - Destination IP address is updated, from external to internal address.
+ * If the original address is outside any of the ranges, packets are forwarded
+ * without NAT.
+ *
+ * Note that address in packet payload (e.g., FTP) are NOT translated.
+ *
+ * __Input Gates__: 2 (0 for internal->external, and 1 for external->internal direction)
+ * __Output Gates__: 2 (same as the input gate)
+ */
+message StaticNATArg {
+  message AddressRange {
+    string start = 1; /// first IP address to use
+    string end = 2; /// last IP address to use
+  }
+
+  message AddressRangePair {
+    AddressRange int_range = 1;
+    AddressRange ext_range = 2; /// should be the same size as int_range
+  }
+
+  repeated AddressRangePair pairs = 1;
 }
 
 /**


### PR DESCRIPTION
This PR adds a new module StaticNAT, which performs 1-to-1 mapping between internal and external IPv4 address. This is useful when to expose servers in a private network.

Unlike the existing dynamic NAT module, port translation is not done as it is unnecessary.