### PR TITLE
mem: do not test zero-byte allocation

### DIFF
--- a/core/memory_test.cc
+++ b/core/memory_test.cc
@@ -225,7 +225,7 @@ TEST(DmaMemoryPoolTest, UnalignedAlloc) {
 
   for (int k = 0; k < 5; k++) {
     while (true) {
-      size_t size_to_alloc = rng.GetRange(1024 * 1024);
+      size_t size_to_alloc = rng.GetRange(1024 * 1024) + 1;
       void *ptr = pool.Alloc(size_to_alloc);
 
       if (ptr == nullptr) {


### PR DESCRIPTION
The allocator is supposed to reject memory block allocation with size 0. The unittest used to often try it when rand() % 1048576 == 0.