### PR TITLE
bessctl: Set __file__ of .bess scripts

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -844,6 +844,7 @@ def _do_run_file(cli, conf_file):
 
     new_globals = {
         '__builtins__': __builtins__,
+        '__file__': conf_file,
         'bess': cli.bess,
         'ConfError': ConfError,
         '__bess_env__': __bess_env__,


### PR DESCRIPTION
With this PR, bess conifg scripts can get their exact location.