### PR TITLE
Support multiple gatehooks of the same type installed per gate

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1471,7 +1471,8 @@ def _show_module(cli, module_name):
                            (gate.igate, track_str,
                             ', '.join('%s:%d ->' % (g.name, g.ogate)
                                       for g in gate.ogates),
-                            ', '.join(gate.hook_name)))
+                            ', '.join('%s::%s' % (h.class_name, h.hook_name)
+                                      for h in gate.gatehooks)))
 
     if len(info.ogates) > 0:
         cli.fout.write('    Output gates:\n')
@@ -1485,7 +1486,8 @@ def _show_module(cli, module_name):
             cli.fout.write(
                 '      %3d: %s -> %d:%s\t%s\n' %
                 (gate.ogate, track_str, gate.igate, gate.name,
-                 ', '.join(gate.hook_name)))
+                 ', '.join("%s::%s" % (h.class_name, h.hook_name)
+                           for h in gate.gatehooks)))
 
     if hasattr(info, 'dump'):
         dump_str = pprint.pformat(info.dump, width=74)
@@ -1545,14 +1547,17 @@ def show_gatehook_all(cli):
 
     if not gatehooks:
         raise cli.CommandError('There is no active gatehook to show.')
-
     for gatehook in gatehooks:
         if gatehook.HasField('igate'):
