### PR TITLE
Fix gtest include path

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -470,7 +470,7 @@ $(eval $(call BUILD, \
         TEST_CXX, \
         gtest-all.o, \
         $(GTEST_DIR)/src/gtest-all.cc, \
-        $(CXX) -o $$@ -c $$< -isystem $(GTEST_DIR) $$(CXXFLAGS) $$(DEPFLAGS)))
+        $(CXX) -o $$@ -c $$< -isystem $(GTEST_DIR)/include $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
         BENCH_CXX, \


### PR DESCRIPTION
We currently pass `$(GTEST_DIR)` as an include path using `-isystem`.
This should really be `$(GTEST_DIR)/include` (see
https://github.com/google/googletest/tree/master/googletest), since the
header files live inside the include directory. This doesn't show up as
an issue for many people since the files are also in `/usr/include` when
installed using the system path but is a problem when this is not the
case.