### PR TITLE
port: Return const reference from conf() accessor

### DIFF
--- a/core/port.h
+++ b/core/port.h
@@ -278,7 +278,7 @@ class Port {
                      const queue_t *queues, int num);
 
   const std::string &name() const { return name_; }
-  Conf conf() const { return conf_; }
+  const Conf &conf() const { return conf_; }
 
   const PortBuilder *port_builder() const { return port_builder_; }
 


### PR DESCRIPTION
According to Google C++ Style Guide we should return a const reference here
instead of making a copy.

I fixed this because I noticed that the accessor is used very often in the
fastpath ({Port,Queue}{Inc,Out}::RunTask call that once per batch). I haven't
noticed any performance impact, I suspect the compiler is smart enough to avoid
the copy, but I think it's better to change it.