### PR TITLE
vport: Fix strncpy warning

### DIFF
--- a/core/drivers/vport.cc
+++ b/core/drivers/vport.cc
@@ -502,11 +502,14 @@ CommandResponse VPort::Init(const bess::pb::VPortArg &arg) {
     goto fail;
   }
 
+  const char *ifname_src;
   if (arg.ifname().length()) {
-    strncpy(ifname_, arg.ifname().c_str(), IFNAMSIZ);
+    ifname_src = arg.ifname().c_str();
   } else {
-    strncpy(ifname_, name().c_str(), IFNAMSIZ);
+    ifname_src = name().c_str();
   }
+  strncpy(ifname_, ifname_src, IFNAMSIZ - 1);
+  ifname_[IFNAMSIZ - 1] = '\0';
 
   if (arg.cpid_case() == bess::pb::VPortArg::kDocker) {
     err = docker_container_pid(arg.docker(), &container_pid_);


### PR DESCRIPTION
g++-8.2.0 complains about strncpy with the following warning:

```
drivers/vport.cc: In member function ‘CommandResponse VPort::Init(const bess::pb::VPortArg&)’:
drivers/vport.cc:508:12: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 16 equals destination size [-Werror=stringop-truncation]
     strncpy(ifname_, name().c_str(), IFNAMSIZ);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/vport.cc:506:12: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 16 equals destination size [-Werror=stringop-truncation]
     strncpy(ifname_, arg.ifname().c_str(), IFNAMSIZ);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
Error: drivers/vport.o
```

Fix the usage of strncpy with an explicit null termination. This was not
a problem for arg.ifname(), because the code checks the length
immediately above, but the compiler is not smart enough to understand
that.