### PR TITLE
mempool: Alloc hugepages from any socket

### DIFF
--- a/core/memory_test.cc
+++ b/core/memory_test.cc
@@ -173,7 +173,7 @@ TEST(DmaMemoryPoolTest, Dump) {
     return;
   }
 
-  DmaMemoryPool pool(128 * 1024 * 1024, 0);
+  DmaMemoryPool pool(128 * 1024 * 1024, -1);
   ASSERT_TRUE(pool.Initialized());
 
   std::cout << pool.Dump();
@@ -185,7 +185,7 @@ TEST(DmaMemoryPoolTest, AlignedAlloc) {
     return;
   }
 
-  DmaMemoryPool pool(128 * 1024 * 1024, 0);
+  DmaMemoryPool pool(128 * 1024 * 1024, -1);
   ASSERT_TRUE(pool.Initialized());
 
   // should be able to alloc 128 * 1MB blocks...
@@ -216,7 +216,7 @@ TEST(DmaMemoryPoolTest, UnalignedAlloc) {
     return;
   }
 
-  DmaMemoryPool pool(128 * 1024 * 1024, 0);
+  DmaMemoryPool pool(128 * 1024 * 1024, -1);
   size_t initial_free_bytes = pool.TotalFreeBytes();
   ASSERT_TRUE(pool.Initialized());
 


### PR DESCRIPTION
... when it is being done for unittest. For test purposes it doesn't matter which node the hugepage came from. Unittest sometimes fails especially when memory is being highly utilized, even if hugepages are available from NUMA nodes other than node 0.