### PR TITLE
Introduce PacketPool & BESS-managed hugepages

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -53,7 +53,7 @@
 #include "module.h"
 #include "module_graph.h"
 #include "opts.h"
-#include "packet.h"
+#include "packet_pool.h"
 #include "port.h"
 #include "resume_hook.h"
 #include "scheduler.h"
@@ -1402,7 +1402,7 @@ class BESSControlImpl final : public BESSControl::Service {
         (socket_filter == -1) ? (RTE_MAX_NUMA_NODES - 1) : socket_filter;
     int socket = (request->socket() == -1) ? 0 : socket_filter;
     for (; socket <= socket_filter; socket++) {
-      struct rte_mempool* mempool = bess::get_pframe_pool_socket(socket);
+      rte_mempool* mempool = bess::PacketPool::GetDefaultPool(socket)->pool();
       MempoolDump* dump = response->add_dumps();
       dump->set_socket(socket);
       dump->set_initialized(mempool != nullptr);

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1402,7 +1402,12 @@ class BESSControlImpl final : public BESSControl::Service {
         (socket_filter == -1) ? (RTE_MAX_NUMA_NODES - 1) : socket_filter;
     int socket = (request->socket() == -1) ? 0 : socket_filter;
     for (; socket <= socket_filter; socket++) {
-      rte_mempool* mempool = bess::PacketPool::GetDefaultPool(socket)->pool();
+      bess::PacketPool* pool = bess::PacketPool::GetDefaultPool(socket);
+      if (!pool) {
+        continue;
+      }
+
+      rte_mempool* mempool = pool->pool();
       MempoolDump* dump = response->add_dumps();
       dump->set_socket(socket);
       dump->set_initialized(mempool != nullptr);

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -45,10 +45,13 @@
 #include <cstring>
 #include <string>
 
-#include "utils/time.h"
+#include "memory.h"
 #include "worker.h"
 
-static int get_numa_count() {
+namespace bess {
+namespace {
+
+int get_numa_count() {
   FILE *fp;
 
   int matched;
@@ -74,23 +77,23 @@ fail:
   return 1;
 }
 
-static void disable_syslog() {
+void disable_syslog() {
   setlogmask(0x01);
 }
 
-static void enable_syslog() {
+void enable_syslog() {
   setlogmask(0xff);
 }
 
-/* for log messages during rte_eal_init() */
-static ssize_t dpdk_log_init_writer(void *, const char *data, size_t len) {
+// for log messages during rte_eal_init()
+ssize_t dpdk_log_init_writer(void *, const char *data, size_t len) {
   enable_syslog();
   LOG(INFO) << std::string(data, len);
   disable_syslog();
   return len;
 }
 
-static ssize_t dpdk_log_writer(void *, const char *data, size_t len) {
+ssize_t dpdk_log_writer(void *, const char *data, size_t len) {
   LOG(INFO) << std::string(data, len);
   return len;
 }
@@ -121,25 +124,26 @@ class CmdLineOpts {
   std::vector<char *> argv_;
 };
 
-static void init_eal(const char *prog_name, int mb_per_socket,
-                     int multi_instance, bool no_huge, int default_core) {
+void init_eal(int dpdk_mb_per_socket, int default_core) {
   int numa_count = get_numa_count();
 
   CmdLineOpts rte_args{
-      prog_name, "--master-lcore", std::to_string(RTE_MAX_LCORE - 1), "--lcore",
+      "bessd",
+      "--master-lcore",
+      std::to_string(RTE_MAX_LCORE - 1),
+      "--lcore",
       std::to_string(RTE_MAX_LCORE - 1) + "@" + std::to_string(default_core),
       // Do not bother with /var/run/.rte_config and .rte_hugepage_info,
       // since we don't want to interfere with other DPDK applications.
       "--no-shconf",
   };
 
-  if (no_huge) {
+  if (dpdk_mb_per_socket <= 0) {
     rte_args.Append({"--no-huge"});
-    rte_args.Append({"-m", std::to_string(mb_per_socket * numa_count)});
   } else {
-    std::string opt_socket_mem = std::to_string(mb_per_socket);
+    std::string opt_socket_mem = std::to_string(dpdk_mb_per_socket);
     for (int i = 1; i < numa_count; i++) {
-      opt_socket_mem += "," + std::to_string(mb_per_socket);
+      opt_socket_mem += "," + std::to_string(dpdk_mb_per_socket);
     }
 
     rte_args.Append({"--socket-mem", opt_socket_mem});
@@ -149,15 +153,11 @@ static void init_eal(const char *prog_name, int mb_per_socket,
     rte_args.Append({"--huge-unlink"});
   }
 
-  if (!no_huge && multi_instance) {
-    rte_args.Append({"--file-prefix", "rte" + std::to_string(getpid())});
-  }
-
-  /* reset getopt() */
+  // reset getopt()
   optind = 0;
 
-  /* DPDK creates duplicated outputs (stdout and syslog).
-   * We temporarily disable syslog, then set our log handler */
+  // DPDK creates duplicated outputs (stdout and syslog).
+  // We temporarily disable syslog, then set our log handler
   cookie_io_functions_t dpdk_log_init_funcs;
   cookie_io_functions_t dpdk_log_funcs;
 
@@ -173,8 +173,9 @@ static void init_eal(const char *prog_name, int mb_per_socket,
   disable_syslog();
   int ret = rte_eal_init(rte_args.Argc(), rte_args.Argv());
   if (ret < 0) {
-    LOG(ERROR) << "rte_eal_init() failed: ret = " << ret;
-    exit(EXIT_FAILURE);
+    LOG(FATAL) << "rte_eal_init() failed: ret = " << ret
+               << " rte_errno = " << rte_errno << " ("
+               << rte_strerror(rte_errno) << ")";
   }
 
   enable_syslog();
@@ -187,7 +188,7 @@ static void init_eal(const char *prog_name, int mb_per_socket,
 // Returns the last core ID of all cores, as the default core all threads will
 // run on. If the process was run with a limited set of cores (by `taskset`),
 // the last one among them will be picked.
-static int determine_default_core() {
+int determine_default_core() {
   cpu_set_t set;
 
   int ret = pthread_getaffinity_np(pthread_self(), sizeof(set), &set);
@@ -208,16 +209,22 @@ static int determine_default_core() {
   return 0;
 }
 
-void init_dpdk(const ::std::string &prog_name, int mb_per_socket,
-               int multi_instance, bool no_huge) {
-  // Isolate all background threads in a separate core.
-  // All non-worker threads will be scheduled on default_core,
-  // including threads spawned by DPDK and gRPC.
-  // FIXME: This is a temporary fix. If a new worker thread is allocated on the
-  //        same core, background threads should migrate to another core.
-  int default_core = determine_default_core();
+bool is_initialized = false;
+
+}  // namespace
+
+bool IsDpdkInitialized() {
+  return is_initialized;
+}
+
+void InitDpdk(int dpdk_mb_per_socket) {
   current_worker.SetNonWorker();
 
-  init_eal(prog_name.c_str(), mb_per_socket, multi_instance, no_huge,
-           default_core);
+  if (!is_initialized) {
+    is_initialized = true;
+    LOG(INFO) << "Initializing DPDK";
+    init_eal(dpdk_mb_per_socket, determine_default_core());
+  }
 }
+
+}  // namespace bess

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -112,6 +112,11 @@ void init_eal(int dpdk_mb_per_socket, int default_core) {
 
   if (dpdk_mb_per_socket <= 0) {
     rte_args.Append({"--no-huge"});
+
+    // even if we opt out of using hugepages, many DPDK libraries still rely on
+    // rte_malloc (e.g., rte_lpm), so we need to reserve some (normal page)
+    // memory in advance. We allocate 512MB (this is shared among nodes).
+    rte_args.Append({"-m", "512"});
   } else {
     std::string opt_socket_mem = std::to_string(dpdk_mb_per_socket);
     for (int i = 1; i < NumNumaNodes(); i++) {

--- a/core/dpdk.h
+++ b/core/dpdk.h
@@ -31,29 +31,14 @@
 #ifndef BESS_DPDK_H_
 #define BESS_DPDK_H_
 
-/* rte_version.h depends on this but has no #include :( */
-#include <cstdio>
-#include <string>
+namespace bess {
 
-#include <rte_version.h>
+bool IsDpdkInitialized();
 
-#define DPDK_VER_NUM(a, b, c) (((a << 16) | (b << 8) | (c)))
+// Initialize DPDK, with the specified amount of hugepage memory.
+// Safe to call multiple times.
+void InitDpdk(int dpdk_mb_per_socket = 0);
 
-/* for DPDK 16.04 or newer */
-#ifdef RTE_VER_YEAR
-#define DPDK_VER DPDK_VER_NUM(RTE_VER_YEAR, RTE_VER_MONTH, RTE_VER_MINOR)
-#endif
-
-/* for DPDK 2.2 or older */
-#ifdef RTE_VER_MAJOR
-#define DPDK_VER DPDK_VER_NUM(RTE_VER_MAJOR, RTE_VER_MINOR, RTE_VER_PATCH_LEVEL)
-#endif
-
-#ifndef DPDK_VER
-#error DPDK version is not available
-#endif
-
-void init_dpdk(const ::std::string &prog_name, int mb_per_socket,
-               int multi_instance, bool no_huge);
+}  // namespace bess
 
 #endif  // BESS_DPDK_H_

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -286,9 +286,9 @@ CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
       sid = 0;
     }
 
-    ret =
-        rte_eth_rx_queue_setup(ret_port_id, i, queue_size[PACKET_DIR_INC], sid,
-                               &eth_rxconf, bess::get_pframe_pool_socket(sid));
+    ret = rte_eth_rx_queue_setup(ret_port_id, i, queue_size[PACKET_DIR_INC],
+                                 sid, &eth_rxconf,
+                                 bess::PacketPool::GetDefaultPool(sid)->pool());
     if (ret != 0) {
       return CommandFailure(-ret, "rte_eth_rx_queue_setup() failed");
     }

--- a/core/drivers/unix_socket.cc
+++ b/core/drivers/unix_socket.cc
@@ -190,7 +190,7 @@ int UnixSocketPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
 
   int received = 0;
   while (received < cnt) {
-    bess::Packet *pkt = static_cast<bess::Packet *>(bess::Packet::Alloc());
+    bess::Packet *pkt = current_worker.packet_pool()->Alloc();
 
     if (!pkt) {
       break;

--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -87,14 +87,15 @@ static void refill_tx_bufs(struct llring *r) {
 
   deficit = REFILL_HIGH - curr_cnt;
 
-  ret = bess::Packet::Alloc((bess::Packet **)pkts, deficit, 0);
-  if (ret == 0)
+  if (!current_worker.packet_pool()->AllocBulk(pkts, deficit, 0)) {
     return;
+  }
 
-  for (int i = 0; i < ret; i++)
+  for (int i = 0; i < deficit; i++) {
     objs[i] = pkts[i]->paddr();
+  }
 
-  ret = llring_mp_enqueue_bulk(r, objs, ret);
+  ret = llring_mp_enqueue_bulk(r, objs, deficit);
   DCHECK_EQ(ret, 0);
 }
 

--- a/core/gate_hooks/track.cc
+++ b/core/gate_hooks/track.cc
@@ -57,7 +57,7 @@ CommandResponse Track::CommandReset(const bess::pb::EmptyArg &) {
 }
 
 void Track::ProcessBatch(const bess::PacketBatch *batch) {
-
+  LOG(ERROR) << current_worker.wid();
   TrackStats *stat = &worker_stats_[current_worker.wid()];
 
   size_t cnt = batch->cnt();

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -108,15 +108,6 @@ TEST_F(GateTest, RemoveHook) {
   ASSERT_EQ(nullptr, g->FindHook(Track::kName));
 }
 
-TEST(HookTest, Track) {
-  Track t;
-  bess::PacketBatch b;
-  b.set_cnt(32);
-  t.ProcessBatch(&b);
-  ASSERT_EQ(1, t.cnt());
-  ASSERT_EQ(b.cnt(), t.pkts());
-}
-
 TEST_F(IOGateTest, OGate) {
   og->SetIgate(ig);
   ASSERT_EQ(ig, og->igate());

--- a/core/main.cc
+++ b/core/main.cc
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
                   << FLAGS_modules;
   }
 
-  bess::PacketPool::CreateDefaultPools();
+  bess::PacketPool::CreateDefaultPools(FLAGS_buffers);
 
   PortBuilder::InitDrivers();
 

--- a/core/main.cc
+++ b/core/main.cc
@@ -35,9 +35,8 @@
 #include "bessctl.h"
 #include "bessd.h"
 #include "debug.h"
-#include "dpdk.h"
 #include "opts.h"
-#include "packet.h"
+#include "packet_pool.h"
 #include "port.h"
 #include "utils/format.h"
 #include "version.h"
@@ -77,10 +76,7 @@ int main(int argc, char *argv[]) {
                   << FLAGS_modules;
   }
 
-  // TODO(barath): Make these DPDK calls generic, so as to not be so tied to
-  // DPDK.
-  init_dpdk(argv[0], FLAGS_m, FLAGS_a, FLAGS_no_huge);
-  bess::init_mempool();
+  bess::PacketPool::CreateDefaultPools();
 
   PortBuilder::InitDrivers();
 
@@ -106,7 +102,6 @@ int main(int argc, char *argv[]) {
   }
 
   rte_eal_mp_wait_lcore();
-  bess::close_mempool();
 
   LOG(INFO) << "BESS daemon has been gracefully shut down";
 

--- a/core/memory.cc
+++ b/core/memory.cc
@@ -202,8 +202,9 @@ void *AllocHugepage(HugepageSize page_size) {
     return ret;
   }
 
+  // Reserve more hugepages and try again
   std::string dir = "/sys/kernel/mm/hugepages/hugepages-2048kB";
-  size_t pages_to_add = 512;
+  size_t pages_to_add = 128;  // add 256MB at once, to minimize fragmentation
 
   if (page_size == HugepageSize::k1GB) {
     dir = "/sys/kernel/mm/hugepages/hugepages-1048576kB";

--- a/core/memory.cc
+++ b/core/memory.cc
@@ -100,8 +100,6 @@ static void *DoAllocHugepage(HugepageSize page_size) {
     return nullptr;
   }
 
-  LOG(INFO) << ptr_remapped;
-
   return ptr_remapped;
 }
 

--- a/core/memory.cc
+++ b/core/memory.cc
@@ -1,0 +1,421 @@
+#include "memory.h"
+
+#include <fcntl.h>
+#include <linux/mempolicy.h>
+#include <sys/mman.h>
+#include <sys/shm.h>
+#include <syscall.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <set>
+
+#include "utils/common.h"
+#include "utils/format.h"
+
+namespace bess {
+namespace {
+
+// set_mempolicy() without libnuma dependency
+static long linux_set_mempolicy(int mode, const unsigned long *nmask,
+                                unsigned long maxnode) {
+  return syscall(__NR_set_mempolicy, mode, nmask, maxnode);
+}
+
+#ifndef SHM_HUGE_SHIFT
+#define SHM_HUGE_SHIFT 26
+#endif
+
+#ifndef SHM_HUGE_2MB
+#define SHM_HUGE_2MB (21 << SHM_HUGE_SHIFT)
+#endif
+
+#ifndef SHM_HUGE_1GB
+#define SHM_HUGE_1GB (30 << SHM_HUGE_SHIFT)
+#endif
+
+static void *DoAllocHugepage(HugepageSize page_size) {
+  int shm_flags = SHM_HUGETLB | SHM_NORESERVE | IPC_CREAT | 0600;  // read/write
+  size_t size = static_cast<size_t>(page_size);
+
+  switch (page_size) {
+    case HugepageSize::k2MB:
+      shm_flags |= SHM_HUGE_2MB;
+      break;
+    case HugepageSize::k1GB:
+      shm_flags |= SHM_HUGE_1GB;
+      break;
+    default:
+      CHECK(0);
+  }
+
+  int shm_id = shmget(IPC_PRIVATE, size, shm_flags);
+  if (shm_id == -1) {
+    // If the hugepage size is not supported by system errno will be EINVAL.
+    // This is normal, so continue (e.g., trying 4MB hugepages on x86_64)
+    if (errno != EINVAL) {
+      PLOG(ERROR) << "shmget() for " << size << " bytes failed";
+    }
+    return nullptr;
+  }
+
+  void *ptr = shmat(shm_id, nullptr, 0);
+  shmctl(shm_id, IPC_RMID, 0);  // won't be freed until everyone detaches
+
+  if (ptr == MAP_FAILED) {
+    if (errno != ENOMEM) {
+      PLOG(ERROR) << "shmat() for " << size << "bytes failed";
+    }
+    return nullptr;
+  }
+
+  if (mlock(ptr, size) != 0) {
+    PLOG(ERROR) << "mlock(ptr) - check 'ulimit -l'";
+    shmdt(ptr);
+    return nullptr;
+  }
+
+  uintptr_t paddr = Virt2PhyGeneric(ptr);
+  if (paddr == 0) {
+    LOG(ERROR) << "Virt2PhyGeneric() failed";
+    shmdt(ptr);
+    return nullptr;
+  }
+
+  void *ptr_remapped = shmat(shm_id, Phy2Virt(paddr), 0);
+  if (ptr_remapped == MAP_FAILED) {
+    PLOG(ERROR) << "shmat() for remapping";
+    shmdt(ptr);
+    return nullptr;
+  }
+
+  // Remove the temporary mapping
+  int ret = shmdt(ptr);
+  PLOG_IF(ERROR, ret != 0) << "shmdt(ptr)";
+
+  if (mlock(ptr_remapped, size) != 0) {
+    PLOG(ERROR) << "mlock(ptr_remapped) - check 'ulimit -l'";
+    shmdt(ptr_remapped);
+    return nullptr;
+  }
+
+  LOG(INFO) << ptr_remapped;
+
+  return ptr_remapped;
+}
+
+}  // namespace
+
+int NumNumaNodes() {
+  static int cached = 0;
+  if (cached > 0) {
+    return cached;
+  }
+
+  std::ifstream fp("/sys/devices/system/node/possible");
+  if (fp.is_open()) {
+    std::string line;
+    if (std::getline(fp, line)) {
+      int cnt;
+      if (utils::Parse(line, "0-%d", &cnt) == 1) {
+        cached = cnt + 1;
+        return cached;
+      }
+    }
+  }
+
+  LOG(INFO) << "/sys/devices/system/node/possible not available. "
+            << "Assuming a single-node system...";
+  cached = 1;
+  return cached;
+}
+
+HugepageSize GetDefaultHugepageSize() {
+  static HugepageSize cached = static_cast<HugepageSize>(0);
+  if (static_cast<size_t>(cached) > 0) {
+    return cached;
+  }
+
+  std::ifstream fp("/proc/meminfo");
+  if (fp.is_open()) {
+    std::string line;
+    while (std::getline(fp, line)) {
+      size_t size_kb;
+      if (utils::Parse(line, "Hugepagesize: %zu kB", &size_kb) == 1) {
+        cached = static_cast<HugepageSize>(size_kb * 1024);
+        CHECK(cached == HugepageSize::k2MB || cached == HugepageSize::k1GB)
+            << "Unknown hugepage size " << static_cast<size_t>(cached);
+        return cached;
+      }
+    }
+  }
+
+  LOG(FATAL) << "Could not detect the default hugepage size from /proc/meminfo";
+}
+
+uintptr_t Virt2PhyGeneric(void *ptr) {
+  const uintptr_t kPageSize = sysconf(_SC_PAGESIZE);
+
+  uintptr_t vaddr = reinterpret_cast<uintptr_t>(ptr);
+  uintptr_t offset = vaddr % kPageSize;
+
+  int fd = open("/proc/self/pagemap", O_RDONLY);
+  if (fd < 0) {
+    PLOG(ERROR) << "open(/proc/self/pagemap)";
+    return 0;
+  }
+
+  uint64_t page_info;
+  int ret = pread(fd, &page_info, sizeof(page_info),
+                  (vaddr / kPageSize) * sizeof(page_info));
+  if (ret != sizeof(page_info)) {
+    PLOG(ERROR) << "pread(/proc/self/pagemap)";
+  }
+
+  close(fd);
+
+  // See Linux Documentation/vm/pagemap.txt
+  // page frame number (physical address / kPageSize) is on lower 55 bits
+  uintptr_t pfn = page_info & ((1ull << 55) - 1);
+  bool present = page_info & (1ull << 63);
+
+  if (!present) {
+    LOG(ERROR) << "Virt2PhyGeneric(): virtual address " << ptr
+               << " is not mapped";
+    return 0;
+  }
+
+  if (pfn == 0) {
+    LOG_FIRST_N(ERROR, 1)
+        << "Virt2PhyGeneric(): PFN for vaddr " << ptr
+        << " is not available. CAP_SYS_ADMIN capability is required. "
+        << "page_info = " << std::hex << page_info << std::dec;
+    return 0;
+  }
+
+  uintptr_t paddr = pfn * kPageSize + offset;
+
+  return paddr;
+}
+
+void *AllocHugepage(HugepageSize page_size) {
+  if (void *ret = DoAllocHugepage(page_size)) {
+    return ret;
+  }
+
+  std::string dir = "/sys/kernel/mm/hugepages/hugepages-2048kB";
+  size_t pages_to_add = 512;
+
+  if (page_size == HugepageSize::k1GB) {
+    dir = "/sys/kernel/mm/hugepages/hugepages-1048576kB";
+    pages_to_add = 1;
+  }
+
+  std::fstream fp(dir + "/nr_hugepages_mempolicy");
+  if (fp) {
+    size_t count;
+    fp >> count;
+    fp << count + pages_to_add;
+    fp.close();
+  } else {
+    LOG(WARNING) << "cannot open " << dir << "/nr_hugepages_mempolicy";
+    return nullptr;
+  }
+
+  return DoAllocHugepage(page_size);  // retry
+}
+
+void *AllocHugepageFromSocket(HugepageSize type, int socket_id) {
+  // From any socket?
+  if (socket_id == -1) {
+    return AllocHugepage(type);
+  }
+
+  CHECK_GE(socket_id, 0);
+  CHECK_LT(socket_id, NumNumaNodes());
+
+  unsigned long mask = 1ul << socket_id;
+  unsigned long maxnode = NumNumaNodes() + 1;  // number of bits in mask
+  int ret;
+
+  // Update mempolicy to allocate hugepage only from the specified node.
+  ret = linux_set_mempolicy(MPOL_BIND | MPOL_F_STATIC_NODES, &mask, maxnode);
+  if (ret < 0) {
+    PLOG(ERROR) << "set_mempolicy(bind, " << socket_id << ")";
+    return nullptr;
+  }
+
+  void *addr = AllocHugepage(type);
+
+  // Go back to default NUMA policy
+  ret = linux_set_mempolicy(MPOL_DEFAULT, nullptr, 0);
+  PLOG_IF(WARNING, ret < 0) << "set_mempolicy(default)";
+
+  return addr;
+}
+
+void FreeHugepage(void *ptr) {
+  // allow null pointers
+  if (!ptr) {
+    return;
+  }
+
+  int ret = shmdt(ptr);
+  PLOG_IF(ERROR, ret != 0) << "shmdt(ptr_remapped)";
+}
+
+DmaMemoryPool::DmaMemoryPool(size_t size, int socket_id)
+    : initialized_(false), socket_id_(socket_id), total_free_bytes_(0) {
+  CHECK_GT(size, 0);
+  CHECK_GE(socket_id, -1);
+
+  // Try 1GB hugepages first, then 2MB ones.
+  HugepageSize page_size = HugepageSize::k1GB;
+
+  while (total_free_bytes_ < size) {
+    size_t page_bytes = static_cast<size_t>(page_size);
+    void *ptr = AllocHugepageFromSocket(page_size, socket_id);
+
+    if (ptr != nullptr) {
+      total_free_bytes_ += page_bytes;
+      AddRegion(reinterpret_cast<uintptr_t>(ptr), page_bytes);
+      pages_.push_back(ptr);
+    } else {
+      if (page_size == HugepageSize::k1GB) {
+        page_size = HugepageSize::k2MB;
+      } else {
+        break;
+      }
+    }
+  }
+
+  if (total_free_bytes_ >= size) {
+    initialized_ = true;
+    return;
+  }
+
+  // Failed. Give up and clean up.
+  for (auto *ptr : pages_) {
+    FreeHugepage(ptr);
+  }
+  pages_.clear();
+}
+
+DmaMemoryPool::~DmaMemoryPool() {
+  for (auto *ptr : pages_) {
+    FreeHugepage(ptr);
+  }
+
+  if (!alloced_.empty()) {
+    LOG(WARNING) << "DmaMemoryPool " << this << " still has " << alloced_.size()
+                 << " unfreed blocks!";
+  }
+}
+
+void *DmaMemoryPool::Alloc(size_t size) {
+  CHECK_GT(size, 0);
+  size = align_ceil(size, 4096);
+  void *ret = nullptr;
+
+  for (const auto &region : regions_) {
+    // first fit
+    if (region.size >= size) {
+      ret = reinterpret_cast<void *>(region.addr);
+      alloced_.emplace(ret, size);
+      regions_.erase(region);
+
+      if (size < region.size) {
+        // there is leftover
+        regions_.insert(
+            {.addr = region.addr + size, .size = region.size - size});
+      }
+
+      total_free_bytes_ -= size;
+      break;
+    }
+  }
+
+  return ret;
+}
+
+void DmaMemoryPool::Free(void *ptr) {
+  // allow null pointers
+  if (!ptr) {
+    return;
+  }
+
+  const auto &it = alloced_.find(ptr);
+  CHECK(it != alloced_.end()) << "Unknown pointer " << ptr;
+  const size_t size = (*it).second;
+  AddRegion(reinterpret_cast<uintptr_t>(ptr), size);
+  alloced_.erase(it);
+  total_free_bytes_ += size;
+}
+
+std::string DmaMemoryPool::Dump() {
+  std::ostringstream out;
+  int i = 0;
+
+  out << "DmaMemoryPool at " << this << ": (" << alloced_.size()
+      << " alive objects)" << std::endl;
+
+  for (const auto &region : regions_) {
+    void *ptr = reinterpret_cast<void *>(region.addr);
+    out << utils::Format("  free segment %02d  vaddr 0x%016" PRIxPTR
+                         "  paddr 0x%016" PRIxPTR "  size 0x%08zx (%zu)",
+                         i++, region.addr, Virt2Phy(ptr), region.size,
+                         region.size)
+        << std::endl;
+  }
+
+  return out.str();
+}
+
+// Add a new region, and splice it with adjacent regions if necessary
+void DmaMemoryPool::AddRegion(uintptr_t addr, size_t size) {
+  ContiguousRegion new_region = {.addr = addr, .size = size};
+
+  auto prev_it = regions_.lower_bound(new_region);
+  auto next_it = prev_it;
+
+  if (prev_it != regions_.begin()) {
+    prev_it--;
+  }
+
+  if (prev_it != next_it && prev_it != regions_.end()) {
+    ContiguousRegion prev = *prev_it;
+    if (prev.addr + prev.size > new_region.addr) {
+      std::cout << prev.addr << ' ' << prev.size << std::endl;
+      std::cout << addr << ' ' << size << std::endl;
+      if (next_it != regions_.end()) {
+        ContiguousRegion next = *next_it;
+        std::cout << next.addr << ' ' << next.size << std::endl;
+      }
+    }
+
+    CHECK_LE(prev.addr + prev.size, new_region.addr);
+
+    if (prev.addr + prev.size == new_region.addr) {
+      // Merge with the previous region
+      new_region.addr = prev.addr;
+      new_region.size += prev.size;
+      regions_.erase(prev_it);
+    }
+  }
+
+  if (next_it != regions_.end()) {
+    ContiguousRegion next = *next_it;
+    CHECK_LE(new_region.addr + new_region.size, next.addr);
+
+    if (new_region.addr + new_region.size == next.addr) {
+      // Merge with the next region
+      new_region.size += next.size;
+      regions_.erase(next_it);
+    }
+  }
+
+  regions_.insert(new_region);
+}
+
+}  // namespace bess

--- a/core/memory.h
+++ b/core/memory.h
@@ -79,6 +79,11 @@ class DmaMemoryPool {
   // Returns a contiguous memory block from the pool, or nullptr if failed.
   // All returned addresses are 4K-aligned.
   void *Alloc(size_t size);
+
+  // Same as Alloc(), but it may allocate memory block smaller than specified
+  // if no such free space is available. 0 <= returned_size <= size.
+  std::pair<void *, size_t> AllocUpto(size_t size);
+
   void Free(void *ptr);
 
   size_t TotalFreeBytes() const { return total_free_bytes_; }

--- a/core/memory.h
+++ b/core/memory.h
@@ -1,0 +1,112 @@
+#ifndef BESS_MEMORY_H_
+#define BESS_MEMORY_H_
+
+#include <glog/logging.h>
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+
+namespace bess {
+
+// For the physical/IO address space   0x 00000000000 - 0x fff00000000 (16TB),
+// we use the virtual address range    0x600000000000 - 0x6fffffffffff
+const uintptr_t kVirtualAddressStart = 0x6000'0000'0000ull;
+const uintptr_t kVirtualAddressEnd = 0x7000'0000'0000ull;  // not inclusive
+
+// it violates the naming scheme, but k2Mb would sound like bits, not bytes..
+enum class HugepageSize : size_t {
+  k2MB = 1 << 21,
+  k1GB = 1 << 30,
+};
+
+// Assumes a single node system if undetectable
+int NumNumaNodes();
+
+HugepageSize GetDefaultHugepageSize();
+
+// Translate a virtual address of this process into a physical one.
+// Unlike Virt2Phy(), the underlying page doesn't need to be a hugepage.
+// (but still the pointer should be a valid one)
+// Returns 0 if failed: invalid virtual address, no CAP_SYS_ADMIN, etc.
+// This function is very slow -- never meant to be used in the datapath.
+uintptr_t Virt2PhyGeneric(void *ptr);
+
+// Same as Virt2PhyGeneric(), but much faster. Only valid for memory blocks
+// allocated by AllocHugepage() or DmaMemoryPool::Alloc()
+static inline uintptr_t Virt2Phy(void *ptr) {
+  uintptr_t vaddr = reinterpret_cast<uintptr_t>(ptr);
+  DCHECK(kVirtualAddressStart <= vaddr);
+  DCHECK(vaddr < kVirtualAddressEnd);
+  return vaddr ^ kVirtualAddressStart;
+}
+
+// Only valid for memory blocks allocated by AllocHugepage() or
+// DmaMemoryPool::Alloc()
+static inline void *Phy2Virt(uintptr_t paddr) {
+  DCHECK(paddr < (kVirtualAddressEnd - kVirtualAddressStart));
+  return reinterpret_cast<void *>(paddr + kVirtualAddressStart);
+}
+
+// Allocate/deallocate a hugepage backed by physical memory.
+// Suitable for DMA. The page is zero-initialized by the kernel
+// These functions are quite low level and you probably won't need them;
+// use DmaMemoryPool::Alloc()/Free() below instead.
+void *AllocHugepage(HugepageSize type);
+void FreeHugepage(void *ptr);
+
+// Same as AllocHugepage, but from a specified NUMA node
+void *AllocHugepageFromSocket(HugepageSize type, int socket_id);
+
+// Manages a set of hugepages for allocation of memory blocks.
+// You can allocate/deallocate a memory region that is contiguous in both
+// physical/virtual address spaces.
+// This is not meant to be a fast memory allocator. It's only suitable for
+// infrequently allocated/freed, large objects (e.g., packet pools).
+class DmaMemoryPool {
+ public:
+  // Memory from any NUMA node can be allocated if socket_id == -1.
+  DmaMemoryPool(size_t size, int socket_id = -1);
+  virtual ~DmaMemoryPool();
+
+  // Return true if fully initialized. false if constructor failed
+  bool Initialized() const { return initialized_; }
+
+  // Returns a contiguous memory block from the pool, or nullptr if failed.
+  // All returned addresses are 4K-aligned.
+  void *Alloc(size_t size);
+  void Free(void *ptr);
+
+  size_t TotalFreeBytes() const { return total_free_bytes_; }
+
+  // Return human-readable debug messages
+  std::string Dump();
+
+ private:
+  struct ContiguousRegion {
+    uintptr_t addr;
+    size_t size;
+
+    bool operator<(const ContiguousRegion &o) const { return addr < o.addr; }
+  };
+
+  void AddRegion(uintptr_t addr, size_t size);
+
+  // current list of contiguous memory regions
+  std::set<ContiguousRegion> regions_;
+
+  // all hugepages backing this pool
+  std::vector<void *> pages_;
+
+  // keeps track of allocated memory blocks and their size
+  std::map<void *, size_t> alloced_;
+
+  bool initialized_;
+  int socket_id_;
+  size_t total_free_bytes_;
+};
+
+}  // namespace bess
+
+#endif  // BESS_MEMORY_H_

--- a/core/memory.h
+++ b/core/memory.h
@@ -73,6 +73,9 @@ class DmaMemoryPool {
   // Return true if fully initialized. false if constructor failed
   bool Initialized() const { return initialized_; }
 
+  // The socket ID this mempool is associated with. -1 means unknown.
+  int SocketId() const { return socket_id_; }
+
   // Returns a contiguous memory block from the pool, or nullptr if failed.
   // All returned addresses are 4K-aligned.
   void *Alloc(size_t size);

--- a/core/memory_test.cc
+++ b/core/memory_test.cc
@@ -1,0 +1,258 @@
+#include "memory.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+
+#include "utils/random.h"
+#include "utils/time.h"
+
+namespace bess {
+
+TEST(PhyMemTest, Phy2Virt) {
+  if (geteuid() == 0) {
+    int x = 0;  // &x is a valid address
+    EXPECT_NE(Virt2PhyGeneric(&x), 0);
+  }
+}
+
+TEST(HugepageTest, NullFree) {
+  FreeHugepage(nullptr);
+}
+
+TEST(HugepageTest, BadSize) {
+  // Try 8MB hugepages, which does not exist on neither x86_64 nor i686
+  ASSERT_DEATH(AllocHugepage(static_cast<HugepageSize>(1 << 23)), "");
+}
+
+class HugepageTest : public ::testing::TestWithParam<HugepageSize> {
+ public:
+  virtual void SetUp() override {
+    HugepageSize type = GetParam();
+    size_ = static_cast<size_t>(type);
+    ptr_ = AllocHugepage(type);
+
+    if (ptr_ == nullptr) {
+      std::cerr << "Hugepage (" << size_ << " bytes) not available."
+                << " Skipping test..." << std::endl;
+    } else {
+      ASSERT_LE(kVirtualAddressStart, reinterpret_cast<uintptr_t>(ptr_));
+      ASSERT_GT(kVirtualAddressEnd, reinterpret_cast<uintptr_t>(ptr_));
+    }
+  }
+
+  virtual void TearDown() override { FreeHugepage(ptr_); }
+
+ protected:
+  static const int kTestIterations = 100000;
+
+  void *ptr_;
+  size_t size_;  // total size: page size * number of pages
+  Random rd_;
+};
+
+TEST_P(HugepageTest, BasicAlloc) {
+  if (ptr_ == nullptr) {
+    // The machine may not be configured with hugepages. Just skip if failed.
+    return;
+  }
+
+  EXPECT_EQ(ptr_, Phy2Virt(Virt2Phy(ptr_)));
+
+  if (geteuid() == 0) {
+    EXPECT_EQ(Virt2Phy(ptr_), Virt2PhyGeneric(ptr_));
+    EXPECT_EQ(ptr_, Phy2Virt(Virt2PhyGeneric(ptr_)));
+  }
+}
+
+TEST_P(HugepageTest, Access) {
+  if (ptr_ == nullptr) {
+    // The machine may not be configured with hugepages. Just skip if failed.
+    return;
+  }
+
+  uint64_t *ptr = reinterpret_cast<uint64_t *>(ptr_);
+  size_t num_elems = size_ / sizeof(*ptr);
+
+  // WRITE
+  for (size_t i = 0; i < num_elems; i++) {
+    ptr[i] = i + 123456789;
+  }
+
+  // READ
+  for (size_t i = 0; i < num_elems; i++) {
+    ASSERT_EQ(ptr[i], i + 123456789);
+  }
+}
+
+TEST_P(HugepageTest, AllZero) {
+  if (ptr_ == nullptr) {
+    // The machine may not be configured with hugepages. Just skip if failed.
+    return;
+  }
+
+  uint64_t *ptr = reinterpret_cast<uint64_t *>(ptr_);
+  size_t num_elems = size_ / sizeof(*ptr);
+
+  for (size_t i = 0; i < num_elems; i++) {
+    ASSERT_EQ(ptr[i], 0);
+  }
+}
+
+// The allocated page is physically contiguous?
+TEST_P(HugepageTest, Contiguous) {
+  if (geteuid() != 0 || ptr_ == nullptr) {
+    // The machine may not be configured with hugepages. Just skip if failed.
+    return;
+  }
+
+  char *ptr = reinterpret_cast<char *>(ptr_);
+
+  for (auto i = 0; i < kTestIterations; i++) {
+    size_t offset = rd_.GetRange(size_);
+    ASSERT_EQ(Virt2Phy(ptr) + offset, Virt2PhyGeneric(ptr + offset))
+        << "offset=" << offset;
+  }
+}
+
+TEST_P(HugepageTest, LeakFree) {
+  if (ptr_ == nullptr) {
+    // The machine may not be configured with hugepages. Just skip if failed.
+    return;
+  }
+
+  double start = get_cpu_time();
+
+  do {
+    // Already allocated, so free first
+    FreeHugepage(ptr_);
+
+    ptr_ = AllocHugepage(GetParam());
+    EXPECT_NE(ptr_, nullptr);
+  } while (get_cpu_time() - start < 0.5);  // 0.5 second for each page size
+}
+
+INSTANTIATE_TEST_CASE_P(PageSize, HugepageTest,
+                        ::testing::Values(HugepageSize::k2MB,
+                                          HugepageSize::k1GB));
+
+TEST(DmaMemoryPoolTest, PoolSetup) {
+  if (geteuid() != 0) {
+    std::cerr << "CAP_SYS_ADMIN required. Skipping test..." << std::endl;
+    return;
+  }
+
+  DmaMemoryPool *pool;
+
+  ASSERT_DEATH(pool = new DmaMemoryPool(0, -1), "");
+  ASSERT_DEATH(pool = new DmaMemoryPool(1024 * 1024, -2), "");
+
+  // Assume at least 128MB of persistent hugepages are available...
+  pool = new DmaMemoryPool(128 * 1024 * 1024, -1);
+  ASSERT_TRUE(pool->Initialized());
+
+  // Do not crash with null pointers
+  pool->Free(nullptr);
+
+  delete pool;
+
+  // Node-specific allocation
+  for (int i = 0; i < NumNumaNodes(); i++) {
+    pool = new DmaMemoryPool(128 * 1024 * 1024, i);
+    ASSERT_TRUE(pool->Initialized());
+    delete pool;
+  }
+}
+
+TEST(DmaMemoryPoolTest, Dump) {
+  if (geteuid() != 0) {
+    std::cerr << "CAP_SYS_ADMIN required. Skipping test..." << std::endl;
+    return;
+  }
+
+  DmaMemoryPool pool(128 * 1024 * 1024, 0);
+  ASSERT_TRUE(pool.Initialized());
+
+  std::cout << pool.Dump();
+}
+
+TEST(DmaMemoryPoolTest, AlignedAlloc) {
+  if (geteuid() != 0) {
+    std::cerr << "CAP_SYS_ADMIN required. Skipping test..." << std::endl;
+    return;
+  }
+
+  DmaMemoryPool pool(128 * 1024 * 1024, 0);
+  ASSERT_TRUE(pool.Initialized());
+
+  // should be able to alloc 128 * 1MB blocks...
+  std::array<void *, 128> ptrs;
+
+  // Try 5 full rounds, to see if cleanup was complete
+  for (int k = 0; k < 5; k++) {
+    for (size_t i = 0; i < ptrs.size(); i++) {
+      ptrs[i] = pool.Alloc(1024 * 1024);
+      ASSERT_NE(ptrs[i], static_cast<void *>(nullptr));
+    }
+
+    // then it may or may not fail (the pool may have more than 128MB)
+    if (pool.TotalFreeBytes() < 1024 * 1024) {
+      ASSERT_EQ(pool.Alloc(1024 * 1024), static_cast<void *>(nullptr));
+    }
+
+    for (size_t i = 0; i < ptrs.size(); i++) {
+      EXPECT_EQ(Virt2Phy(ptrs[i]), Virt2PhyGeneric(ptrs[i]));
+      pool.Free(ptrs[i]);
+    }
+  }
+}
+
+TEST(DmaMemoryPoolTest, UnalignedAlloc) {
+  if (geteuid() != 0) {
+    std::cerr << "CAP_SYS_ADMIN required. Skipping test..." << std::endl;
+    return;
+  }
+
+  DmaMemoryPool pool(128 * 1024 * 1024, 0);
+  size_t initial_free_bytes = pool.TotalFreeBytes();
+  ASSERT_TRUE(pool.Initialized());
+
+  std::vector<void *> ptrs;
+  Random rng;
+
+  for (int k = 0; k < 5; k++) {
+    while (true) {
+      size_t size_to_alloc = rng.GetRange(1024 * 1024);
+      void *ptr = pool.Alloc(size_to_alloc);
+
+      if (ptr == nullptr) {
+        EXPECT_GE(ptrs.size(), 128);
+        break;
+      }
+
+      ptrs.push_back(ptr);
+    }
+
+    EXPECT_LT(pool.TotalFreeBytes(), initial_free_bytes);
+    std::cout << "Total free but fragmented (< 1MB) space: "
+              << pool.TotalFreeBytes() << " bytes" << std::endl;
+
+    // Shuffle
+    for (size_t i = 0; i < ptrs.size() - 1; i++) {
+      size_t j = i + 1 + rng.GetRange(ptrs.size() - i - 1);
+      std::swap(ptrs[i], ptrs[j]);
+    }
+
+    for (void *ptr : ptrs) {
+      pool.Free(ptr);
+    }
+
+    EXPECT_EQ(pool.TotalFreeBytes(), initial_free_bytes);
+    ptrs.clear();
+  }
+}
+
+}  // namespace bess

--- a/core/module.h
+++ b/core/module.h
@@ -44,7 +44,7 @@
 #include "gate.h"
 #include "message.h"
 #include "metadata.h"
-#include "packet.h"
+#include "packet_pool.h"
 
 using bess::gate_idx_t;
 

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -429,7 +429,7 @@ bess::Packet *FlowGen::FillPacket(struct flow *f) {
 
   int size = template_size_;
 
-  if (!(pkt = bess::Packet::Alloc())) {
+  if (!(pkt = current_worker.packet_pool()->Alloc())) {
     return nullptr;
   }
 

--- a/core/modules/url_filter.cc
+++ b/core/modules/url_filter.cc
@@ -103,7 +103,7 @@ inline static bess::Packet *Generate403Packet(const Ethernet::Address &src_eth,
                                               be32_t src_ip, be32_t dst_ip,
                                               be16_t src_port, be16_t dst_port,
                                               be32_t seq, be32_t ack) {
-  bess::Packet *pkt = bess::Packet::Alloc();
+  bess::Packet *pkt = current_worker.packet_pool()->Alloc();
   char *ptr = static_cast<char *>(pkt->buffer()) + SNBUF_HEADROOM;
   pkt->set_data_off(SNBUF_HEADROOM);
 
@@ -143,7 +143,7 @@ inline static bess::Packet *GenerateResetPacket(
     const Ethernet::Address &src_eth, const Ethernet::Address &dst_eth,
     be32_t src_ip, be32_t dst_ip, be16_t src_port, be16_t dst_port, be32_t seq,
     be32_t ack) {
-  bess::Packet *pkt = bess::Packet::Alloc();
+  bess::Packet *pkt = current_worker.packet_pool()->Alloc();
   char *ptr = static_cast<char *>(pkt->buffer()) + SNBUF_HEADROOM;
   pkt->set_data_off(SNBUF_HEADROOM);
   pkt->set_total_len(sizeof(rst_template));

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -54,6 +54,7 @@ DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
               "Load modules from the specified directory");
 DEFINE_bool(core_dump, false, "Generate a core dump on fatal faults");
 DEFINE_bool(no_crashlog, false, "Disable the generation of a crash log file");
+DEFINE_bool(dpdk, false, "Let DPDK manage hugepages");
 
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {
@@ -98,9 +99,8 @@ static bool ValidateMegabytesPerSocket(const char *, int32_t value) {
   return true;
 }
 DEFINE_int32(m, 1024,
-             "Specifies per-socket size of DPDK-managed hugepages (in MBs). "
-             "If set to 0, BESS will manage hugepages automatically without "
-             "relying on DPDK.");
+             "Specifies per-socket hugepages to allocate (in MBs). "
+             "If set to 0, no hugepage is used");
 static const bool _m_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_m, &ValidateMegabytesPerSocket);
 

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -54,7 +54,10 @@ DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
               "Load modules from the specified directory");
 DEFINE_bool(core_dump, false, "Generate a core dump on fatal faults");
 DEFINE_bool(no_crashlog, false, "Disable the generation of a crash log file");
-DEFINE_bool(dpdk, false, "Let DPDK manage hugepages");
+
+// Note: currently BESS-managed hugepages do not support VFIO driver,
+//       so DPDK is default for now.
+DEFINE_bool(dpdk, true, "Let DPDK manage hugepages");
 
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -48,8 +48,6 @@ DEFINE_bool(f, false, "Run BESS in foreground mode (for developers)");
 DEFINE_bool(k, false, "Kill existing BESS instance, if any");
 DEFINE_bool(s, false, "Show TC statistics every second");
 DEFINE_bool(d, false, "Run BESS in debug mode (with debug log messages)");
-DEFINE_bool(a, false, "Allow multiple instances");
-DEFINE_bool(no_huge, false, "Disable hugepages");
 DEFINE_bool(skip_root_check, false,
             "Skip checking that the process is running as root.");
 DEFINE_string(modules, bess::bessd::GetCurrentDirectory() + "modules",
@@ -92,14 +90,17 @@ static const bool _p_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_p, &ValidateTCPPort);
 
 static bool ValidateMegabytesPerSocket(const char *, int32_t value) {
-  if (value <= 0) {
+  if (value < 0) {
     LOG(ERROR) << "Invalid memory size: " << value;
     return false;
   }
 
   return true;
 }
-DEFINE_int32(m, 1024, "Specifies how many megabytes to use per socket");
+DEFINE_int32(m, 1024,
+             "Specifies per-socket size of DPDK-managed hugepages (in MBs). "
+             "If set to 0, BESS will manage hugepages automatically without "
+             "relying on DPDK.");
 static const bool _m_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_m, &ValidateMegabytesPerSocket);
 
@@ -114,7 +115,8 @@ static bool ValidateBuffersPerSocket(const char *, int32_t value) {
   }
   return true;
 }
-DEFINE_int32(buffers, 262144, "Specifies how many packet buffers to allocate per socket,"
-	     " must be a power of 2.");
+DEFINE_int32(buffers, 262144,
+             "Specifies how many packet buffers to allocate per socket,"
+             " must be a power of 2.");
 static const bool _buffers_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_buffers, &ValidateBuffersPerSocket);

--- a/core/opts.h
+++ b/core/opts.h
@@ -44,7 +44,6 @@ DECLARE_string(b);
 DECLARE_int32(p);
 DECLARE_string(grpc_url);
 DECLARE_int32(m);
-DECLARE_bool(no_huge);
 DECLARE_bool(skip_root_check);
 DECLARE_string(modules);
 DECLARE_bool(core_dump);

--- a/core/opts.h
+++ b/core/opts.h
@@ -49,5 +49,6 @@ DECLARE_string(modules);
 DECLARE_bool(core_dump);
 DECLARE_bool(no_crashlog);
 DECLARE_int32(buffers);
+DECLARE_bool(dpdk);
 
 #endif  // BESS_OPTS_H_

--- a/core/packet_pool.cc
+++ b/core/packet_pool.cc
@@ -1,0 +1,225 @@
+#include "packet_pool.h"
+
+#include <sys/mman.h>
+
+#include <rte_errno.h>
+#include <rte_mempool.h>
+
+#include "dpdk.h"
+#include "opts.h"
+
+namespace bess {
+namespace {
+
+struct PoolPrivate {
+  rte_pktmbuf_pool_private dpdk_priv;
+  PacketPool *owner;
+};
+
+// callback function for each packet
+void InitPacket(rte_mempool *mp, void *, void *mbuf, unsigned index) {
+  rte_pktmbuf_init(mp, nullptr, mbuf, index);
+
+  auto *pkt = static_cast<Packet *>(mbuf);
+  pkt->set_vaddr(pkt);
+  pkt->set_paddr(rte_mempool_virt2iova(pkt));
+}
+
+void DoMunmap(rte_mempool_memhdr *memhdr, void *) {
+  if (munmap(memhdr->addr, memhdr->len) < 0) {
+    PLOG(WARNING) << "munmap()";
+  }
+}
+
+}  // namespace
+
+PacketPool *PacketPool::default_pools_[RTE_MAX_NUMA_NODES];
+
+void PacketPool::CreateDefaultPools(size_t capacity) {
+  InitDpdk(FLAGS_m);
+
+  rte_dump_physmem_layout(stdout);
+
+  for (int i = 0; i < RTE_MAX_LCORE; i++) {
+    int sid = rte_lcore_to_socket_id(i);
+
+    if (!default_pools_[sid]) {
+      PacketPool *pool;
+
+      pool = new DpdkPacketPool(capacity, sid);
+      default_pools_[sid] = pool;
+    }
+  }
+}
+
+PacketPool::PacketPool(size_t capacity, int socket_id) {
+  if (!IsDpdkInitialized()) {
+    InitDpdk(0);
+  }
+
+  static int next_id_;
+  name_ = "PacketPool" + std::to_string(next_id_++);
+
+  LOG(INFO) << name_ << " requests for " << capacity << " packets";
+
+  pool_ = rte_mempool_create_empty(name_.c_str(), capacity, sizeof(Packet),
+                                   capacity > 1024 ? kMaxCacheSize : 0,
+                                   sizeof(PoolPrivate), socket_id, 0);
+  if (!pool_) {
+    LOG(FATAL) << "rte_mempool_create() failed: " << rte_strerror(rte_errno)
+               << " (rte_errno=" << rte_errno << ")";
+  }
+
+  int ret = rte_mempool_set_ops_byname(pool_, "ring_mp_mc", NULL);
+  if (ret < 0) {
+    LOG(FATAL) << "rte_mempool_set_ops_byname() returned " << ret;
+  }
+}
+
+PacketPool::~PacketPool() {
+  // munmap is triggered by the registered callback DoMunmap()
+  rte_mempool_free(pool_);
+}
+
+bool PacketPool::AllocBulk(Packet **pkts, size_t count, size_t len) {
+  if (rte_mempool_get_bulk(pool_, reinterpret_cast<void **>(pkts), count) < 0) {
+    return false;
+  }
+
+  // We must make sure that the following 12 fields are initialized
+  // as done in rte_pktmbuf_reset(). We group them into two 16-byte stores.
+  //
+  // - 1st store: mbuf.rearm_data
+  //   2B data_off == RTE_PKTMBUF_HEADROOM (SNBUF_HEADROOM)
+  //   2B refcnt == 1
+  //   2B nb_segs == 1
+  //   2B port == 0xff (0xffff should make more sense)
+  //   8B ol_flags == 0
+  //
+  // - 2nd store: mbuf.rx_descriptor_fields1
+  //   4B packet_type == 0
+  //   4B pkt_len == len
+  //   2B data_len == len
+  //   2B vlan_tci == 0
+  //   4B (rss == 0)       (not initialized by rte_pktmbuf_reset)
+  //
+  // We can ignore these fields:
+  //   vlan_tci_outer == 0 (not required if ol_flags == 0)
+  //   tx_offload == 0     (not required if ol_flags == 0)
+  //   next == nullptr     (all packets in a mempool must already be nullptr)
+
+  __m128i rearm = _mm_setr_epi16(SNBUF_HEADROOM, 1, 1, 0xff, 0, 0, 0, 0);
+  __m128i rxdesc = _mm_setr_epi32(0, len, len, 0);
+
+  size_t i;
+
+  // 4 at a time didn't help
+  for (i = 0; i < (count & (~0x1)); i += 2) {
+    // since the data is likely to be in the store buffer
+    // as 64-bit writes, 128-bit read will cause stalls
+    Packet *pkt0 = pkts[i];
+    Packet *pkt1 = pkts[i + 1];
+
+    _mm_store_si128(&pkt0->rearm_data_, rearm);
+    _mm_store_si128(&pkt0->rx_descriptor_fields1_, rxdesc);
+    _mm_store_si128(&pkt1->rearm_data_, rearm);
+    _mm_store_si128(&pkt1->rx_descriptor_fields1_, rxdesc);
+  }
+
+  if (count & 0x1) {
+    Packet *pkt = pkts[i];
+
+    _mm_store_si128(&pkt->rearm_data_, rearm);
+    _mm_store_si128(&pkt->rx_descriptor_fields1_, rxdesc);
+  }
+
+  // TODO: sanity check for packets
+  return true;
+}
+
+void PacketPool::PostPopulate() {
+  PoolPrivate priv = {
+      .dpdk_priv = {.mbuf_data_room_size = SNBUF_HEADROOM + SNBUF_DATA,
+                    .mbuf_priv_size = SNBUF_RESERVE},
+      .owner = this};
+
+  rte_pktmbuf_pool_init(pool_, &priv.dpdk_priv);
+  rte_mempool_obj_iter(pool_, InitPacket, nullptr);
+
+  LOG(INFO) << name_ << " has been created with " << Capacity() << " packets";
+  if (Capacity() == 0) {
+    LOG(FATAL) << name_ << " has no packets allocated\n"
+               << "Troubleshooting:\n"
+               << "  - Check 'ulimit -l'\n"
+               << "  - Do you have enough memory on the machine?\n"
+               << "  - Maybe memory is too fragmented. Try rebooting.\n";
+  }
+}
+
+PlainPacketPool::PlainPacketPool(size_t capacity, int socket_id)
+    : PacketPool(capacity, socket_id) {
+  pool_->flags |= MEMPOOL_F_NO_PHYS_CONTIG;
+
+  size_t page_shift = __builtin_ffs(getpagesize());
+  size_t element_size =
+      pool_->header_size + pool_->elt_size + pool_->trailer_size;
+  size_t size = rte_mempool_xmem_size(pool_->size, element_size, page_shift,
+                                      pool_->flags);
+
+  void *addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  if (addr == MAP_FAILED) {
+    PLOG(FATAL) << "mmap()";
+  }
+
+  // No error check, as we do not provide a guarantee that memory is pinned.
+  int ret = mlock(addr, size);
+  pinned_ = (ret == 0);  // may fail as non-root users have mlock limit
+
+  ret = rte_mempool_populate_iova(pool_, static_cast<char *>(addr),
+                                  RTE_BAD_IOVA, size, nullptr, nullptr);
+  if (ret < static_cast<ssize_t>(pool_->size)) {
+    LOG(WARNING) << "rte_mempool_populate_iova() returned " << ret
+                 << " (rte_errno=" << rte_errno << ", "
+                 << rte_strerror(rte_errno) << ")";
+  }
+
+  PostPopulate();
+}
+
+BessPacketPool::BessPacketPool(size_t capacity, int socket_id)
+    : PacketPool(capacity, socket_id), mem_(512 * 1024 * 1024, socket_id) {
+  size_t page_shift = __builtin_ffs(getpagesize());
+  size_t element_size =
+      pool_->header_size + pool_->elt_size + pool_->trailer_size;
+  size_t size = rte_mempool_xmem_size(pool_->size, element_size, page_shift,
+                                      pool_->flags);
+
+  int ret = 0;
+  if (void *addr = mem_.Alloc(size)) {
+    ret = rte_mempool_populate_iova(pool_, static_cast<char *>(addr),
+                                    RTE_BAD_IOVA, size, DoMunmap, nullptr);
+  }
+
+  if (ret < static_cast<ssize_t>(pool_->size)) {
+    LOG(WARNING) << "rte_mempool_populate_iova() returned " << ret
+                 << " (rte_errno=" << rte_errno << ", "
+                 << rte_strerror(rte_errno) << ")";
+  }
+
+  PostPopulate();
+}
+
+DpdkPacketPool::DpdkPacketPool(size_t capacity, int socket_id)
+    : PacketPool(capacity, socket_id) {
+  int ret = rte_mempool_populate_default(pool_);
+  if (ret < static_cast<ssize_t>(pool_->size)) {
+    LOG(WARNING) << "rte_mempool_populate_default() returned " << ret
+                 << " (rte_errno=" << rte_errno << ", "
+                 << rte_strerror(rte_errno) << ")";
+  }
+
+  PostPopulate();
+}
+
+}  // namespace bess

--- a/core/packet_pool.cc
+++ b/core/packet_pool.cc
@@ -195,7 +195,8 @@ PlainPacketPool::PlainPacketPool(size_t capacity, int socket_id)
 }
 
 BessPacketPool::BessPacketPool(size_t capacity, int socket_id)
-    : PacketPool(capacity, socket_id), mem_(FLAGS_m * 1024 * 1024, socket_id) {
+    : PacketPool(capacity, socket_id),
+      mem_(static_cast<size_t>(FLAGS_m) * 1024 * 1024, socket_id) {
   size_t page_shift = __builtin_ffs(getpagesize());
   size_t element_size =
       pool_->header_size + pool_->elt_size + pool_->trailer_size;

--- a/core/packet_pool.h
+++ b/core/packet_pool.h
@@ -1,0 +1,126 @@
+#ifndef BESS_PACKET_POOL_H_
+#define BESS_PACKET_POOL_H_
+
+#include "memory.h"
+#include "packet.h"
+
+// "Congiguous" here means that all packets reside in a single memory region
+// in the virtual/physical address space.
+//                                       Contiguous?
+//                   Backed memory    Virtual  Physical  mlock()ed  fail-free
+// --------------------------------------------------------------------------
+// PlainPacketPool   Plain 4k pages   O        X         X          O
+//   : For standalone benchmarks and unittests. Cannot be used for DMA.
+//
+// BessPacketPool    BESS hugepages   O        O         O          X
+//   : BESS default. It allocates and manages huge pages internally.
+//     No hugetlbfs is required.
+//
+// DpdkPacketPool    DPDK hugepages   O/X      O/X       O          O
+//   : It is used as a fallback option if allocation of BessPacketPool has
+//     failed. The memory region will be contiguous in most cases,
+//     but not so if 2MB hugepages are used and scattered. MLX4/5 drivers
+//     will fail in this case.
+
+namespace bess {
+
+// PacketPool is a C++ wrapper for DPDK rte_mempool. It has a pool of
+// pre-populated Packet objects, which can be fetched via Alloc().
+// Alloc() and Free() are thread-safe.
+class PacketPool {
+ public:
+  static PacketPool *GetDefaultPool(int node) { return default_pools_[node]; }
+
+  static void CreateDefaultPools(size_t capacity = kDefaultCapacity);
+
+  // socket_id == -1 means "I don't care".
+  PacketPool(size_t capacity = kDefaultCapacity, int socket_id = -1);
+  virtual ~PacketPool();
+
+  // PacketPool is neither copyable nor movable.
+  PacketPool(const PacketPool &) = delete;
+  PacketPool &operator=(const PacketPool &) = delete;
+
+  // Allocate a packet from the pool, with specified initial packet size.
+  Packet *Alloc(size_t len = 0) {
+    Packet *pkt = reinterpret_cast<Packet *>(rte_pktmbuf_alloc(pool_));
+    if (pkt) {
+      pkt->pkt_len_ = len;
+      pkt->data_len_ = len;
+
+      // TODO: sanity check
+    }
+    return pkt;
+  }
+
+  // Allocate multiple packets. Note that this function has no partial success;
+  // it allocates either all "count" packets (returns true) or none (false).
+  bool AllocBulk(Packet **pkts, size_t count, size_t len = 0);
+
+  // The number of total packets in the pool. 0 if initialization failed.
+  size_t Capacity() const { return pool_->populated_size; }
+
+  // The number of available packets in the pool. Approximate by nature.
+  size_t Size() const { return rte_mempool_avail_count(pool_); }
+
+  // Note: It would be ideal to not expose this
+  rte_mempool *pool() { return pool_; }
+
+  virtual bool IsVirtuallyContiguous() = 0;
+  virtual bool IsPhysicallyContiguous() = 0;
+  virtual bool IsPinned() = 0;
+
+ protected:
+  static const size_t kDefaultCapacity = (1 << 16) - 1;  // 64k - 1
+  static const size_t kMaxCacheSize = 512;               // per-core cache size
+
+  // Child classes are expected to call this function in their constructor
+  void PostPopulate();
+
+  std::string name_;
+  rte_mempool *pool_;
+
+ private:
+  // Default per-node packet pools
+  static PacketPool *default_pools_[RTE_MAX_NUMA_NODES];
+
+  friend class Packet;
+};
+
+class PlainPacketPool : public PacketPool {
+ public:
+  PlainPacketPool(size_t capacity = kDefaultCapacity, int socket_id = -1);
+
+  virtual bool IsVirtuallyContiguous() override { return true; }
+  virtual bool IsPhysicallyContiguous() override { return false; }
+  virtual bool IsPinned() override { return pinned_; }
+
+ private:
+  bool pinned_;
+};
+
+class BessPacketPool : public PacketPool {
+ public:
+  BessPacketPool(size_t capacity = kDefaultCapacity, int socket_id = -1);
+
+  virtual bool IsVirtuallyContiguous() override { return true; }
+  virtual bool IsPhysicallyContiguous() override { return true; }
+  virtual bool IsPinned() override { return true; }
+
+ private:
+  DmaMemoryPool mem_;
+};
+
+class DpdkPacketPool : public PacketPool {
+ public:
+  DpdkPacketPool(size_t capacity = kDefaultCapacity, int socket_id = -1);
+
+  // TODO(sangjin): it may or may not be contiguous. Check it.
+  virtual bool IsVirtuallyContiguous() override { return false; }
+  virtual bool IsPhysicallyContiguous() override { return false; }
+  virtual bool IsPinned() override { return true; }
+};
+
+}  // namespace bess
+
+#endif  // BESS_PACKET_POOL_H_

--- a/core/utils/exact_match_table_test.cc
+++ b/core/utils/exact_match_table_test.cc
@@ -32,13 +32,14 @@
 
 #include <gtest/gtest.h>
 
+#include "../packet_pool.h"
 #include "endian.h"
 
+using bess::utils::Error;
 using bess::utils::ExactMatchField;
 using bess::utils::ExactMatchKey;
 using bess::utils::ExactMatchRuleFields;
 using bess::utils::ExactMatchTable;
-using bess::utils::Error;
 
 TEST(EmTableTest, AddField) {
   ExactMatchTable<uint8_t> em;
@@ -136,7 +137,9 @@ TEST(EmTableTest, FindMakeKeysPktBatch) {
   ExactMatchRuleFields rule = {{0x04, 0x03, 0x02, 0x01}};
   ExactMatchKey keys[n];
   bess::PacketBatch batch;
-  bess::Packet pkts[n];
+  bess::PlainPacketPool pool;
+  bess::Packet *pkts[n];
+  pool.AllocBulk(pkts, n, 0);
   char databuf[32] = {0};
 
   ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
@@ -144,8 +147,7 @@ TEST(EmTableTest, FindMakeKeysPktBatch) {
 
   batch.clear();
   for (size_t i = 0; i < n; i++) {
-    bess::Packet *pkt = &pkts[i];
-
+    bess::Packet *pkt = pkts[i];
     bess::utils::Copy(pkt->append(sizeof(databuf)), databuf, sizeof(databuf));
     batch.add(pkt);
   }

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -47,7 +47,7 @@
 #include "metadata.h"
 #include "module.h"
 #include "opts.h"
-#include "packet.h"
+#include "packet_pool.h"
 #include "resume_hook.h"
 #include "resume_hooks/metadata.h"
 #include "scheduler.h"
@@ -230,8 +230,6 @@ bool is_any_worker_running() {
 }
 
 void Worker::SetNonWorker() {
-  int socket;
-
   // These TLS variables should not be accessed by non-worker threads.
   // Assign INT_MIN to the variables so that the program can crash
   // when accessed as an index of an array.
@@ -240,13 +238,14 @@ void Worker::SetNonWorker() {
   socket_ = INT_MIN;
   fd_event_ = INT_MIN;
 
-  // Packet pools should be available to non-worker threads.
-  // (doesn't need to be NUMA-aware, so pick any)
-  for (socket = 0; socket < RTE_MAX_NUMA_NODES; socket++) {
-    struct rte_mempool *pool = bess::get_pframe_pool_socket(socket);
-    if (pool) {
-      pframe_pool_ = pool;
-      break;
+  if (!packet_pool_) {
+    // Packet pools should be available to non-worker threads.
+    // (doesn't need to be NUMA-aware, so pick any)
+    for (int socket = 0; socket < RTE_MAX_NUMA_NODES; socket++) {
+      if (bess::PacketPool *pool = bess::PacketPool::GetDefaultPool(socket)) {
+        packet_pool_ = pool;
+        break;
+      }
     }
   }
 }
@@ -292,7 +291,7 @@ void *Worker::Run(void *_arg) {
   wid_ = arg->wid;
   core_ = arg->core;
   socket_ = rte_socket_id();
-  DCHECK_GE(socket_, 0); /* shouldn't be SOCKET_ID_ANY (-1) */
+  DCHECK_GE(socket_, 0);  // shouldn't be SOCKET_ID_ANY (-1)
   fd_event_ = eventfd(0, 0);
   DCHECK_GE(fd_event_, 0);
 
@@ -300,8 +299,8 @@ void *Worker::Run(void *_arg) {
 
   current_tsc_ = rdtsc();
 
-  pframe_pool_ = bess::get_pframe_pool_socket(socket_);
-  DCHECK(pframe_pool_);
+  packet_pool_ = bess::PacketPool::GetDefaultPool(socket_);
+  DCHECK_NOTNULL(packet_pool_);
 
   status_ = WORKER_PAUSING;
 

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -132,7 +132,7 @@ void resume_worker(int wid) {
     worker_signal sig = worker_signal::unblock;
 
     ret = write(workers[wid]->fd_event(), &sig, sizeof(sig));
-    DCHECK_EQ(ret, sizeof(uint64_t));
+    CHECK_EQ(ret, sizeof(uint64_t));
 
     while (workers[wid]->status() == WORKER_PAUSED) {
     } /* spin */
@@ -187,7 +187,7 @@ void destroy_worker(int wid) {
     worker_signal sig = worker_signal::quit;
 
     ret = write(workers[wid]->fd_event(), &sig, sizeof(sig));
-    DCHECK_EQ(ret, sizeof(uint64_t));
+    CHECK_EQ(ret, sizeof(uint64_t));
 
     while (workers[wid]->status() == WORKER_PAUSED) {
     } /* spin */
@@ -257,7 +257,7 @@ int Worker::BlockWorker() {
   status_ = WORKER_PAUSED;
 
   ret = read(fd_event_, &t, sizeof(t));
-  DCHECK_EQ(ret, sizeof(t));
+  CHECK_EQ(ret, sizeof(t));
 
   if (t == worker_signal::unblock) {
     status_ = WORKER_RUNNING;
@@ -291,16 +291,16 @@ void *Worker::Run(void *_arg) {
   wid_ = arg->wid;
   core_ = arg->core;
   socket_ = rte_socket_id();
-  DCHECK_GE(socket_, 0);  // shouldn't be SOCKET_ID_ANY (-1)
+  CHECK_GE(socket_, 0);  // shouldn't be SOCKET_ID_ANY (-1)
   fd_event_ = eventfd(0, 0);
-  DCHECK_GE(fd_event_, 0);
+  CHECK_GE(fd_event_, 0);
 
   scheduler_ = arg->scheduler;
 
   current_tsc_ = rdtsc();
 
   packet_pool_ = bess::PacketPool::GetDefaultPool(socket_);
-  DCHECK_NOTNULL(packet_pool_);
+  CHECK_NOTNULL(packet_pool_);
 
   status_ = WORKER_PAUSING;
 

--- a/core/worker.h
+++ b/core/worker.h
@@ -39,7 +39,6 @@
 #include <type_traits>
 
 #include "gate.h"
-#include "pktbatch.h"
 #include "traffic_class.h"
 #include "utils/common.h"
 #include "utils/random.h"
@@ -68,6 +67,7 @@ typedef enum {
 
 namespace bess {
 class Scheduler;
+class PacketPool;
 }  // namespace bess
 
 class Task;
@@ -101,9 +101,7 @@ class Worker {
   int socket() { return socket_; }
   int fd_event() { return fd_event_; }
 
-  struct rte_mempool *pframe_pool() {
-    return pframe_pool_;
-  }
+  bess::PacketPool *packet_pool() { return packet_pool_; }
 
   bess::Scheduler *scheduler() { return scheduler_; }
 
@@ -127,7 +125,7 @@ class Worker {
   int socket_;
   int fd_event_;
 
-  struct rte_mempool *pframe_pool_;
+  bess::PacketPool *packet_pool_;
 
   bess::Scheduler *scheduler_;
 


### PR DESCRIPTION
PacketPool is a C++ class that abstracts rte_mempool. It supports 3 different memory backends:

1. normal memory (4kB pages): useful when no hugepage is readily available or strictly necessary, e.g., unit test or microbenchmark. `Packet` is no longer needed to be manually crafted even when DPDK is not being used. Since this memory is not DMA-able, PMD drivers cannot be used.

2. BESS hugepages (2MB/1GB pages): implemented on top of System V shared memory, which does not require a hugetlbfs mounted directory. Also, if hugepages are not reserved, it will automatically try to reserve some. DPDK is initialized with `--no-huge` option and BESS directly allocates hugepages.

3. DPDK hugepages (2MB/1GB pages): hugepages are allocated and managed by DPDK. Thus the same configuration (nr_hugepages and hugetlbfs) as other DPDK applications is required.

---

Note: some PMD drivers (and depending on VFIO environments) do not correctly support non-DPDK hugepages in DPDK 17.11 version. Until we upgrade to a latest version (18.05 or 18.08), DPDK-based hugepages are used by default. BESS-based hugepages can be enabled with `-nodpdk` option.