### PR TITLE
 kmod: fix ndo_select_queue prototype for linux-4.19 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Eran Gampel
 * Tamás Lévai
 * Matthew Mussomele
+* Kevin Mitchell

--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -615,10 +615,15 @@ static u16 sn_select_queue(struct net_device *netdev, struct sk_buff *skb)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv)
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv,
+			   select_queue_fallback_t fallback)
+#else
+static u16 sn_select_queue(struct net_device *netdev,
+			   struct sk_buff *skb,
+			   struct net_device *sb_dev,
 			   select_queue_fallback_t fallback)
 #endif
 {


### PR DESCRIPTION
Just add a branch to the existing #ifdef. There is no use of the changed
argument inside the function, so there are no substantive changes
required.

I verified it now builds on 4.9, 4.18 and 4.19