### PR TITLE
Fix vport kernel panic when network namespace is closed

### DIFF
--- a/core/kmod/sn_ethtool.c
+++ b/core/kmod/sn_ethtool.c
@@ -141,4 +141,5 @@ const struct ethtool_ops sn_ethtool_ops = {
 	.get_strings 		= sn_ethtool_get_strings,
 	.get_ethtool_stats 	= sn_ethtool_get_ethtool_stats,
 	.get_drvinfo		= sn_ethtool_get_drvinfo,
+	.get_link		= ethtool_op_get_link,
 };

--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -902,6 +902,11 @@ fail_free:
 
 void sn_release_netdev(struct sn_device *dev)
 {
+	if (!dev) {
+		log_err("called with a null pointer");
+		return;
+	}
+
 	rtnl_lock();
 
 	/* it is possible that the netdev has already been unregistered */


### PR DESCRIPTION
The network interface may be terminated involuntarily (i.e., other than calling SN_IOC_RELEASE_HOSTNIC). If that has happened, filp->private_data ends up pointing to freed memory space. When it is accessed by SN_IOC_RELEASE_HOSTNIC later, kernel may crash due to page fault. The problem can be easily reproduced when a network namespace is closed. VPort belonging to that namespace are also forcibly closed, thus ioctl(SN_IOC_RELEASE_HOSTNIC) later causes kernel panic.

This patch defers the memory space until its associated file/inode is released. One can test it by running `bessctl run port/vport_latency`.