### PR TITLE
Add protobuf package to pip installation list

### DIFF
--- a/env/runtime.yml
+++ b/env/runtime.yml
@@ -15,6 +15,7 @@
     - name: Install list of Python packages
       pip:
         name:
+          - protobuf
           - grpcio
           - scapy
         state: latest


### PR DESCRIPTION
Somewhat surprisingly, `protobuf` is not a prerequisite of `grpcio`, so we have to list it explicitly.