### PR TITLE
travis: Use prebuilt DPDK when building BESS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,14 @@ before_install:
 
 install:
   # note that if you are building a slightly different dpdk you will
-  # want to avoid the "ln -s /build/dpdk-17.05 deps" step below
+  # want to avoid the "ln -s /build/dpdk-17.11 deps" step below
   - sudo apt-get install -y python2.7 python3 python3-pip python3-setuptools ruby-dev
   - sudo gem install ffi fpm
   - pip2 install --user grpcio==1.10 scapy codecov
   - pip3 install --user grpcio==1.10 scapy coverage
   - "[[ ${COVERAGE:-0} == 0 ]] || sudo apt-get install -y g++-7"  # install gcov-7
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
+  - ln -s /build/dpdk-17.11 deps
   - "docker pull nefelinetworks/bess_build:latest${TAG_SUFFIX} | cat"  # cat suppresses progress bars
 
 before_script:


### PR DESCRIPTION
Now DPDK is built with -march=corei7 (Nehalem), not -march=native. Since the minimum CPU requirement for BESS is also Nehalem, we can safely assume that the compiled DPDK can be used on any (including Travis VMs) machines if only they can run BESS.