### PR TITLE
Fix vport initialization on recent kernels

### DIFF
--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -785,6 +785,8 @@ int sn_create_netdev(void *bar, struct sn_device **dev_ret)
 		return -ENOMEM;
 	}
 
+	netdev->priv_flags |= IFF_NO_QUEUE;
+
 	if (strcmp(conf->ifname, "") == 0)
 		name = "sn%d";
 	else


### PR DESCRIPTION
The default queue discipline on Linux is pfifo. It will fail
to initialize rendering the device unusable on recent kernels
if the device queue depth is zero. All devices with queue depth
of zero must also specify that they are IFF_NO_QUEUE in order
to select the noop scheduler.

This is from some point in 4.x onwards (I have not had the time
to trace the exact kernel revision).

Signed-off-by: Anton Ivanov <anton.ivanov@cambridgegreys.com>