### PR TITLE
make: correctly compile dpdk for nehalem

### DIFF
--- a/build.py
+++ b/build.py
@@ -323,6 +323,8 @@ def download_dpdk(quiet=False):
 def configure_dpdk():
     try:
         print('Configuring DPDK...')
+        # override RTE_MACHINE with the one in DPDK_BASE_CONFIG
+        cmd("sed -i '/CONFIG_RTE_MACHINE/s/^/#/g' %s/config/defconfig_x86_64-native-linuxapp-gcc" % DPDK_DIR)
         cmd('cp -f %s %s' % (DPDK_BASE_CONFIG, DPDK_FINAL_CONFIG))
 
         check_kernel_headers()


### PR DESCRIPTION
While RTE_MACHINE is set to "nhm" (nehalem) in deps/dpdk-17.11_common_linuxapp,
it is overridden by deps/dpdk-17.11/config/defconfig_x86_64-native-linuxapp-gcc
(as RTE_MACHINE=native). This causes issues if you compile BESS on a machine
with a newer microarchitecture than the machine that will run it (e.g.,
compiling on newer skylake-based machines for a haswell-based machine). This
changes comments out RTE_MACHINE=native before configuring DPDK. DPDK is now
forced to compile for nehalem.