-            cli.fout.write('%-16s %d:%s\n' % (gatehook.hook_name, gatehook.igate,
+            cli.fout.write('%-16s %d:%s\n' % ('%s::%s' % (gatehook.class_name,
+                                              gatehook.hook_name),
+                                              gatehook.igate,
                                               gatehook.module_name))
         else:
-            cli.fout.write('%-16s %s:%d\n' % (gatehook.hook_name,
-                                    gatehook.module_name, gatehook.ogate))
+            cli.fout.write('%-16s %s:%d\n' % ('%s::%s' % (gatehook.class_name,
+                                              gatehook.hook_name),
+                                              gatehook.module_name,
+                                              gatehook.ogate))
 
 
 def _show_gatehook_class(cli, cls_name, detail):

--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1927,7 +1927,7 @@ def _capture_gate(cli, module_name, direction, gate, opts, program, hook_fn):
 
     unhook = True
     try:
-        hook_fn(True, '', module_name, direction, gate, fifo)
+        ret = hook_fn(True, '', module_name, direction, gate, fifo)
         proc.wait()
     except KeyboardInterrupt:
         # kill all descendants in the process group
@@ -1941,7 +1941,7 @@ def _capture_gate(cli, module_name, direction, gate, opts, program, hook_fn):
         proc.wait()
         try:
             if unhook:
-                hook_fn(False, '', module_name, direction, gate)
+                hook_fn(False, ret.name, module_name, direction, gate)
         finally:
             try:
                 os.close(fd)

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -113,7 +113,7 @@ static CommandResponse enable_hook_for_module(
       return CommandFailure(EINVAL, "'%s': %cgate '%hu' does not exist",
                             m->name().c_str(), is_igate ? 'i' : 'o', gate_idx);
     }
-    return gate->CreateGateHook(&builder, gate, is_igate, "noname", arg);
+    return gate->CreateGateHook(&builder, gate, is_igate, "", arg);
   }
 
   if (is_igate) {
@@ -121,7 +121,8 @@ static CommandResponse enable_hook_for_module(
       if (!gate) {
         continue;
       }
-      CommandResponse ret = gate->CreateGateHook(&builder, gate, is_igate, "noname", arg);
+      CommandResponse ret = gate->CreateGateHook(&builder, gate, is_igate,
+          "", arg);
       if (ret.error().code() != 0) {
         return ret;
       }
@@ -131,7 +132,8 @@ static CommandResponse enable_hook_for_module(
       if (!gate) {
         continue;
       }
-      CommandResponse ret = gate->CreateGateHook(&builder, gate, is_igate, "noname", arg);
+      CommandResponse ret = gate->CreateGateHook(&builder, gate, is_igate,
+          "", arg);
       if (ret.error().code() != 0) {
         return ret;
       }

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -127,7 +127,8 @@ static Status enable_hook_for_module(ConfigureGateHookResponse* response,
     return Status::OK;
   }
 
-  //XXX this codes is not all or nothing if a gatehook command are failed
+  std::vector<std::string> created_hook_names;
+
   if (is_igate) {
     for (auto& gate : m->igates()) {
       if (!gate) {
@@ -136,7 +137,16 @@ static Status enable_hook_for_module(ConfigureGateHookResponse* response,
       bess::GateHook* hook =
           gate->CreateGateHook(&builder, gate, hook_name, arg, error);
       if (error->code() != 0 || !hook) {
+        // in case of failed creating gate hook, remove previously created
+        // before return
+        auto it = created_hook_names.begin();
+        while ( it != created_hook_names.end()){
+          gate->RemoveHook(*it);
+          it = created_hook_names.erase(it);
+        }
         return Status::OK;
+      } else {
+        created_hook_names.push_back(hook->name());
       }
     }
   } else {
@@ -147,7 +157,16 @@ static Status enable_hook_for_module(ConfigureGateHookResponse* response,
       bess::GateHook* hook =
           gate->CreateGateHook(&builder, gate, hook_name, arg, error);
       if (error->code() != 0 || !hook) {
+        // in case of failed creating gate hook, remove previously created
+        // before return
+        auto it = created_hook_names.begin();
+        while ( it != created_hook_names.end()){
+          gate->RemoveHook(*it);
+          it = created_hook_names.erase(it);
+        }
         return Status::OK;
+      } else {
+        created_hook_names.push_back(hook->name());
       }
     }
   }

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -127,7 +127,7 @@ static Status enable_hook_for_module(ConfigureGateHookResponse* response,
     return Status::OK;
   }
 
-  //FIXME This operation is not all or nothing
+  //XXX this codes is not all or nothing if a gatehook command are failed
   if (is_igate) {
     for (auto& gate : m->igates()) {
       if (!gate) {
@@ -195,7 +195,7 @@ static int collect_igates(Module* m, GetModuleInfoResponse* response) {
 
     GetModuleInfoResponse_IGate* igate = response->add_igates();
 
-    Track* t = reinterpret_cast<Track*>(g->FindHook(Track::kName));
+    Track* t = reinterpret_cast<Track*>(g->FindHookByClass(Track::kName));
 
     if (t) {
       igate->set_cnt(t->cnt());
@@ -231,7 +231,7 @@ static int collect_ogates(Module* m, GetModuleInfoResponse* response) {
     GetModuleInfoResponse_OGate* ogate = response->add_ogates();
 
     ogate->set_ogate(g->gate_idx());
-    Track* t = reinterpret_cast<Track*>(g->FindHook(Track::kName));
+    Track* t = reinterpret_cast<Track*>(g->FindHookByClass(Track::kName));
     if (t) {
       ogate->set_cnt(t->cnt());
       ogate->set_pkts(t->pkts());
@@ -1498,7 +1498,6 @@ class BESSControlImpl final : public BESSControl::Service {
                                request->hook().class_name().c_str());
     }
 
-    //XXX this codes isf not all or nothing if a gatehook command are failed
     if (request->hook().module_name().length() == 0) {
       // Install this hook on all modules
       for (const auto& it : ModuleGraph::GetAllModules()) {

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -140,7 +140,7 @@ static Status enable_hook_for_module(ConfigureGateHookResponse* response,
         // in case of failed creating gate hook, remove previously created
         // before return
         auto it = created_hook_names.begin();
-        while ( it != created_hook_names.end()){
+        while (it != created_hook_names.end()) {
           gate->RemoveHook(*it);
           it = created_hook_names.erase(it);
         }
@@ -160,7 +160,7 @@ static Status enable_hook_for_module(ConfigureGateHookResponse* response,
         // in case of failed creating gate hook, remove previously created
         // before return
         auto it = created_hook_names.begin();
-        while ( it != created_hook_names.end()){
+        while (it != created_hook_names.end()) {
           gate->RemoveHook(*it);
           it = created_hook_names.erase(it);
         }
@@ -231,11 +231,10 @@ static int collect_igates(Module* m, GetModuleInfoResponse* response) {
     }
 
     for (const auto& hook : g->hooks()) {
-      GetModuleInfoResponse_GateHook *hook_info = igate->add_gatehooks();
+      GetModuleInfoResponse_GateHook* hook_info = igate->add_gatehooks();
       hook_info->set_class_name(hook->class_name());
       hook_info->set_hook_name(hook->name());
     }
-
   }
 
   return 0;
@@ -261,11 +260,10 @@ static int collect_ogates(Module* m, GetModuleInfoResponse* response) {
     ogate->set_igate(g->igate()->gate_idx());
 
     for (const auto& hook : g->hooks()) {
-      GetModuleInfoResponse_GateHook *hook_info = ogate->add_gatehooks();
+      GetModuleInfoResponse_GateHook* hook_info = ogate->add_gatehooks();
       hook_info->set_class_name(hook->class_name());
       hook_info->set_hook_name(hook->name());
     }
-
   }
 
   return 0;
@@ -1416,7 +1414,7 @@ class BESSControlImpl final : public BESSControl::Service {
   }
 
   Status ListGateHookClass(ServerContext*, const EmptyRequest*,
-                    ListGateHookClassResponse* response) override {
+                           ListGateHookClassResponse* response) override {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     for (const auto& pair : bess::GateHookBuilder::all_gate_hook_builders()) {
@@ -1427,8 +1425,8 @@ class BESSControlImpl final : public BESSControl::Service {
   }
 
   Status GetGateHookClassInfo(ServerContext*,
-                      const GetGateHookClassInfoRequest* request,
-                      GetGateHookClassInfoResponse* response) override {
+                              const GetGateHookClassInfoRequest* request,
+                              GetGateHookClassInfoResponse* response) override {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     VLOG(1) << "GetGateHookClassInfo from client:" << std::endl
@@ -1439,7 +1437,8 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     const std::string& cls_name = request->name();
-    const auto& it = bess::GateHookBuilder::all_gate_hook_builders().find(cls_name);
+    const auto& it =
+        bess::GateHookBuilder::all_gate_hook_builders().find(cls_name);
     if (it == bess::GateHookBuilder::all_gate_hook_builders().end()) {
       return return_with_error(response, ENOENT, "No gatehook class '%s' found",
                                cls_name.c_str());
@@ -1493,7 +1492,7 @@ class BESSControlImpl final : public BESSControl::Service {
 
   Status ConfigureGateHook(ServerContext*,
                            const ConfigureGateHookRequest* request,
-                           ConfigureGateHookResponse *response) override {
+                           ConfigureGateHookResponse* response) override {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     WorkerPauser wp;
@@ -1521,12 +1520,12 @@ class BESSControlImpl final : public BESSControl::Service {
       // Install this hook on all modules
       for (const auto& it : ModuleGraph::GetAllModules()) {
         if (request->enable()) {
-          enable_hook_for_module(response, request->hook().hook_name(), it.second,
-                                 gate_idx, is_igate, use_gate, builder->second,
-                                 request->hook().arg());
+          enable_hook_for_module(response, request->hook().hook_name(),
+                                 it.second, gate_idx, is_igate, use_gate,
+                                 builder->second, request->hook().arg());
         } else {
-          disable_hook_for_module(response, request->hook().hook_name(), it.second,
-                                  gate_idx, is_igate, use_gate);
+          disable_hook_for_module(response, request->hook().hook_name(),
+                                  it.second, gate_idx, is_igate, use_gate);
         }
         if (response->error().code() != 0) {
           return Status::OK;

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -42,60 +42,60 @@ namespace bess {
 
 const GateHookCommands GateHook::cmds;
 
-bool GateHookFactory::RegisterGateHook(GateHook::constructor_t constructor,
+bool GateHookBuilder::RegisterGateHook(GateHook::constructor_t constructor,
                                        const std::string &class_name,
                                        const std::string &name_template,
                                        const std::string &help_text,
                                        const GateHookCommands &cmds,
                                        GateHook::init_func_t init_func) {
-  return all_gate_hook_factories_holder()
+  return all_gate_hook_builders_holder()
       .emplace(std::piecewise_construct, std::forward_as_tuple(class_name),
                std::forward_as_tuple(constructor, class_name, name_template,
                  help_text, cmds, init_func))
       .second;
 }
 
-std::map<std::string, GateHookFactory>
-    &GateHookFactory::all_gate_hook_factories_holder(bool reset) {
-  // Maps from hook names to hook factories. Tracks all hooks (via their
-  // GateHookFactorys).
-  static std::map<std::string, GateHookFactory> all_gate_hook_factories;
+std::map<std::string, GateHookBuilder>
+    &GateHookBuilder::all_gate_hook_builders_holder(bool reset) {
+  // Maps from hook names to hook builders. Tracks all hooks (via their
+  // GateHookBuilders).
+  static std::map<std::string, GateHookBuilder> all_gate_hook_builders;
 
   if (reset) {
-    all_gate_hook_factories.clear();
+    all_gate_hook_builders.clear();
   }
 
-  return all_gate_hook_factories;
+  return all_gate_hook_builders;
 }
 
-const std::map<std::string, GateHookFactory>
-    &GateHookFactory::all_gate_hook_factories() {
-  return all_gate_hook_factories_holder();
+const std::map<std::string, GateHookBuilder>
+    &GateHookBuilder::all_gate_hook_builders() {
+  return all_gate_hook_builders_holder();
 }
 
-// Creates new gate hook from the given factory, initializes it,
+// Creates new gate hook from the given builder, initializes it,
 // and adds it to the given gate.  If any of these steps go wrong
 // the gatehook instance is destroyed and we return a failed
 // CommandResponse, otherwise we return a successful one.
-CommandResponse Gate::NewGateHook(const GateHookFactory *factory, Gate *gate,
+CommandResponse Gate::CreateGateHook(const GateHookBuilder *builder, Gate *gate,
                                   bool is_igate, const std::string &name,
                                   const google::protobuf::Any &arg) {
-  bess::GateHook *hook = factory->hook_constructor_();
-  CommandResponse init_ret = factory->hook_init_func_(hook, gate, arg);
+  bess::GateHook *hook = builder->hook_constructor_();
+  CommandResponse init_ret = builder->hook_init_func_(hook, gate, arg);
   if (init_ret.error().code() != 0) {
     delete hook;
     return init_ret;
   }
-  hook->set_class_name(factory->class_name());
+  hook->set_class_name(builder->class_name());
   hook->set_name(name);
-  hook->set_factory(factory);
+  hook->set_builder(builder);
   hook->set_arg(arg);
   hook->set_gate(gate);
   int ret = gate->AddHook(hook);
   if (ret != 0) {
     delete hook;
     return CommandFailure(ret, "Unable to add hook '%s::%s' to '%s' %cgate '%hu'",
-                          factory->class_name_.c_str(), name.c_str(),
+                          builder->class_name_.c_str(), name.c_str(),
                           gate->module()->name().c_str(), is_igate ? 'i' : 'o',
                           gate->gate_idx());
   }
@@ -140,7 +140,7 @@ void Gate::RemoveHook(const std::string &name) {
 }
 
 // TODO(torek): combine (template) with ModuleBuilder::RunCommand
-CommandResponse GateHookFactory::RunCommand(
+CommandResponse GateHookBuilder::RunCommand(
     GateHook *hook, const std::string &user_cmd,
     const google::protobuf::Any &arg) const {
   Module *mod = hook->gate()->module();
@@ -186,26 +186,26 @@ void IGate::RemoveOgate(const OGate *og) {
 
 // Add internally-generated Track() hook to this ogate.
 void OGate::AddTrackHook() {
-  static const GateHookFactory *track_factory;
+  static const GateHookBuilder *track_builder;
   static google::protobuf::Any arg;
 
-  // If we haven't located the track hook factory yet, do that first.
-  if (track_factory == nullptr) {
+  // If we haven't located the track hook builder yet, do that first.
+  if (track_builder == nullptr) {
     const auto it =
-        bess::GateHookFactory::all_gate_hook_factories().find(Track::kName);
+        bess::GateHookBuilder::all_gate_hook_builders().find(Track::kName);
     // Would like to use CHECK_NE here, but cannot because
     // operator<< is not defined on the arguments.
-    if (it == bess::GateHookFactory::all_gate_hook_factories().end()) {
-      CHECK(0) << "Track gate hook factory is missing";
+    if (it == bess::GateHookBuilder::all_gate_hook_builders().end()) {
+      CHECK(0) << "Track gate hook builder is missing";
     }
-    track_factory = &it->second;
+    track_builder = &it->second;
 
     // A new Track() instance takes an argument that has a "bits" flag.
     static bess::pb::TrackArg track_arg;
     track_arg.set_bits(false);
     arg.PackFrom(track_arg);
   }
-  this->NewGateHook(track_factory, this, false, "track", arg);
+  this->CreateGateHook(track_builder, this, false, "track", arg);
 }
 
 void OGate::SetIgate(IGate *ig) {

--- a/core/gate.cc
+++ b/core/gate.cc
@@ -52,7 +52,7 @@ bool GateHookBuilder::RegisterGateHook(GateHook::constructor_t constructor,
   return all_gate_hook_builders_holder()
       .emplace(std::piecewise_construct, std::forward_as_tuple(class_name),
                std::forward_as_tuple(constructor, class_name, name_template,
-                 help_text, cmds, init_func))
+                                     help_text, cmds, init_func))
       .second;
 }
 
@@ -80,8 +80,9 @@ const std::string Gate::GenerateDefaultName(const GateHookBuilder *builder,
   const std::vector<GateHook *> hooks = gate->hooks();
   for (int i = 0;; i++) {
     std::string name = name_template + std::to_string(i);
-    if (std::none_of(hooks.begin(), hooks.end(), [&](const GateHook *hook){
-      return name == hook->name(); })) {
+    if (std::none_of(hooks.begin(), hooks.end(), [&](const GateHook *hook) {
+          return name == hook->name();
+        })) {
       return name;
     }
   }
@@ -181,9 +182,9 @@ void Gate::RemoveHookByClass(const std::string &class_name) {
 }
 
 // TODO(torek): combine (template) with ModuleBuilder::RunCommand
-CommandResponse
-    GateHookBuilder::RunCommand(GateHook *hook, const std::string &user_cmd,
-                                const google::protobuf::Any &arg) const {
+CommandResponse GateHookBuilder::RunCommand(
+    GateHook *hook, const std::string &user_cmd,
+    const google::protobuf::Any &arg) const {
   Module *mod = hook->gate()->module();
   for (auto &cmd : cmds_) {
     if (user_cmd == cmd.cmd) {

--- a/core/gate.h
+++ b/core/gate.h
@@ -122,6 +122,15 @@ class GateHook {
   DISALLOW_COPY_AND_ASSIGN(GateHook);
 };
 
+struct CompareGatehookName : public std::unary_function<GateHook, GateHook>
+{
+  explicit CompareGatehookName(const std::string &name) : name_(name) {}
+  bool operator() (const GateHook *gatehook) {
+    return name_ == gatehook->name();
+  }
+  std::string name_;
+};
+
 // A class for creating new 'gate hook's
 class GateHookBuilder {
  public:
@@ -221,10 +230,11 @@ class Gate {
   gate_idx_t gate_idx_;         // input/output gate index of itself
   uint32_t global_gate_index_;  // a globally unique igate index
 
-  // TODO(melvin): Consider using a map here instead. It gets rid of the need to
-  // scan to find modules for queries. Not sure how priority would work in a
-  // map, though.
   std::vector<GateHook *> hooks_;
+
+ private:
+  const std::string GenerateDefaultName(const GateHookBuilder *builder,
+      Gate *gate);
 
   DISALLOW_COPY_AND_ASSIGN(Gate);
 };

--- a/core/gate.h
+++ b/core/gate.h
@@ -211,9 +211,8 @@ class Gate {
 
   // Creates, initializes, and then inserts gate hook in priority order.
   GateHook *CreateGateHook(const GateHookBuilder *builder, Gate *gate,
-                              const std::string &name,
-                              const google::protobuf::Any &arg,
-                              pb_error_t *error);
+                           const std::string &name,
+                           const google::protobuf::Any &arg, pb_error_t *error);
 
   GateHook *FindHook(const std::string &name);
 
@@ -229,7 +228,7 @@ class Gate {
   friend class GateTest;
 
   // Inserts hook in priority order and returns 0 on success.
-  int AddHook(GateHook *hook, pb_error_t *error);
+  int AddHook(GateHook *hook);
 
   Module *module_;              // the module this gate belongs to
   gate_idx_t gate_idx_;         // input/output gate index of itself

--- a/core/gate.h
+++ b/core/gate.h
@@ -210,9 +210,10 @@ class Gate {
   const std::vector<GateHook *> &hooks() const { return hooks_; }
 
   // Creates, initializes, and then inserts gate hook in priority order.
-  CommandResponse CreateGateHook(const GateHookBuilder *builder, Gate *gate,
-                              bool is_gate, const std::string &name,
-                              const google::protobuf::Any &arg);
+  GateHook *CreateGateHook(const GateHookBuilder *builder, Gate *gate,
+                              const std::string &name,
+                              const google::protobuf::Any &arg,
+                              pb_error_t *error);
 
   GateHook *FindHook(const std::string &name);
 
@@ -224,7 +225,7 @@ class Gate {
   friend class GateTest;
 
   // Inserts hook in priority order and returns 0 on success.
-  int AddHook(GateHook *hook);
+  int AddHook(GateHook *hook, pb_error_t *error);
 
   Module *module_;              // the module this gate belongs to
   gate_idx_t gate_idx_;         // input/output gate index of itself

--- a/core/gate.h
+++ b/core/gate.h
@@ -219,6 +219,10 @@ class Gate {
 
   void RemoveHook(const std::string &name);
 
+  GateHook *FindHookByClass(const std::string &name);
+
+  void RemoveHookByClass(const std::string &name);
+
   void ClearHooks();
 
  protected:

--- a/core/gate.h
+++ b/core/gate.h
@@ -73,8 +73,11 @@ class GateHook {
 
   explicit GateHook(const std::string &class_name, const std::string &name,
                     uint16_t priority = 0, Gate *gate = nullptr)
-      : gate_(gate), class_name_(class_name), name_(name), priority_(priority),
-      builder_() {}
+      : gate_(gate),
+        class_name_(class_name),
+        name_(name),
+        priority_(priority),
+        builder_() {}
 
   virtual ~GateHook() {}
 
@@ -86,7 +89,7 @@ class GateHook {
 
   const google::protobuf::Any &arg() const { return arg_; }
 
-  void set_class_name(const std::string& name) { class_name_ = name; }
+  void set_class_name(const std::string &name) { class_name_ = name; }
 
   void set_name(const std::string &name) { name_ = name; }
 
@@ -122,10 +125,9 @@ class GateHook {
   DISALLOW_COPY_AND_ASSIGN(GateHook);
 };
 
-struct CompareGatehookName : public std::unary_function<GateHook, GateHook>
-{
+struct CompareGatehookName : public std::unary_function<GateHook, GateHook> {
   explicit CompareGatehookName(const std::string &name) : name_(name) {}
-  bool operator() (const GateHook *gatehook) {
+  bool operator()(const GateHook *gatehook) {
     return name_ == gatehook->name();
   }
   std::string name_;
@@ -137,8 +139,7 @@ class GateHookBuilder {
   GateHookBuilder(GateHook::constructor_t constructor,
                   const std::string &class_name,
                   const std::string &name_template,
-                  const std::string &help_text,
-                  const GateHookCommands &cmds,
+                  const std::string &help_text, const GateHookCommands &cmds,
                   GateHook::init_func_t init_func)
       : hook_constructor_(constructor),
         class_name_(class_name),
@@ -157,8 +158,7 @@ class GateHookBuilder {
   static std::map<std::string, GateHookBuilder> &all_gate_hook_builders_holder(
       bool reset = false);
 
-  static const std::map<std::string, GateHookBuilder>
-      &all_gate_hook_builders();
+  static const std::map<std::string, GateHookBuilder> &all_gate_hook_builders();
 
   const std::string &class_name() const { return class_name_; }
   const std::string &name_template() const { return name_template_; }
@@ -238,7 +238,7 @@ class Gate {
 
  private:
   const std::string GenerateDefaultName(const GateHookBuilder *builder,
-      Gate *gate);
+                                        Gate *gate);
 
   DISALLOW_COPY_AND_ASSIGN(Gate);
 };
@@ -320,10 +320,10 @@ static inline bess::GateHook::init_func_t InitGateHookWithGenericArg(
   };
 }
 
-#define ADD_GATE_HOOK(_HOOK, _NAME_TEMPLATE, _HELP)                   \
+#define ADD_GATE_HOOK(_HOOK, _NAME_TEMPLATE, _HELP)                    \
   bool __gate_hook__##_HOOK = bess::GateHookBuilder::RegisterGateHook( \
       std::function<bess::GateHook *()>([]() { return new _HOOK(); }), \
-      _HOOK::kName, _NAME_TEMPLATE, _HELP, _HOOK::cmds, \
+      _HOOK::kName, _NAME_TEMPLATE, _HELP, _HOOK::cmds,                \
       InitGateHookWithGenericArg(&_HOOK::Init));
 
 #endif  // BESS_GATE_H_

--- a/core/gate_hooks/pcapng.cc
+++ b/core/gate_hooks/pcapng.cc
@@ -87,7 +87,7 @@ void BytesToHexDump(const void *src, size_t len, char *dst) {
 const std::string Pcapng::kName = "PcapNg";
 
 Pcapng::Pcapng()
-    : bess::GateHook(Pcapng::kName, Pcapng::kPriority),
+    : bess::GateHook(Pcapng::kName, "pcapng", Pcapng::kPriority),
       opener_(),
       attrs_(),
       attr_template_() {}
@@ -247,4 +247,4 @@ void Pcapng::ProcessBatch(const bess::PacketBatch *batch) {
   }
 }
 
-ADD_GATE_HOOK(Pcapng, "metadata-dump-able packet dump")
+ADD_GATE_HOOK(Pcapng, "pcapng", "metadata-dump-able packet dump")

--- a/core/gate_hooks/pcapng.cc
+++ b/core/gate_hooks/pcapng.cc
@@ -190,7 +190,8 @@ void Pcapng::ProcessBatch(const bess::PacketBatch *batch) {
     bess::Packet *pkt = batch->pkts()[i];
 
     Option opt_comment = {
-        .code = Option::kComment, .len = comment_size,
+        .code = Option::kComment,
+        .len = comment_size,
     };
 
     for (const Attr &attr : attrs_) {
@@ -204,7 +205,8 @@ void Pcapng::ProcessBatch(const bess::PacketBatch *batch) {
     }
 
     Option opt_end = {
-        .code = Option::kEndOfOpts, .len = 0,
+        .code = Option::kEndOfOpts,
+        .len = 0,
     };
 
     EnhancedPacketBlock epb = {

--- a/core/gate_hooks/tcpdump.cc
+++ b/core/gate_hooks/tcpdump.cc
@@ -104,4 +104,4 @@ void Tcpdump::ProcessBatch(const bess::PacketBatch *batch) {
   }
 }
 
-ADD_GATE_HOOK(Tcpdump, "dump traffic on a network")
+ADD_GATE_HOOK(Tcpdump, "tcpdump", "dump traffic on a network")

--- a/core/gate_hooks/tcpdump.h
+++ b/core/gate_hooks/tcpdump.h
@@ -45,7 +45,8 @@ class TcpdumpOpener final : public bess::utils::FifoOpener {
 // Tcpdump dumps copies of the packets seen by a gate. Useful for debugging.
 class Tcpdump final : public bess::GateHook {
  public:
-  Tcpdump() : bess::GateHook(Tcpdump::kName, Tcpdump::kPriority), opener_() {}
+  Tcpdump() : bess::GateHook(Tcpdump::kName, "tcpdump",
+      Tcpdump::kPriority), opener_() {}
 
   virtual ~Tcpdump() {}
 

--- a/core/gate_hooks/tcpdump.h
+++ b/core/gate_hooks/tcpdump.h
@@ -45,8 +45,9 @@ class TcpdumpOpener final : public bess::utils::FifoOpener {
 // Tcpdump dumps copies of the packets seen by a gate. Useful for debugging.
 class Tcpdump final : public bess::GateHook {
  public:
-  Tcpdump() : bess::GateHook(Tcpdump::kName, "tcpdump",
-      Tcpdump::kPriority), opener_() {}
+  Tcpdump()
+      : bess::GateHook(Tcpdump::kName, "tcpdump", Tcpdump::kPriority),
+        opener_() {}
 
   virtual ~Tcpdump() {}
 

--- a/core/gate_hooks/track.cc
+++ b/core/gate_hooks/track.cc
@@ -42,7 +42,7 @@ const GateHookCommands Track::cmds = {{"reset", "EmptyArg",
                                        GateHookCommand::THREAD_UNSAFE}};
 
 Track::Track()
-    : bess::GateHook(Track::kName, Track::kPriority),
+    : bess::GateHook(Track::kName, "track", Track::kPriority),
       track_bytes_(),
       cnt_(),
       pkts_(),
@@ -74,4 +74,4 @@ void Track::ProcessBatch(const bess::PacketBatch *batch) {
   }
 }
 
-ADD_GATE_HOOK(Track, "count the packets and batches")
+ADD_GATE_HOOK(Track, "track", "count the packets and batches")

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -48,9 +48,7 @@ class GateTest : public ::testing::Test {
 
   virtual void TearDown() { delete g; }
 
-  int AddHook(GateHook *hook) {
-    return g->AddHook(hook);
-  }
+  int AddHook(GateHook *hook) { return g->AddHook(hook); }
 
   Gate *g;
 };

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -49,8 +49,7 @@ class GateTest : public ::testing::Test {
   virtual void TearDown() { delete g; }
 
   int AddHook(GateHook *hook) {
-    pb_error_t error;
-    return g->AddHook(hook, &error);
+    return g->AddHook(hook);
   }
 
   Gate *g;
@@ -74,23 +73,35 @@ class IOGateTest : public ::testing::Test {
   IGate *ig;
 };
 
-TEST_F(GateTest, AddExistingHookFails) {
-  ASSERT_EQ(0, AddHook(new Track()));
-  GateHook *hook = new Track();
-  ASSERT_EQ(EEXIST, AddHook(hook));
-  delete hook;
+TEST_F(GateTest, AllowMultipleHook) {
+  GateHook *track0 = new Track();
+  track0->set_name("track0");
+  ASSERT_EQ(0, AddHook(track0));
+  GateHook *track1 = new Track();
+  track1->set_name("track1");
+  ASSERT_EQ(0, AddHook(track1));
+}
+
+TEST_F(GateTest, MultipleHookSameNameFail) {
+  GateHook *track0 = new Track();
+  track0->set_name("track0");
+  ASSERT_EQ(0, AddHook(track0));
+  GateHook *track1 = new Track();
+  track1->set_name("track0");
+  ASSERT_EQ(EEXIST, AddHook(track1));
+  delete track1;
 }
 
 TEST_F(GateTest, HookPriority) {
   ASSERT_EQ(0, AddHook(new Track()));
   ASSERT_EQ(0, AddHook(new Tcpdump()));
-  ASSERT_EQ(Track::kName, g->hooks()[0]->name());
+  ASSERT_EQ(Track::kName, g->hooks()[0]->class_name());
 }
 
 TEST_F(GateTest, FindHook) {
-  ASSERT_EQ(nullptr, g->FindHook(Track::kName));
+  ASSERT_EQ(nullptr, g->FindHookByClass(Track::kName));
   ASSERT_EQ(0, AddHook(new Track()));
-  ASSERT_NE(nullptr, g->FindHook(Track::kName));
+  ASSERT_NE(nullptr, g->FindHookByClass(Track::kName));
 }
 
 TEST_F(GateTest, RemoveHook) {

--- a/core/gate_test.cc
+++ b/core/gate_test.cc
@@ -48,7 +48,10 @@ class GateTest : public ::testing::Test {
 
   virtual void TearDown() { delete g; }
 
-  int AddHook(GateHook *hook) { return g->AddHook(hook); }
+  int AddHook(GateHook *hook) {
+    pb_error_t error;
+    return g->AddHook(hook, &error);
+  }
 
   Gate *g;
 };

--- a/core/resume_hook.cc
+++ b/core/resume_hook.cc
@@ -40,24 +40,24 @@ namespace bess {
 std::set<std::unique_ptr<ResumeHook>, ResumeHook::UniquePtrLess>
     global_resume_hooks;
 
-std::map<std::string, ResumeHookFactory>
-    &ResumeHookFactory::all_resume_hook_factories_holder() {
-  // Maps from hook names to hook factories. Tracks all hooks (via their
-  // ResumeHookFactorys).
-  static std::map<std::string, ResumeHookFactory> all_resume_hook_factories;
+std::map<std::string, ResumeHookBuilder>
+    &ResumeHookBuilder::all_resume_hook_builders_holder() {
+  // Maps from hook names to hook builders. Tracks all hooks (via their
+  // ResumeHookBuilders).
+  static std::map<std::string, ResumeHookBuilder> all_resume_hook_builders;
 
-  return all_resume_hook_factories;
+  return all_resume_hook_builders;
 }
 
-const std::map<std::string, ResumeHookFactory>
-    &ResumeHookFactory::all_resume_hook_factories() {
-  return all_resume_hook_factories_holder();
+const std::map<std::string, ResumeHookBuilder>
+    &ResumeHookBuilder::all_resume_hook_builders() {
+  return all_resume_hook_builders_holder();
 }
 
-bool ResumeHookFactory::RegisterResumeHook(
+bool ResumeHookBuilder::RegisterResumeHook(
     ResumeHook::constructor_t constructor, ResumeHook::init_func_t init_func,
     const std::string &hook_name) {
-  return all_resume_hook_factories_holder()
+  return all_resume_hook_builders_holder()
       .emplace(std::piecewise_construct, std::forward_as_tuple(hook_name),
                std::forward_as_tuple(constructor, init_func, hook_name))
       .second;

--- a/core/resume_hook.cc
+++ b/core/resume_hook.cc
@@ -73,12 +73,12 @@ void run_global_resume_hooks(bool run_modules) {
 
   if (run_modules) {
     auto &resume_modules = event_modules[Event::PreResume];
-    for (auto it = resume_modules.begin(); it != resume_modules.end(); ) {
+    for (auto it = resume_modules.begin(); it != resume_modules.end();) {
       int ret = (*it)->OnEvent(Event::PreResume);
       if (ret == -ENOTSUP) {
-	it = resume_modules.erase(it);
+        it = resume_modules.erase(it);
       } else {
-	it++;
+        it++;
       }
     }
   }

--- a/core/resume_hook.h
+++ b/core/resume_hook.h
@@ -89,9 +89,9 @@ class ResumeHook {
   const bool is_default_;
 };
 
-class ResumeHookFactory {
+class ResumeHookBuilder {
  public:
-  ResumeHookFactory(typename ResumeHook::constructor_t constructor,
+  ResumeHookBuilder(typename ResumeHook::constructor_t constructor,
                     typename ResumeHook::init_func_t init_func,
                     const std::string &hook_name)
       : hook_constructor_(constructor),
@@ -104,11 +104,11 @@ class ResumeHookFactory {
 
   const std::string &hook_name() const { return hook_name_; }
 
-  static std::map<std::string, ResumeHookFactory>
-      &all_resume_hook_factories_holder();
+  static std::map<std::string, ResumeHookBuilder>
+      &all_resume_hook_builders_holder();
 
-  static const std::map<std::string, ResumeHookFactory>
-      &all_resume_hook_factories();
+  static const std::map<std::string, ResumeHookBuilder>
+      &all_resume_hook_builders();
 
   std::unique_ptr<ResumeHook> CreateResumeHook() const {
     return std::unique_ptr<ResumeHook>(hook_constructor_());
@@ -144,7 +144,7 @@ InitResumeHookWithGenericArg(CommandResponse (H::*fn)(const A &)) {
 }
 
 #define ADD_RESUME_HOOK(_HOOK)                                               \
-  bool __resume_hook__##_HOOK = bess::ResumeHookFactory::RegisterResumeHook( \
+  bool __resume_hook__##_HOOK = bess::ResumeHookBuilder::RegisterResumeHook( \
       std::function<bess::ResumeHook *()>([]() { return new _HOOK(); }),     \
       InitResumeHookWithGenericArg(&_HOOK::Init), _HOOK::kName);
 

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -54,9 +54,9 @@
 #include "utils/random.h"
 #include "utils/time.h"
 
-using bess::Scheduler;
 using bess::DefaultScheduler;
 using bess::ExperimentalScheduler;
+using bess::Scheduler;
 
 int num_workers = 0;
 std::thread worker_threads[Worker::kMaxWorkers];
@@ -440,12 +440,12 @@ WorkerPauser::~WorkerPauser() {
         int ret = m->OnEvent(bess::Event::PreResume);
         modules_run.insert(m);
         if (ret == -ENOTSUP) {
-	  it = resume_modules.erase(it);
+          it = resume_modules.erase(it);
         } else {
-	  it++;
-	}
+          it++;
+        }
       } else {
-	it++;
+        it++;
       }
     }
     resume_worker(wid);

--- a/core/worker.cc
+++ b/core/worker.cc
@@ -64,7 +64,7 @@ Worker *volatile workers[Worker::kMaxWorkers];
 
 using bess::TrafficClassBuilder;
 using namespace bess::traffic_class_initializer_types;
-using bess::ResumeHookFactory;
+using bess::ResumeHookBuilder;
 
 std::list<std::pair<int, bess::TrafficClass *>> orphan_tcs;
 

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -400,18 +400,22 @@ message GetModuleInfoRequest {
 }
 
 message GetModuleInfoResponse {
+  message GateHook {
+    string class_name = 1;         /// gate hook class_name and
+    string hook_name = 2;          /// gate hook name
+  }
   message IGate {
     message OGate {
       uint64 ogate = 1;  /// Output gate of "previous" module
       string name = 2;   /// Name of "previous" module
     }
-    uint64 igate = 1;           /// Input gate ID
-    repeated OGate ogates = 2;  /// The list of upstream output gates
-    uint64 cnt = 3;             /// # of packet batches seen
-    uint64 pkts = 4;            /// # of packets seen
-    uint64 bytes = 5;            /// # of bytes seen
-    double timestamp = 6;       /// The time that cnt/pkts counters were read
-    repeated string hook_name = 7;         /// List of hooks per gate
+    uint64 igate = 1;                /// Input gate ID
+    repeated OGate ogates = 2;       /// The list of upstream output gates
+    uint64 cnt = 3;                  /// # of packet batches seen
+    uint64 pkts = 4;                 /// # of packets seen
+    uint64 bytes = 5;                /// # of bytes seen
+    double timestamp = 6;            /// The time that cnt/pkts counters were read
+    repeated GateHook gatehooks = 7;  /// List of gate hook
   }
   message OGate {
     uint64 ogate = 1;      /// Output gate ID
@@ -421,7 +425,7 @@ message GetModuleInfoResponse {
     double timestamp = 5;  /// The time thatcnt/pkts counters were read
     string name = 6;       /// Name of the "next" module it connects to
     uint64 igate = 7;      /// Input gate ID of the "next" module
-    repeated string hook_name = 8;         /// List of hooks per gate
+    repeated GateHook gatehooks = 8; /// List of gate hook
   }
   message Attribute {
     string name = 1;   /// Name of per-packet metadata attribute
@@ -552,13 +556,14 @@ message PcapngArg {
 
 
 message GateHookInfo {
-  string hook_name = 1;         /// Name of the hook
-  string module_name = 2;       /// Name of module
+  string class_name = 1;         /// Name of the hook
+  string hook_name = 2;         /// Name of the hook
+  string module_name = 3;       /// Name of module
   oneof gate {
-    int64 igate = 3;            /// Input gate index. All input gates if -1
-    int64 ogate = 4;            /// Output gate index. All output gates if -1
+    int64 igate = 4;            /// Input gate index. All input gates if -1
+    int64 ogate = 5;            /// Output gate index. All output gates if -1
   }
-  google.protobuf.Any arg = 5;  /// Hook-specific arguments
+  google.protobuf.Any arg = 6;  /// Hook-specific arguments
 }
 
 message ConfigureGateHookRequest {

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -571,6 +571,11 @@ message ConfigureGateHookRequest {
   bool enable = 2;
 }
 
+message ConfigureGateHookResponse {
+  Error error = 1;
+  string name = 2;  /// Name of the created gatehook (specified or default one)
+}
+
 message ListGateHooksResponse {
   Error error = 1;
   repeated GateHookInfo hooks = 2;

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -415,7 +415,8 @@ message GetModuleInfoResponse {
     uint64 pkts = 4;                 /// # of packets seen
     uint64 bytes = 5;                /// # of bytes seen
     double timestamp = 6;            /// The time that cnt/pkts counters were read
-    repeated GateHook gatehooks = 7;  /// List of gate hook
+    reserved 7; // repeated string hook_name = 7;
+    repeated GateHook gatehooks = 8;  /// List of gate hook
   }
   message OGate {
     uint64 ogate = 1;      /// Output gate ID
@@ -425,7 +426,8 @@ message GetModuleInfoResponse {
     double timestamp = 5;  /// The time thatcnt/pkts counters were read
     string name = 6;       /// Name of the "next" module it connects to
     uint64 igate = 7;      /// Input gate ID of the "next" module
-    repeated GateHook gatehooks = 8; /// List of gate hook
+    reserved 8; // repeated string hook_name = 7;
+    repeated GateHook gatehooks = 9; /// List of gate hook
   }
   message Attribute {
     string name = 1;   /// Name of per-packet metadata attribute
@@ -556,7 +558,7 @@ message PcapngArg {
 
 
 message GateHookInfo {
-  string class_name = 1;         /// Name of the hook
+  string class_name = 1;        /// Name of the hook class
   string hook_name = 2;         /// Name of the hook
   string module_name = 3;       /// Name of module
   oneof gate {

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -298,7 +298,7 @@ service BESSControl {
   rpc GetGateHookClassInfo (GetGateHookClassInfoRequest) returns (GetGateHookClassInfoResponse) {}
 
   /// Enable/Disable a gate hook.
-  rpc ConfigureGateHook (ConfigureGateHookRequest) returns (CommandResponse) {}
+  rpc ConfigureGateHook (ConfigureGateHookRequest) returns (ConfigureGateHookResponse) {}
 
   /// Enumerate all gatehook installed
   rpc ListGateHooks (EmptyRequest) returns (ListGateHooksResponse) {}


### PR DESCRIPTION
This PR is for support of installing multiple gatehooks of the same class type for a single gate. 
1) Now gatehooks also have it's own name with class name
2) If gatehook name is not given with creation request, the default name using name template is assigned
3) Multiple gatehooks for the same class type can be installed now
4) Necessary changes for gatehook request/response are made accordingly