### PR TITLE
Optimize the size of build container.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - sudo gem install ffi fpm
   - pip2 install --user grpcio==1.10 scapy codecov
   - pip3 install --user grpcio==1.10 scapy coverage
-  - "[[ ${COVERAGE:-0} == 0 ]] || sudo apt-get install -y g++-7"  # install gcov-7
+  - "[[ ${COVERAGE:-0} == 0 ]] || sudo apt-get install -y gcc-7"  # install gcov-7
   - "[[ ${SANITIZE:-0} == 0 ]] || sudo apt-get install -y llvm-3.8"
   - ln -s /build/dpdk-17.11 deps
   - "docker pull nefelinetworks/bess_build:latest${TAG_SUFFIX} | cat"  # cat suppresses progress bars

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -1,5 +1,7 @@
 # vim: syntax=dockerfile
 
+# Bionic Beaver (18.04) does not require ppa repositories for any packages
+# we need, such as g++-7, clang-6.0, ansible, grpc, etc.
 ARG BASE_IMAGE=ubuntu:bionic
 FROM ${BASE_IMAGE}
 

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -5,28 +5,32 @@
 ARG BASE_IMAGE=ubuntu:bionic
 FROM ${BASE_IMAGE}
 
-# Install Ansible
-RUN apt-get -q update
-RUN apt-get install -y software-properties-common
-RUN apt-add-repository -y ppa:ansible/ansible
-RUN apt-get -q update
-RUN apt-get install -y ansible git
+RUN echo "APT::Install-Recommends false;" >> /etc/apt/apt.conf.d/00recommends && \
+	echo "APT::Install-Suggests false;" >> /etc/apt/apt.conf.d/00recommends && \
+	echo "APT::AutoRemove::RecommendsImportant false;" >> /etc/apt/apt.conf.d/00recommends && \
+	echo "APT::AutoRemove::SuggestsImportant false;" >> /etc/apt/apt.conf.d/00recommends
 
 COPY build-dep.yml /tmp/
 COPY kmod.yml /tmp/
 COPY ci.yml /tmp/
-RUN ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook /tmp/ci.yml -i "localhost," -c local && rm -rf /tmp/*
 
-RUN mkdir -p /build
+# Install dependency packages with Ansible
+RUN apt-get -q update && \
+	apt-get install -y ansible curl && \
+        ansible-playbook /tmp/ci.yml -i "localhost," -c local && \
+	apt-get purge -y ansible && \
+	apt-get autoremove -y && \
+	rm -rf /var/lib/apt/lists
+
+RUN mkdir -p /build/bess
 
 # Pre-build DPDK from the specified BESS branch
 ARG BESS_DPDK_BRANCH=master
-RUN cd /build && \
-	git clone -b ${BESS_DPDK_BRANCH} https://github.com/netsys/bess && \
-	cd /build/bess && \
+RUN cd /build/bess && \
+	curl -s -L https://github.com/NetSys/bess/archive/${BESS_DPDK_BRANCH}.tar.gz | tar zx --strip-components=1 && \
 	./build.py dpdk && \
 	mv /build/bess/deps/dpdk-17.11 /build/dpdk-17.11 && \
-	rm -rf /build/bess
+	rm -rf /build/bess /build/dpdk-17.11/build/build /build/dpdk-17.11/build/app
 
 ENV CCACHE_DIR=/tmp/ccache
 ENV CCACHE_COMPRESS=true

--- a/env/build-dep.yml
+++ b/env/build-dep.yml
@@ -1,8 +1,9 @@
 - hosts: all
   tags: build-dep
   tasks:
-    - apt_repository: repo='ppa:ubuntu-toolchain-r/test/ubuntu'
+    - apt_repository: repo='ppa:ubuntu-toolchain-r/test' codename={{ ansible_distribution_release }}
       become: true
+      when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 18
 
     - name: Install prerequisite packages
       apt: name={{item}} update_cache=yes

--- a/env/ci.yml
+++ b/env/ci.yml
@@ -11,18 +11,10 @@
 - hosts: all
   tags: ci
   tasks:
-    - apt_key: url='http://apt.llvm.org/llvm-snapshot.gpg.key'
-      become: true
-
-    - apt_repository: repo='deb http://apt.llvm.org/{{ ansible_distribution_release }}/ llvm-toolchain-{{ ansible_distribution_release }}-6.0 main'
-      become: true
-
     - name: Install additional compilers for the build container
       apt: name={{item}} update_cache=yes
       become: true
       with_items:
-        - apt-transport-https
-        - ca-certificates
         - g++-8
         - clang-6.0
         - ccache

--- a/env/kmod.yml
+++ b/env/kmod.yml
@@ -8,5 +8,5 @@
         - apt-transport-https
         - ca-certificates
         - build-essential
-        - linux-generic
+        - linux-headers-generic
         - linux-headers-{{ansible_kernel}}


### PR DESCRIPTION
This PR reduces the size of Docker build container from 2.9GB down to 0.9GB, reducing ~1.5 mins for downloading the image from Travis CI. The changes include:

* eliminate the use of git in the container (git has lots of dependencies)
* purge temporary files
* remove non-essential directories of prebuilt DPDK
* use non-ppa packages for g++-8 and clang-6.0