### PR TITLE
Add an HTTP server for pipeline monitoring

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -435,6 +435,15 @@ def get_var_attrs(cli, var_token, partial_word):
             var_desc = 'determines whether to pause workers for the operation (default: "pause")'
             var_candidates = ['pause', 'no_pause']
 
+        elif var_token == '[HOST]':
+            var_type = 'host'
+            var_desc = 'HTTP server address to listen on (default: "localhost")'
+
+        elif var_token == '[PORT_NUMBER]':
+            var_type = 'int'
+            var_desc = 'HTTP server address to listen on (default: 5000)'
+
+
     except socket.error as e:
         if e.errno in [errno.ECONNRESET, errno.EPIPE]:
             cli.bess.disconnect()
@@ -2095,3 +2104,18 @@ def show_system_packets(cli, socket):
         cli.fout.write('\tring_count: {}\n'.format(dump.ring_count))
         cli.fout.write('\tring_free_count: {}\n'.format(dump.ring_free_count))
         cli.fout.write('\tring_bytes: {}\n'.format(dump.ring_bytes))
+
+
+@cmd('http [HOST] [PORT_NUMBER]', 'Run an HTTP server')
+def http(cli, host, port):
+    host = host or 'localhost'
+    port = port or 5000
+
+    try:
+        import server
+    except ImportError:
+        raise cli.CommandError('Failed to load server ("pip install flask"?)')
+
+    server.app.env = 'development'
+    server.app.bess = cli.bess
+    server.app.run(host=host, port=int(port))

--- a/bessctl/server.py
+++ b/bessctl/server.py
@@ -1,0 +1,26 @@
+import json
+
+from flask import Flask, jsonify
+from google.protobuf.json_format import MessageToJson
+
+app = Flask(__name__)
+app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
+
+
+@app.route('/')
+def get_html():
+    return app.send_static_file('graph.html')
+
+
+@app.route('/pipeline')
+def get_pipeline():
+    if not app.bess.is_connected():
+        app.bess.disconnect()
+        app.bess.connect(grpc_url=app.bess.peer)
+    modules = {}
+    for m_pb in app.bess.list_modules().modules:
+        # NOTE: MessageToJson will convert 64-bit integers to strings!
+        info_pb = app.bess.get_module_info(m_pb.name)
+        modules[m_pb.name] = json.loads(
+            MessageToJson(info_pb, including_default_value_fields=True))
+    return jsonify(modules)

--- a/bessctl/static/graph.html
+++ b/bessctl/static/graph.html
@@ -5,14 +5,14 @@
     <title>BESS Pipeline</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
   </head>
-  <body>
+  <body class="d-flex flex-column vh-100">
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
 
     <script src="https://d3js.org/d3.v4.min.js"></script>
     <script src="https://d3js.org/d3-fetch.v1.min.js"></script>
-    <script src="https://unpkg.com/viz.js@1.8.0/viz.js" type="javascript/worker"></script>
-    <script src="https://unpkg.com/d3-graphviz@1.4.0/build/d3-graphviz.min.js"></script>
+    <script src="https://unpkg.com/viz.js@1.8.2/viz.js" type="javascript/worker"></script>
+    <script src="https://unpkg.com/d3-graphviz@2.6.1/build/d3-graphviz.min.js"></script>
 
     <script src="/static/pipeline.js"></script>
 
@@ -34,9 +34,9 @@
       </div>
     </nav>
 
-    <div class="container-fluid" id="main">
-      <div class="row py-3">
-        <div class="col-12 col-md-3 col-lg-2">
+    <div class="container-fluid py-3 d-flex flex-grow-1">
+      <div class="row d-flex flex-grow-1 mr-0">
+        <div class="col-12 col-sm-4 col-lg-3 col-xl-2">
           <div class="border rounded bg-light p-3">
             <div class="form-group">
               <label class="form-label"> Options </label>
@@ -106,8 +106,8 @@
           </div>
         </div>  <!-- col-2 -->
 
