### PR TITLE
cuckoo_map: allow template argument deduction

### DIFF
--- a/core/utils/cuckoo_map.h
+++ b/core/utils/cuckoo_map.h
@@ -210,10 +210,14 @@ class CuckooMap {
   // On success returns a pointer to the inserted entry, nullptr otherwise.
   // NOTE: when Insert() returns nullptr, the copy/move constructor of `V` may
   // not be called.
-  template <typename VV>
-  Entry* Insert(const K& key, VV&& value, const H& hasher = H(),
+  Entry* Insert(const K& key, const V& value, const H& hasher = H(),
                 const E& eq = E()) {
-    return DoEmplace(key, hasher, eq, std::forward<VV>(value));
+    return DoEmplace(key, hasher, eq, value);
+  }
+
+  Entry* Insert(const K& key, V&& value, const H& hasher = H(),
+                const E& eq = E()) {
+    return DoEmplace(key, hasher, eq, std::move(value));
   }
 
   // Emplace/update-in-place a key value pair


### PR DESCRIPTION
The forwarding reference `VV&&` cannot be directly deduced from a braced-init-list function parameter. This limitation makes `c.Insert(key, {2, 3, 4});` fail, although it looks completely benign (C++ standard 14.8.2.5 (5.6)). Instead one must specify the type of the value like `c.Insert<std::vector<int>>(key, {2, 3, 4});`. It is unnecessarily verbose since the value type is already known to be `V`, but the compiler does not know about the relationship between `V` and `VV`.

This patch replaces the use of forwarding reference `VV&&` with two separate copy/move references. It does make the code a bit more verbose on the library side, but not on the user side.