### PR TITLE
makefile: allow plugins to inject .mk files

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -180,6 +180,9 @@ endif
 
 -include extra*.mk
 
+# Each plugin may have their own extra Makefile snippets
+-include $(addsuffix /extra*.mk,$(PLUGINS))
+
 # Given PLUGINS (set in extra.mk), set up PROTO_PLUGINS,
 # DRIVER_PLUGINS, MODULE_PLUGINS, and UTIL_PLUGINS.  Note
 # that paths in extra.mk are already absolute.  Use


### PR DESCRIPTION
Plugins may require some special software prerequisites, target dependencies, or compiler flags to build their own modules. Since it would be impractical to provide generic mechanisms to meet such plugin-specific requirements without some heavy lifting, this PR instead introduces a hacky way; it enables plugins to implant their extra*.mk files into the main Makefile.