### PR TITLE
Fix kmod in 5.0+ kernels

### DIFF
--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -884,7 +884,11 @@ int sn_register_netdev(void *bar, struct sn_device *dev)
 	}
 
 	/* interface "UP" by default */
-	dev_open(dev->netdev);
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0))
+    dev_open(dev->netdev);
+#else
+    dev_open(dev->netdev, NULL);
+#endif
 
 	strcpy(conf->ifname, dev->netdev->name);
 


### PR DESCRIPTION
5.0 kernels included a new parameter in the dev_open()
function. Fixed by adding a #if/#else block for the
newer kernel and pass new parameter as NULL.

Signed-off-by: Sam Hague <shague@gmail.com>