### PR TITLE
 build: disable `close_fds` for submake call

### DIFF
--- a/build.py
+++ b/build.py
@@ -397,6 +397,7 @@ def build_bess():
     generate_protobuf_files()
 
     print('Building BESS daemon...')
+    sys.stdout.flush()
     cmd('bin/bessctl daemon stop 2> /dev/null || true', shell=True)
     cmd('rm -f core/bessd')  # force relink as DPDK might have been rebuilt
     nproc = int(cmd('nproc', quiet=True))
@@ -415,7 +416,7 @@ def build_kmod():
         if not is_kernel_header_installed():
             print('"kernel-headers-%s" is not available. Build may fail.' %
                   kernel_release)
-
+    sys.stdout.flush()
     cmd('sudo -n rmmod bess 2> /dev/null || true', shell=True)
     try:
         cmd('make -C core/kmod')

--- a/build.py
+++ b/build.py
@@ -59,7 +59,9 @@ def cmd(cmd, quiet=False, shell=False):
     if not quiet:
         quiet = os.getenv('V') is None
 
-    kwargs = {'universal_newlines': True}
+    kwargs = {'universal_newlines': True,
+              'close_fds': False}  # For Python >3.2, default is True
+
     if quiet:
         kwargs['stdout'] = subprocess.PIPE
         kwargs['stderr'] = subprocess.STDOUT


### PR DESCRIPTION
Unlike Python 2, the default value for the close_fds argument for Popen is true. This is problematic in case we want to use the GNU make jobserver, since it requires that file descriptors (pipe fds to jobserver) remain open in the submake process.