### PR TITLE
Adds L2 mac-learning to L2Forward module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Eran Gampel
 * Tamás Lévai
 * Matthew Mussomele
+* Tim Rozet

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -60,10 +60,11 @@ struct l2_table {
 class L2Forward final : public Module {
  public:
   static const gate_idx_t kNumOGates = MAX_GATES;
+  static const gate_idx_t kNumIGates = MAX_GATES;
 
   static const Commands cmds;
 
-  L2Forward() : Module(), l2_table_(), default_gate_() {
+  L2Forward() : Module(), l2_table_(), default_gate_(), learn_() {
     max_allowed_workers_ = Worker::kMaxWorkers;
   }
 
@@ -84,6 +85,7 @@ class L2Forward final : public Module {
  private:
   struct l2_table l2_table_;
   gate_idx_t default_gate_;
+  int learn_;
 };
 
 #endif  // BESS_MODULES_L2FORWARD_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -628,6 +628,7 @@ message IPLookupArg {
 message L2ForwardArg {
   int64 size = 1; /// Configures the forwarding hash table -- total number of hash table entries.
   int64 bucket = 2; /// Configures the forwarding hash table -- total number of slots per hash value.
+  bool learn = 3; /// Whether or not to activate learning mode.
 }
 
 /**


### PR DESCRIPTION
New learn mode for the L2Forward module allows MAC address learning. The
incoming packets are added to the L2 FIB with the source MAC address and
incoming gate. Therefore multiple input gates are now allowed for this
module, and should be used when using learn mode. The output gates used
should mirror the same ID used for input gates for learn to work
correctly. For example:

tcam::L2Forward(learn=True)

inaf = PortInc(port=p0)
in86 = PortInc(port=p1)

inaf -> 1:tcam
in86 -> 2:tcam

outaf = PortOut(port=p0)
out86 = PortOut(port=p1)

tcam:2 -> out86
tcam:1 -> outaf