### PR TITLE
Fixes to kernel module

### DIFF
--- a/core/kmod/sn_host.c
+++ b/core/kmod/sn_host.c
@@ -267,8 +267,10 @@ again:
 	buf_queue = NULL;
 
 	for (i = 0; i < buf->tx_queue_cnt; i++)
-		if (buf->queue_arr[i].queue == queue)
+		if (buf->queue_arr[i].queue == queue) {
 			buf_queue = &buf->queue_arr[i];
+			break;
+		}
 
 	if (!buf_queue) {
 		if (buf->tx_queue_cnt == MAX_TX_BUFFER_QUEUE_CNT) {

--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -611,10 +611,15 @@ static u16 sn_select_queue(struct net_device *netdev, struct sk_buff *skb)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv)
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,18,0)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv,
+			   select_queue_fallback_t fallback)
+#else
+static u16 sn_select_queue(struct net_device *netdev,
+			   struct sk_buff *skb,
+			   struct net_device *sb_dev,
 			   select_queue_fallback_t fallback)
 #endif
 {


### PR DESCRIPTION
1. Minor performance optimization in the queue selection
2. Fix to make BESS build on 4.18+ kernels.