### PR TITLE
Mapping a logical internal/external ports to actual bess gates in nat

### DIFF
--- a/bessctl/conf/perftest/nat.bess
+++ b/bessctl/conf/perftest/nat.bess
@@ -49,6 +49,6 @@ Source() \
     -> nat::NAT(ext_addrs=nat_config)
 
 if bidirectional:
-    nat -> MACSwap() -> IPSwap() -> 1:nat:1 -> Sink()
+    nat:1 -> MACSwap() -> IPSwap() -> 1:nat:0 -> Sink()
 else:
-    nat -> Sink()
+    nat:1 -> Sink()

--- a/bessctl/conf/samples/nat.bess
+++ b/bessctl/conf/samples/nat.bess
@@ -51,7 +51,7 @@ packets = [gen_packet(scapy.UDP, '172.16.100.1', '10.0.0.1'),
 
 # dynamic NAT configuration
 nat::NAT(ext_addrs=[{'ext_addr': '192.168.0.1'}, {'ext_addr': '192.168.0.2'}])
-Source() -> Rewrite(templates=packets) -> 0:nat:0 -> MACSwap() -> IPSwap() -> 1:nat:1 -> Sink()
+Source() -> Rewrite(templates=packets) -> 0:nat:1 -> MACSwap() -> IPSwap() -> 1:nat:0 -> Sink()
 
 # static NAT configuration
 static_nat::StaticNAT(pairs=[
@@ -60,4 +60,4 @@ static_nat::StaticNAT(pairs=[
     {'int_range': {'start': '192.168.0.0', 'end': '192.168.255.255'},
      'ext_range': {'start': '66.77.0.0', 'end': '66.77.255.255'}},
 ])
-Source() -> Rewrite(templates=packets) -> 0:static_nat:0 -> MACSwap() -> IPSwap() -> 1:static_nat:1 -> Sink()
+Source() -> Rewrite(templates=packets) -> 0:static_nat:1 -> MACSwap() -> IPSwap() -> 1:static_nat:0 -> Sink()

--- a/bessctl/module_tests/nat.py
+++ b/bessctl/module_tests/nat.py
@@ -63,8 +63,8 @@ class BessNatTest(BessModuleTestCase):
         pkt_orig = eth / ip_orig / l4_orig / l7
 
         pkt_outs = self.run_module(module, 0, [pkt_orig], [0, 1])
-        self.assertEquals(len(pkt_outs[0]), 1)
-        pkt_natted = pkt_outs[0][0]
+        self.assertEquals(len(pkt_outs[1]), 1)
+        pkt_natted = pkt_outs[1][0]
 
         # The NAT module can choose an arbitrary source port/id.
         # We cannot test it, we have to read from the output.
@@ -81,9 +81,9 @@ class BessNatTest(BessModuleTestCase):
         pkt_reply = eth / ip_reply / l4_reply / l7
 
         pkt_outs = self.run_module(module, 1, [pkt_reply], [0, 1])
-        self.assertEquals(len(pkt_outs[1]), 1)
+        self.assertEquals(len(pkt_outs[0]), 1)
         self.assertSamePackets(eth / ip_unnatted / _swap_l4(l4_orig) / l7,
-                               pkt_outs[1][0])
+                               pkt_outs[0][0])
 
     def test_nat_udp(self):
         nat_config = [{'ext_addr': '192.168.1.1'}]

--- a/bessctl/module_tests/placement_constraint.py
+++ b/bessctl/module_tests/placement_constraint.py
@@ -62,7 +62,7 @@ class BessModuleConstraintTest(BessModuleTestCase):
         # Swap src/dst IP addresses / ports
         ip = IPSwap()
 
-        Source() -> 0:nat:0 -> mac -> ip -> 1:nat:1 -> Sink()
+        Source() -> 0:nat:1 -> mac -> ip -> 1:nat:0 -> Sink()
 
         self.assertFalse(bess.check_constraints())
 
@@ -74,7 +74,7 @@ class BessModuleConstraintTest(BessModuleTestCase):
         # Swap src/dst IP addresses / ports
         ip = IPSwap()
 
-        Source() -> 0:nat:0 -> Queue() -> ip -> 1:nat:1 -> Sink()
+        Source() -> 0:nat:1 -> Queue() -> ip -> 1:nat:0 -> Sink()
 
         self.assertFalse(bess.check_constraints())
 
@@ -85,8 +85,8 @@ class BessModuleConstraintTest(BessModuleTestCase):
         bess.add_worker(0, 0)
         bess.add_worker(1, 1)
         nat = NAT(ext_addrs=nat_config)
-        src0 -> 0: nat: 0 -> Sink()
-        src1 -> 1: nat: 1 -> Sink()
+        src0 -> 0: nat: 1 -> Sink()
+        src1 -> 1: nat: 0 -> Sink()
         src0.attach_task(wid=0)
         src1.attach_task(wid=1)
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -324,7 +324,7 @@ inline void Stamp(Ipv4 *ip, void *l4, const Endpoint &before,
 
 template <NAT::Direction dir>
 inline void NAT::DoProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  gate_idx_t ogate_idx = static_cast<gate_idx_t>(dir);
+  gate_idx_t ogate_idx = dir == kForward ? 1 : 0;
   int cnt = batch->cnt();
   uint64_t now = ctx->current_ns;
 

--- a/core/modules/static_nat.cc
+++ b/core/modules/static_nat.cc
@@ -145,7 +145,7 @@ static inline void UpdateChecksum(bess::utils::Ipv4 *ip, uint32_t incr) {
 
 template <StaticNAT::Direction dir>
 inline void StaticNAT::DoProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  gate_idx_t ogate_idx = static_cast<gate_idx_t>(dir);
+  gate_idx_t ogate_idx = dir == kForward ? 1 : 0;
   int cnt = batch->cnt();
 
   for (int i = 0; i < cnt; i++) {


### PR DESCRIPTION
In nat module, packet flows are looks like
 internal --> 0:nat:0 --> external (forward direction)
 external --> 1:nat:1 --> internal (reverse direction)

This PR makes the bess gates are correspondint with the logical nat
ports, 0 for internal, and 1 for external, so the new packet flows will
looks like
 internal --> 0:nat:1 --> external (forward direction)
 external --> 1:nat:0 --> internal (reverse direction)