### PR TITLE
module_test: fix invalid IPv4 address format

### DIFF
--- a/bessctl/module_tests/exact_match.py
+++ b/bessctl/module_tests/exact_match.py
@@ -60,15 +60,15 @@ class BessExactMatchTest(BessModuleTestCase):
         # exact match for ip src and dst
         em = ExactMatch(fields=[{'offset': 26, 'num_bytes': 4},
                                 {'offset': 30, 'num_bytes': 4}])
-        em.add(fields=[{'value_bin': socket.inet_aton('65.43.21.00')},
+        em.add(fields=[{'value_bin': socket.inet_aton('65.43.21.0')},
                        {'value_bin': socket.inet_aton('12.34.56.78')}], gate=1)
-        em.add(fields=[{'value_bin': socket.inet_aton('00.12.34.56')},
+        em.add(fields=[{'value_bin': socket.inet_aton('0.12.34.56')},
                        {'value_bin': socket.inet_aton('12.34.56.78')}], gate=2)
         em.set_default_gate(gate=3)
 
-        pkt1 = get_tcp_packet(sip='65.43.21.00', dip='12.34.56.78')
-        pkt2 = get_tcp_packet(sip='00.12.34.56', dip='12.34.56.78')
-        pkt_nomatch = get_tcp_packet(sip='00.12.33.56', dip='12.34.56.78')
+        pkt1 = get_tcp_packet(sip='65.43.21.0', dip='12.34.56.78')
+        pkt2 = get_tcp_packet(sip='0.12.34.56', dip='12.34.56.78')
+        pkt_nomatch = get_tcp_packet(sip='0.12.33.56', dip='12.34.56.78')
 
         pkt_outs = self.run_module(em, 0, [], [0])
         self.assertEquals(len(pkt_outs[0]), 0)

--- a/bessctl/module_tests/wildcard_match.py
+++ b/bessctl/module_tests/wildcard_match.py
@@ -68,8 +68,8 @@ class BessWildcardMatchTest(BessModuleTestCase):
         wm = WildcardMatch(fields=[{'offset': 26, 'num_bytes': 4},
                                    {'offset': 30, 'num_bytes': 4}])
         ip_ip = vstring([0xff, 0xff, 0xff, 0xff], [0xff, 0xff, 0xff, 0xff])
-        sip1 = '65.43.21.00'
-        sip2 = '00.12.34.56'
+        sip1 = '65.43.21.0'
+        sip2 = '0.12.34.56'
         dip = '12.34.56.78'
         s1d_pair = [{'value_bin': socket.inet_aton(sip1)},
                     {'value_bin': socket.inet_aton(dip)}]
@@ -81,9 +81,9 @@ class BessWildcardMatchTest(BessModuleTestCase):
         wm.add(gate=2, priority=1, masks=ip_ip, values=s2d_pair)
         wm.set_default_gate(gate=3)
 
-        pkt1 = get_tcp_packet(sip='65.43.21.00', dip='12.34.56.78')
-        pkt2 = get_tcp_packet(sip='00.12.34.56', dip='12.34.56.78')
-        pkt_nomatch = get_tcp_packet(sip='00.12.33.56', dip='12.34.56.78')
+        pkt1 = get_tcp_packet(sip='65.43.21.0', dip='12.34.56.78')
+        pkt2 = get_tcp_packet(sip='0.12.34.56', dip='12.34.56.78')
+        pkt_nomatch = get_tcp_packet(sip='0.12.33.56', dip='12.34.56.78')
 
         pkt_outs = self.run_module(wm, 0, [], range(4))
         for i in range(4):


### PR DESCRIPTION
recent versions of scapy seem to use libc `inet_pton` whenever possible
in place of `inet_aton`. `inet_pton` is much stricter when it comes to
formatting; "65.43.21.00" is illegal because of two 0s.