### PR TITLE
kmod: adapt ndo_select_queue prototype to linux-4.19

### DIFF
--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -615,10 +615,15 @@ static u16 sn_select_queue(struct net_device *netdev, struct sk_buff *skb)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv)
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv,
+			   select_queue_fallback_t fallback)
+#else
+static u16 sn_select_queue(struct net_device *netdev,
+			   struct sk_buff *skb,
+			   struct net_device *sb_dev,
 			   select_queue_fallback_t fallback)
 #endif
 {


### PR DESCRIPTION
Resubmitting this patch with since I have a signed CLA.

There is no use of the changed argument in the function, so there are no
substantive changes required.