### PR TITLE
Modified core/Makefile to check for installed g++7 on Ubuntu 16.04

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -55,7 +55,12 @@ CXXVERSION := $(shell $(CXX) -dumpversion)
 
 ifeq "$(CXXCOMPILER)" "g++"
   ifneq "$(shell printf '$(CXXVERSION)\n7' | sort -V | head -n1)" "7"
-    $(error g++ 7 or higher is required. Use container_build.py if newer g++ is not available.)
+  # check for installed g++-7 on Ubuntu 16.04LTS
+    ifeq "$(shell printf '$(shell $(CXX)-7 -dumpversion)\n7' | sort -V | head -n1)" "7"
+      CXX := g++-7
+    else
+      $(error g++ 7 or higher is required. Use container_build.py if newer g++ is not available.)
+    endif
   endif
 endif
 


### PR DESCRIPTION
This is the quick and dirty modification that allows compiling of bess on a new Ubuntu 16.04 installation by checking if g++7 is installed separate from the default g++ on the system. 

Per 17 USC § 105 this code is public domain. For additional details see the [DoD CIO Open Source Software FAQ](https://dodcio.defense.gov/Open-Source-Software-FAQ/#Q:_Can_government_employees_contribute_code_to_open_source_software_projects.3F)