### PR TITLE
copy_bench: Fix compilation with libbenchmark 1.4.1

### DIFF
--- a/core/utils/copy_bench.cc
+++ b/core/utils/copy_bench.cc
@@ -173,4 +173,4 @@ BENCHMARK_REGISTER_F(CopyFixture, CopySloppy)->Apply(SetArguments);
 BENCHMARK_REGISTER_F(CopyFixture, RteMemcpy)->Apply(SetArguments);
 BENCHMARK_REGISTER_F(CopyFixture, Memcpy)->Apply(SetArguments);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();


### PR DESCRIPTION
With libbenchmark 1.4.1 the semicolon is required.

https://github.com/google/benchmark/pull/495