### PR TITLE
drivers/pmd: fix stats reporting for net_e1000_igb

### DIFF
--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -408,10 +408,11 @@ void PMDPort::CollectStats(bool reset) {
 
   port_stats_.inc.dropped = stats.imissed;
 
-  // i40e PMD driver, ixgbevf and net_bonding vdevs don't support per-queue
-  // stats
+  // i40e/net_e1000_igb PMD drivers, ixgbevf and net_bonding vdevs don't support
+  // per-queue stats
   if (driver_ == "net_i40e" || driver_ == "net_i40e_vf" ||
-      driver_ == "net_ixgbe_vf" || driver_ == "net_bonding") {
+      driver_ == "net_ixgbe_vf" || driver_ == "net_bonding" ||
+      driver_ == "net_e1000_igb") {
     // NOTE:
     // - if link is down, tx bytes won't increase
     // - if destination MAC address is incorrect, rx pkts won't increase


### PR DESCRIPTION
I've been testing against I350 and I354 and they appear to not report per-queue stats. I'm not sure about 82575, 82576, 82580, I210, I211, and DH89xx though.