### PR TITLE
scheduler: Reset silent_drops in context before running task

### DIFF
--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -266,6 +266,7 @@ class DefaultScheduler : public Scheduler {
       current_worker.set_current_ns(ctx->current_ns);
 
       ctx->task = leaf->task();
+      ctx->silent_drops = 0;
 
       // Run.
       auto ret = (*ctx->task)(ctx);


### PR DESCRIPTION
silent_drops were not reset, causing a constant increase of deadend
packets even if no packets were processed:

```
localhost:10514 $ show worker
   Worker ID    Status  CPU core  # of TCs    Deadend pkts
           0   RUNNING         0         6     14946328395
```

This commit fixes it for the DefaultScheduler.

The ExperimentalScheduler doesn't appear to account for those at all.