### PR TITLE
Thread-safe track gatehook having per-worker statistics

### DIFF
--- a/core/gate_hooks/track.cc
+++ b/core/gate_hooks/track.cc
@@ -68,9 +68,11 @@ void Track::ProcessBatch(const bess::PacketBatch *batch) {
     return;
   }
 
+  uint64_t bytes = 0;
   for (size_t i = 0; i < cnt; i++) {
-    stat->bytes += batch->pkts()[i]->data_len() + kEthernetOverhead;
+    bytes += batch->pkts()[i]->data_len() + kEthernetOverhead;
   }
+  stat->bytes += bytes;
 }
 
 ADD_GATE_HOOK(Track, "count the packets and batches")

--- a/core/gate_hooks/track.cc
+++ b/core/gate_hooks/track.cc
@@ -44,9 +44,7 @@ const GateHookCommands Track::cmds = {{"reset", "EmptyArg",
 Track::Track()
     : bess::GateHook(Track::kName, Track::kPriority),
       track_bytes_(),
-      cnt_(),
-      pkts_(),
-      bytes_() {}
+      worker_stats_() {}
 
 CommandResponse Track::Init(const bess::Gate *, const bess::pb::TrackArg &arg) {
   track_bytes_ = arg.bits();
@@ -54,23 +52,24 @@ CommandResponse Track::Init(const bess::Gate *, const bess::pb::TrackArg &arg) {
 }
 
 CommandResponse Track::CommandReset(const bess::pb::EmptyArg &) {
-  cnt_ = 0;
-  pkts_ = 0;
-  bytes_ = 0;
+  worker_stats_ = {};
   return CommandSuccess();
 }
 
 void Track::ProcessBatch(const bess::PacketBatch *batch) {
+
+  TrackStats *stat = &worker_stats_[current_worker.wid()];
+
   size_t cnt = batch->cnt();
-  cnt_ += 1;
-  pkts_ += cnt;
+  stat->cnt += 1;
+  stat->pkts += cnt;
 
   if (!track_bytes_) {
     return;
   }
 
   for (size_t i = 0; i < cnt; i++) {
-    bytes_ += batch->pkts()[i]->data_len() + kEthernetOverhead;
+    stat->bytes += batch->pkts()[i]->data_len() + kEthernetOverhead;
   }
 }
 

--- a/core/gate_hooks/track.h
+++ b/core/gate_hooks/track.h
@@ -43,11 +43,29 @@ class Track final : public bess::GateHook {
 
   CommandResponse Init(const bess::Gate *, const bess::pb::TrackArg &);
 
-  uint64_t cnt() const { return cnt_; }
+  uint64_t cnt() const {
+    uint64_t cnt = 0;
+    for (int i = 0; i < Worker::kMaxWorkers; i++) {
+      cnt += worker_stats_[i].cnt;
+    }
+    return cnt;
+  }
 
-  uint64_t pkts() const { return pkts_; }
+  uint64_t pkts() const {
+    uint64_t pkts = 0;
+    for (int i = 0; i < Worker::kMaxWorkers; i++) {
+      pkts += worker_stats_[i].pkts;
+    }
+    return pkts;
+  }
 
-  uint64_t bytes() const { return bytes_; }
+  uint64_t bytes() const {
+    uint64_t bytes = 0;
+    for (int i = 0; i < Worker::kMaxWorkers; i++) {
+      bytes += worker_stats_[i].bytes;
+    }
+    return bytes;
+  }
 
   void set_track_bytes(bool track) { track_bytes_ = track; }
 
@@ -60,9 +78,13 @@ class Track final : public bess::GateHook {
 
  private:
   bool track_bytes_;
-  uint64_t cnt_;
-  uint64_t pkts_;
-  uint64_t bytes_;
+  struct alignas(64) TrackStats {
+    uint64_t cnt;
+    uint64_t pkts;
+    uint64_t bytes;
+  };
+
+  std::array<TrackStats, Worker::kMaxWorkers> worker_stats_;
 };
 
 #endif  // BESS_GATE_HOOKS_TRACK_


### PR DESCRIPTION
Track data-path can be accessed from multiple threads. With this PR, `track` has a per-thread storage to update and aggregate them when requesting the actual number.