### PR TITLE
Stop pausing workers for every gatehook command

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1420,8 +1420,6 @@ class BESSControlImpl final : public BESSControl::Service {
                                gate_idx, rh.hook_name().c_str());
     }
 
-    WorkerPauser wp;
-
     // DPDK functions may be called, so be prepared
     current_worker.SetNonWorker();
 


### PR DESCRIPTION
Thread-safe gatehook commands paused workers.  Now we just
don't pause at all; non-thread-safe gate hook commands
will produce an error like non-thread-safe module commands.

Closes #798.