### PR TITLE
packet.h: Use refcnt_ when AVX isn't available (fixes #853)

### DIFF
--- a/core/packet.h
+++ b/core/packet.h
@@ -343,7 +343,7 @@ inline void Packet::Free(Packet **pkts, size_t cnt) {
     const Packet *pkt = pkts[i];
 
     if (unlikely(pkt->pool_ != pool || !pkt->is_simple() ||
-                 pkt->refcnt() != 1)) {
+                 pkt->refcnt_ != 1)) {
       goto slow_path;
     }
   }


### PR DESCRIPTION
I'd like to regularly compile bess on an old machine without AVX.  I'd also like to use the upstream code without any local modification.  So, I propose this PR, which is what @sangjinhan suggested as a quick fix in the discussion of issue #853.

Thank you.