### PR TITLE
bessctl: add reconnection to 'daemon start'

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -150,7 +150,7 @@ def run_cli(instream=sys.stdin):
 
     try:
         s.connect()
-    except BESS.APIError as e:
+    except BESS.RPCError as e:
         if cli.interactive:
             cli.ferr.write(str(e) + '\n')
             cli.ferr.write('Perhaps bessd daemon is not running locally? '

--- a/bessctl/measurement_utils.py
+++ b/bessctl/measurement_utils.py
@@ -48,7 +48,7 @@ def get_local_bess_handle():
     bess = BESS()
     try:
         bess.connect()
-    except BESS.APIError:
+    except BESS.RPCError:
         raise Exception('BESS is not running')
     return bess
 

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -146,7 +146,7 @@ class BESS(object):
     class RPCError(Exception):
         pass
 
-    # errors from this class itself
+    # errors from this class itself or misuse of this class
     class APIError(Exception):
         pass
 
@@ -214,7 +214,7 @@ class BESS(object):
                                    grpc.ChannelConnectivity.SHUTDOWN,
                                    self.BROKEN_CHANNEL]:
                 self.disconnect()
-                raise self.APIError(
+                raise self.RPCError(
                     'Connection to {} failed'.format(grpc_url))
             time.sleep(0.1)
 


### PR DESCRIPTION
When bessctl tries to connects to the bessd gRPC server, it may be rejected with TCP RST if it is not fully up yet. Retry for 3 seconds in case of this transient failure. Since the time window of this race condition is very short (might happen only for a few milliseconds), 3 seconds should be enough.