### PR TITLE
ignore *.o.ur-safe files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ env/.vagrant
 *.symvers
 *.mod.c
 modules.order
+*.o.ur-safe
 
 # Libraries
 *.lib


### PR DESCRIPTION
Some recent Ubuntu update generates these files when linking
kernel modules.  Since they are build artifacts, ignore them.