### PR TITLE
build.py: Do not delete bess symlink

### DIFF
--- a/build.py
+++ b/build.py
@@ -441,7 +441,6 @@ def build_all():
 def do_clean():
     print('Cleaning up...')
     cmd('make -C core clean')
-    cmd('rm -f bin/bessd')
     cmd('make -C core/kmod clean')
     for path in ('pybess/builtin_pb', 'pybess/plugin_pb'):
         cmd('rm -rf '


### PR DESCRIPTION
Since commit 8293a9fa195c("build: do not create bessd symlink at compile
time"), the symlink is committed to the repo.