### PR TITLE
Support UDP flows and Fill L3/L4 checksums

### DIFF
--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -40,6 +40,8 @@
 #include "../utils/endian.h"
 #include "../utils/random.h"
 
+#define MAX_TEMPLATE_SIZE 1536
+
 typedef std::pair<uint64_t, struct flow *> Event;
 typedef std::priority_queue<Event, std::vector<Event>, std::greater<Event>>
     EventQueue;
@@ -114,8 +116,8 @@ class FlowGen final : public Module {
   void PopulateInitialFlows();
 
   CommandResponse UpdateBaseAddresses();
-  bess::Packet *FillUDPPacket(struct flow *f);
-  bess::Packet *FillTCPPacket(struct flow *f);
+  bess::Packet *FillUdpPacket(struct flow *f);
+  bess::Packet *FillTcpPacket(struct flow *f);
   void GeneratePackets(Context *ctx, bess::PacketBatch *batch);
 
   CommandResponse ProcessArguments(const bess::pb::FlowGenArg &arg);
@@ -130,9 +132,9 @@ class FlowGen final : public Module {
   // Priority queue of future events
   EventQueue events_;
 
-  char *tmpl_;
+  unsigned char tmpl_[MAX_TEMPLATE_SIZE] = {};
   int template_size_;
-  uint16_t l4_proto_;
+  uint8_t l4_proto_;
 
   Random rng_;
 

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -121,6 +121,7 @@ class FlowGen final : public Module {
   void GeneratePackets(Context *ctx, bess::PacketBatch *batch);
 
   CommandResponse ProcessArguments(const bess::pb::FlowGenArg &arg);
+  CommandResponse ProcessUpdatableArguments(const bess::pb::FlowGenArg &arg);
 
   // the number of concurrent flows
   int active_flows_;

--- a/core/modules/flowgen.h
+++ b/core/modules/flowgen.h
@@ -73,7 +73,7 @@ class FlowGen final : public Module {
         generated_flows_(),
         flows_free_(),
         events_(),
-        templ_(),
+        tmpl_(),
         template_size_(),
         rng_(),
         arrival_(),
@@ -114,7 +114,8 @@ class FlowGen final : public Module {
   void PopulateInitialFlows();
 
   CommandResponse UpdateBaseAddresses();
-  bess::Packet *FillPacket(struct flow *f);
+  bess::Packet *FillUDPPacket(struct flow *f);
+  bess::Packet *FillTCPPacket(struct flow *f);
   void GeneratePackets(Context *ctx, bess::PacketBatch *batch);
 
   CommandResponse ProcessArguments(const bess::pb::FlowGenArg &arg);
@@ -129,8 +130,9 @@ class FlowGen final : public Module {
   // Priority queue of future events
   EventQueue events_;
 
-  char *templ_;
+  char *tmpl_;
   int template_size_;
+  uint16_t l4_proto_;
 
   Random rng_;
 


### PR DESCRIPTION
With this PR, `Flowgen` supports UDP flows along with existing TCP flows, and also fill L3/L4 checksums appropriately.