-        <div class="col-12 col-md-9 col-lg-10 d-flex justify-content-center" id="graph">
-          <div id="toasts" style="position: absolute; top: 0; right: 1em;">
+        <div class="col-12 col-sm-8 col-lg-9 col-xl-10 border align-self-stretch" id="graph">
+          <div id="toasts" style="position: absolute; top: 1em; right: 1em;">
             <div class="toast" id="toast_disconnected" data-autohide="false">
               <div class="toast-header text-white bg-danger">
                 <strong>Error</strong>
@@ -127,7 +127,7 @@
               </div>
             </div>
           </div>
-        </div>
+        </div>  <!-- col-10 -->
       </div>
     </div>
 
@@ -150,6 +150,10 @@
       function refresh() {
         // remove previous (but not-yet-fired) timer
         clearTimeout(timer);
+
+        graphviz.width($('#graph').width());
+        graphviz.height($('#graph').height());
+
         d3.json('pipeline').then(function(modules) {
           update_toast('#toast_disconnected', false);
           update_toast('#toast_emptypipeline', jQuery.isEmptyObject(modules));
@@ -171,7 +175,7 @@
       }
 
       var t = d3.transition().duration(500).ease(d3.easeLinear);
-      var graphviz = d3.select("#graph").graphviz()
+      var graphviz = d3.select("#graph").graphviz({zoomScaleExtent: [0.3, 2.0]});
     </script>
   </body>
 </html>

--- a/bessctl/static/graph.html
+++ b/bessctl/static/graph.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>BESS Pipeline</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+  </head>
+  <body>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
+
+    <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script src="https://d3js.org/d3-fetch.v1.min.js"></script>
+    <script src="https://unpkg.com/viz.js@1.8.0/viz.js" type="javascript/worker"></script>
+    <script src="https://unpkg.com/d3-graphviz@1.4.0/build/d3-graphviz.min.js"></script>
+
+    <script src="/static/pipeline.js"></script>
+
+    <nav class="navbar navbar-expand-md navbar-dark bg-primary sticky-top">
+      <a class="navbar-brand" href="#">BESS</a>
+      <div class="collapse navbar-collapse">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item active">
+            <a class="nav-link" href="#"> Pipeline </a>
+          </li>
+          <li class="nav-item disabled">
+            <a class="nav-link" href="#"> Port </a>
+          </li>
+          <li class="nav-item disabled">
+            <a class="nav-link" href="#"> TC </a>
+          </li>
+        </ul>
+        <button type="button" class="btn btn-light" onclick="refresh()">Refresh now</button>
+      </div>
+    </nav>
+
+    <div class="container-fluid" id="main">
+      <div class="row py-3">
+        <div class="col-12 col-md-3 col-lg-2">
+          <div class="border rounded bg-light p-3">
+            <div class="form-group">
+              <label class="form-label"> Options </label>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="checkbox" class="form-check-input" name="autorefresh" checked>
+                  Auto refresh
+                </label>
+              </div>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="checkbox" class="form-check-input" name="humanreadable" checked>
+                  Human readable
+                </label>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label"> Mode </label>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="mode" value="rate" checked>
+                  Current rate
+                </label>
+              </div>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="mode" value="total">
+                  Total
+                </label>
+              </div>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="mode" value="none">
+                  None
+                </label>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label"> Metric </label>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="metric" value="pkts" checked>
+                  Packets
+                </label>
+              </div>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="metric" value="bits">
+                  Bits
+                </label>
+              </div>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="metric" value="cnt">
+                  Batches
+                </label>
+              </div>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" name="metric" value="batchsize">
+                  Packets/batch
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>  <!-- col-2 -->
+
+        <div class="col-12 col-md-9 col-lg-10 d-flex justify-content-center" id="graph">
+          <div id="toasts" style="position: absolute; top: 0; right: 1em;">
+            <div class="toast" id="toast_disconnected" data-autohide="false">
+              <div class="toast-header text-white bg-danger">
+                <strong>Error</strong>
+                <span class="spinner-border spinner-border-sm ml-auto" role="status"></span>
+              </div>
+              <div class="toast-body">
+                Disconnected from the BESS daemon. Reconnecting...
+              </div>
+            </div>
+            <div class="toast" id="toast_emptypipeline" data-autohide="false">
+              <div class="toast-header text-white bg-info">
+                <strong>Warning</strong>
+                <span class="spinner-grow spinner-grow-sm ml-auto" role="status"></span>
+              </div>
+              <div class="toast-body">
+                Pipeline is empty. No module is found.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      var timer = setTimeout(refresh, 1000);
+
+      function update_toast(selector, show_if) {
+        elem = $(selector)
+        if (show_if) {
+          if (!elem.hasClass('show')) {
+            elem.prependTo('#toasts').toast('show');
+          }
+        } else {
+          if (elem.hasClass('show')) {
+            elem.toast('hide');
+          }
+        }
+      }
+
+      function refresh() {
+        // remove previous (but not-yet-fired) timer
+        clearTimeout(timer);
+        d3.json('pipeline').then(function(modules) {
+          update_toast('#toast_disconnected', false);
+          update_toast('#toast_emptypipeline', jQuery.isEmptyObject(modules));
+          dot_str = graph_to_dot(modules);
+          graphviz.transition(t).renderDot(dot_str);
+          if ($('input[name="autorefresh"]').is(':checked')) {
+            timer = setTimeout(refresh, 1000);
+          }
+        }).catch(function(error) {
+          update_toast('#toast_disconnected', true);
+          update_toast('#toast_emptypipeline', false);
+          timer = setTimeout(refresh, 3000);
+        });
+      }
+
+      var knobs = document.querySelectorAll('.form-check-input');
+      for (var i = 0; i < knobs.length; i++) {
+        knobs[i].addEventListener('click', refresh);
+      }
+
+      var t = d3.transition().duration(500).ease(d3.easeLinear);
+      var graphviz = d3.select("#graph").graphviz()
+    </script>
+  </body>
+</html>

--- a/bessctl/static/graph.html
+++ b/bessctl/static/graph.html
@@ -135,7 +135,7 @@
       var timer = setTimeout(refresh, 1000);
 
       function update_toast(selector, show_if) {
-        elem = $(selector)
+        var elem = $(selector)
         if (show_if) {
           if (!elem.hasClass('show')) {
             elem.prependTo('#toasts').toast('show');

--- a/bessctl/static/pipeline.js
+++ b/bessctl/static/pipeline.js
@@ -1,0 +1,177 @@
+// colorscheme:
+// #01295f cool black
+// #437f97 queen blue
+// #849324 olive drab
+// #ffb30f dark tangerine
+// #fd151b vivid red
+
+// (node name, gate type, gate ID) -> [(timestamp, pkts, bits, cnt), ...]
+var stats = {};
+
+var opt_field;
+var opt_mode;
+
+function gates_to_str(gates, gate_type) {
+    var ret = '';
+
+    for (i = 0; i < gates.length; i++) {
+        gate_num = gates[i][gate_type]
+        if (gate_type == 'igate') {
+            color = '#437f97'
+        } else {
+            color = '#01295f'
+        }
+        ret += `<td port="${gate_type}${gate_num}" border="0" cellpadding="0" bgcolor="${color}"><font color="#ffffff" point-size="6">${gate_num}</font></td>
+`;
+    }
+
+    return `
+      <tr>
+        <td border="0" cellspacing="0" cellpadding="0">
+          <table border="0" cellborder="0" cellspacing="0" cellpadding="0">
+            <tr>
+              ${ret}
+            </tr>
+          </table>
+        </td>
+      </tr>`;
+}
+
+function add_datapoints(stats, module_name, gates, gate_type) {
+    for (var i = 0; i < gates.length; i++) {
+        var gate = gates[i];
+        key = [module_name, gate_type, gate[gate_type]];
+        value = {timestamp: gate.timestamp,
+                 bits: Number(gate.bytes * 8),
+                 pkts: Number(gate.pkts),
+                 cnt: Number(gate.cnt),
+                 batchsize: gate.cnt ? gate.pkts / gate.cnt : 0};
+        if (!(key in stats)) {
+            stats[key] = [value];
+        } else {
+            stats[key].push(value);
+        }
+    }
+}
+
+function get_edge_label(stats) {
+    var num_stats = stats.length;
+    var value = stats[num_stats - 1];
+    var label = '?'
+
+    if (value.timestamp > 0) {
+        switch (opt_mode) {
+            case 'total':
+                label = value[opt_field];
+                break;
+            case 'rate':
+                if (num_stats >= 2) {
+                    last = stats[num_stats - 2];
+                    time_diff = value.timestamp - last.timestamp;
+                    if (opt_field == 'batchsize') {
+                        packets = value.pkts - last.pkts;
+                        batches = value.cnt - last.cnt;
+                        label = batches ? packets / batches : 'N/A';
+                    } else {
+                        value_diff = value[opt_field] - last[opt_field];
+                        label = Math.round(value_diff / time_diff);
+                    }
+                }
+                break;
+            case 'none':
+                return '';
+            default:
+                throw new Error('Unknown mode ' + opt_mode);
+        }
+    }
+
+    if ((typeof label == 'number') && opt_humanreadable) {
+        var unit = ' ';
+        if (opt_mode == 'rate') {
+            if (label > 1000000000) {
+                label /= 1000000000;
+                unit += 'G';
+            } else if (label > 1000000) {
+                label /= 1000000;
+                unit += 'M';
+            } else if (label > 1000) {
+                label /= 1000;
+                unit += 'k';
+            }
+            if (opt_field == 'pkts') {
+                unit += 'pps';
+            } else if (opt_field == 'bits') {
+                unit += 'bps';
+            }
+        }
+        label = label.toLocaleString('en-US', {maximumFractionDigits: 2}) + unit;
+    }
+
+    // We need this HTML hack to give background color to edge labels
+    return `<<table border="0" cellpadding="0"><tr><td bgcolor="white">${label}</td></tr></table>>`;
+}
+
+function graph_to_dot(modules) {
+    opt_field = document.querySelector('input[name="metric"]:checked').value;
+    opt_mode = document.querySelector('input[name="mode"]:checked').value;
+    opt_humanreadable = document.querySelector('input[name="humanreadable"]').checked;
+
+    var nodes = ''
+    for (var module_name in modules) {
+        module = modules[module_name];
+        // add_datapoints(stats, module_name, module.igates, 'igate')
+        add_datapoints(stats, module_name, module.ogates, 'ogate')
+
+        module.show_igates = module.igates.length > 1 ||
+            (module.igates.length == 1 && module.igates[0].igate != 0);
+        module.show_ogates = module.ogates.length > 1 ||
+            (module.ogates.length == 1 && module.ogates[0].ogate != 0);
+
+        var desc = module.desc ? `<font point-size="9">${module.desc}</font>` : '';
+        var igates = module.show_igates ? gates_to_str(module.igates, 'igate') : '';
+        var ogates = module.show_ogates ? gates_to_str(module.ogates, 'ogate') : '';
+
+        nodes += `
+  ${module_name} [shape=plaintext label=
+    <<table port="mod" border="1" cellborder="0" cellspacing="0" cellpadding="1">
+      ${igates}<tr>
+        <td width="60">${module_name}</td>
+      </tr>
+      <tr>
+        <td><font color="#888888" point-size="9"><i>${module.mclass}</i></font></td>
+      </tr>
+      <tr>
+        <td>${desc}</td>
+      </tr>
+      ${ogates}</table>>];
+`;
+    }
+
+    var edges = ''
+    for (module_name in modules) {
+        module = modules[module_name];
+        for (var i = 0; i < module.ogates.length; i++) {
+            var gate = module.ogates[i];
+            var dst_module = modules[gate.name];
+            var out_port = module.show_ogates ? `ogate${gate.ogate}:s` : 'mod';
+            var in_port = dst_module.show_igates ? `igate${gate.igate}:n` : 'mod';
+
+            var label = get_edge_label(stats[[module_name, 'ogate', gate.ogate]]);
+            if (label != '') {
+                label = ` [label=${label}]`;
+            }
+
+            edges += `  "${module_name}":${out_port} -> "${gate.name}":${in_port}${label}\n`;
+        }
+    }
+
+    ret = `digraph G {
+  graph [ rankdir=TB ];
+  node [ fontsize=12 ];
+  edge [ fontsize=9, color="#ffb30f", arrowsize=0.5, labeldistance=1.2 ];
+${nodes}
+${edges}
+}
+`
+    return ret
+}

--- a/bessctl/static/pipeline.js
+++ b/bessctl/static/pipeline.js
@@ -10,12 +10,13 @@ var stats = {};
 
 var opt_field;
 var opt_mode;
+var opt_humanreadable;
 
 function gates_to_str(gates, gate_type) {
     var ret = '';
 
-    for (i = 0; i < gates.length; i++) {
-        gate_num = gates[i][gate_type]
+    for (var i = 0; i < gates.length; i++) {
+        var gate_num = gates[i][gate_type]
         if (gate_type == 'igate') {
             color = '#437f97'
         } else {
@@ -40,8 +41,8 @@ function gates_to_str(gates, gate_type) {
 function add_datapoints(stats, module_name, gates, gate_type) {
     for (var i = 0; i < gates.length; i++) {
         var gate = gates[i];
-        key = [module_name, gate_type, gate[gate_type]];
-        value = {timestamp: gate.timestamp,
+        var key = [module_name, gate_type, gate[gate_type]];
+        var value = {timestamp: gate.timestamp,
                  bits: Number(gate.bytes * 8),
                  pkts: Number(gate.pkts),
                  cnt: Number(gate.cnt),
@@ -66,14 +67,14 @@ function get_edge_label(stats) {
                 break;
             case 'rate':
                 if (num_stats >= 2) {
-                    last = stats[num_stats - 2];
-                    time_diff = value.timestamp - last.timestamp;
+                    var last = stats[num_stats - 2];
+                    var time_diff = value.timestamp - last.timestamp;
                     if (opt_field == 'batchsize') {
-                        packets = value.pkts - last.pkts;
-                        batches = value.cnt - last.cnt;
+                        var packets = value.pkts - last.pkts;
+                        var batches = value.cnt - last.cnt;
                         label = batches ? packets / batches : 'N/A';
                     } else {
-                        value_diff = value[opt_field] - last[opt_field];
+                        var value_diff = value[opt_field] - last[opt_field];
                         label = Math.round(value_diff / time_diff);
                     }
                 }
@@ -116,9 +117,10 @@ function graph_to_dot(modules) {
     opt_mode = document.querySelector('input[name="mode"]:checked').value;
     opt_humanreadable = document.querySelector('input[name="humanreadable"]').checked;
 
-    var nodes = ''
+    var nodes = '';
     for (var module_name in modules) {
-        module = modules[module_name];
+	var module = modules[module_name];
+	// no need to collect igate data since we don't show them yet.
         // add_datapoints(stats, module_name, module.igates, 'igate')
         add_datapoints(stats, module_name, module.ogates, 'ogate')
 
@@ -147,9 +149,9 @@ function graph_to_dot(modules) {
 `;
     }
 
-    var edges = ''
+    var edges = '';
     for (module_name in modules) {
-        module = modules[module_name];
+        var module = modules[module_name];
         for (var i = 0; i < module.ogates.length; i++) {
             var gate = module.ogates[i];
             var dst_module = modules[gate.name];
@@ -165,7 +167,7 @@ function graph_to_dot(modules) {
         }
     }
 
-    ret = `digraph G {
+    return `digraph G {
   graph [ rankdir=TB ];
   node [ fontsize=12 ];
   edge [ fontsize=9, color="#ffb30f", arrowsize=0.5, labeldistance=1.2 ];
@@ -173,5 +175,4 @@ ${nodes}
 ${edges}
 }
 `
-    return ret
 }

--- a/env/runtime.yml
+++ b/env/runtime.yml
@@ -18,6 +18,7 @@
           - protobuf
           - grpcio
           - scapy
+          - flask
         state: latest
       become: true
 


### PR DESCRIPTION
`show pipeline` / `monitor pipeline` is a useful tool to monitor the BESS dataflow graph. However, the ascii diagram quickly becomes illegible as the graph grows in a non-trivial manner. One can generate an SVG file in the bessctl CLI, but it is cumbersome and not capable of real-time monitoring.

This PR creates a new bessctl command, `bessctl http [address] [port]`, which runs an HTTP server to show the current dataflow graph. Other features, such as port/TC monitoring, may be added later.

![Screenshot from 2019-03-11 22-29-29](https://user-images.githubusercontent.com/1916976/54176807-7bb2d980-444d-11e9-99c5-3b6cbf55fee0.png)