### PR TITLE
Make L2Forward and Replicate changes thread safe and transactional

### DIFF
--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -588,12 +588,6 @@ static int sn_start_xmit(struct sk_buff *skb, struct net_device *netdev)
 		return NET_XMIT_DROP;
 	}
 
-	if (unlikely(skb_shinfo(skb)->frag_list)) {
-		log_err("frag_list is not NULL!\n");
-		dev_kfree_skb(skb);
-		return NET_XMIT_DROP;
-	}
-
 	if (unlikely(txq >= dev->num_txq)) {
 		log_err("invalid txq=%u\n", txq);
 		dev_kfree_skb(skb);
@@ -688,9 +682,8 @@ extern const struct ethtool_ops sn_ethtool_ops;
 
 static void sn_set_offloads(struct net_device *netdev)
 {
-	netif_set_gso_max_size(netdev, SNBUF_DATA);
-
 #if 0
+	netif_set_gso_max_size(netdev, SNBUF_DATA);
 	netdev->hw_features = NETIF_F_SG |
 			      NETIF_F_IP_CSUM |
 			      NETIF_F_RXCSUM |
@@ -699,8 +692,8 @@ static void sn_set_offloads(struct net_device *netdev)
 			      NETIF_F_LRO |
 			      NETIF_F_GSO_UDP_TUNNEL;
 #else
-	/* Disable all offloading features for now */
-	netdev->hw_features = 0;
+	/* We can safely enable SG, the rest needs work */
+	netdev->hw_features = (NETIF_F_SG | NETIF_F_FRAGLIST);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0))

--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -610,6 +610,10 @@ static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv,
 			   select_queue_fallback_t fallback)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,2,0)
+static u16 sn_select_queue(struct net_device *netdev,
+			   struct sk_buff *skb,
+			   struct net_device *sb_dev)
 #else
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -350,6 +350,8 @@ static int l2_flush(struct l2_table *l2tbl) {
   memset(l2tbl->table, 0,
          sizeof(struct l2_entry) * l2tbl->size * l2tbl->bucket);
 
+  l2tbl->count = 0;
+
   return 0;
 }
 
@@ -557,6 +559,8 @@ const Commands L2Forward::cmds = {
      MODULE_CMD_FUNC(&L2Forward::CommandLookup), Command::THREAD_SAFE},
     {"populate", "L2ForwardCommandPopulateArg",
      MODULE_CMD_FUNC(&L2Forward::CommandPopulate), Command::THREAD_UNSAFE},
+    {"clear", "EmptyArg",
+     MODULE_CMD_FUNC(&L2Forward::CommandClear), Command::THREAD_SAFE},
 };
 
 struct l2_table *L2Forward::ActiveTable(void) {
@@ -785,6 +789,16 @@ CommandResponse L2Forward::CommandDelete(
 CommandResponse L2Forward::CommandSetDefaultGate(
     const bess::pb::L2ForwardCommandSetDefaultGateArg &arg) {
   default_gate_ = arg.gate();
+  return CommandSuccess();
+}
+
+CommandResponse L2Forward::CommandClear(
+    const bess::pb::EmptyArg &) {
+
+  
+  l2_flush(L2Forward::BackupTable());
+  L2Forward::SwapTables();
+  l2_flush(L2Forward::BackupTable());
   return CommandSuccess();
 }
 

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -599,6 +599,7 @@ CommandResponse L2Forward::Init(const bess::pb::L2ForwardArg &arg) {
 
   ret = l2_init(L2Forward::BackupTable(), size, bucket);
   if (ret != 0) {
+    l2_deinit(L2Forward::ActiveTable());
     return CommandFailure(-ret,
                           "initialization of backup table failed with argument "
                           "size: '%d' bucket: '%d'",

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -89,6 +89,9 @@ class L2Forward final : public Module {
 
   struct l2_table *ActiveTable(void);
   struct l2_table *BackupTable(void);
+
+  bool source_check;
+
   void SwapTables(void);
   int DoAdd(const bess::pb::L2ForwardCommandAddArg &arg);
   int DoDelete(const bess::pb::L2ForwardCommandDeleteArg &arg);

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -90,6 +90,8 @@ class L2Forward final : public Module {
   struct l2_table *ActiveTable(void);
   struct l2_table *BackupTable(void);
   void SwapTables(void);
+  int DoAdd(const bess::pb::L2ForwardCommandAddArg &arg);
+  int DoDelete(const bess::pb::L2ForwardCommandDeleteArg &arg);
 };
 
 #endif  // BESS_MODULES_L2FORWARD_H_

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -33,6 +33,7 @@
 
 #include "../module.h"
 #include "../pb/module_msg.pb.h"
+#include <atomic>
 
 #if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
 #error this code assumes little endian architecture (x86)
@@ -82,8 +83,13 @@ class L2Forward final : public Module {
       const bess::pb::L2ForwardCommandPopulateArg &arg);
 
  private:
-  struct l2_table l2_table_;
+  struct l2_table l2_table_[2];
   gate_idx_t default_gate_;
+  std::atomic_int active_table;
+
+  struct l2_table *ActiveTable(void);
+  struct l2_table *BackupTable(void);
+  void SwapTables(void);
 };
 
 #endif  // BESS_MODULES_L2FORWARD_H_

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -93,6 +93,7 @@ class L2Forward final : public Module {
   bool source_check;
 
   void SwapTables(void);
+  void RollBack(void);
   int DoAdd(const bess::pb::L2ForwardCommandAddArg &arg);
   int DoDelete(const bess::pb::L2ForwardCommandDeleteArg &arg);
 };

--- a/core/modules/l2_forward.h
+++ b/core/modules/l2_forward.h
@@ -81,6 +81,8 @@ class L2Forward final : public Module {
   CommandResponse CommandLookup(const bess::pb::L2ForwardCommandLookupArg &arg);
   CommandResponse CommandPopulate(
       const bess::pb::L2ForwardCommandPopulateArg &arg);
+  CommandResponse CommandClear(
+      const bess::pb::EmptyArg &);
 
  private:
   struct l2_table l2_table_[2];

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -85,7 +85,7 @@ void Replicate::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
         EmitPacket(ctx, newpkt, gates_[j + active_gates * kMaxGates]);
       }
     }
-    EmitPacket(ctx, tocopy, 0);
+    EmitPacket(ctx, tocopy, gates_[active_gates * kMaxGates]);
   }
 }
 

--- a/core/modules/replicate.h
+++ b/core/modules/replicate.h
@@ -32,6 +32,7 @@
 
 #include "../module.h"
 #include "../pb/module_msg.pb.h"
+#include <atomic>
 
 class Replicate final : public Module {
  public:
@@ -55,9 +56,10 @@ class Replicate final : public Module {
       const bess::pb::ReplicateCommandSetGatesArg &arg);
 
  private:
-  // ID number for each egress gate.
-  gate_idx_t gates_[kMaxGates];
+  // ID number for each egress gate - twice.
+  gate_idx_t gates_[kMaxGates * 2];
   // The total number of output gates
+  std::atomic_int active_gates;
   int ngates_;
 };
 

--- a/core/modules/replicate.h
+++ b/core/modules/replicate.h
@@ -60,7 +60,7 @@ class Replicate final : public Module {
   gate_idx_t gates_[kMaxGates * 2];
   // The total number of output gates
   std::atomic_int active_gates;
-  int ngates_;
+  int ngates_[2];
 };
 
 #endif  // BESS_MODULES_RELICATE_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -628,6 +628,7 @@ message IPLookupArg {
 message L2ForwardArg {
   int64 size = 1; /// Configures the forwarding hash table -- total number of hash table entries.
   int64 bucket = 2; /// Configures the forwarding hash table -- total number of slots per hash value.
+  bool source_check = 3; /// Configures the rpf check, if true, "unexpected" packets are dropped to default gate
 }
 
 /**

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -220,6 +220,12 @@ message L2ForwardCommandPopulateArg {
 }
 
 /**
+ * This message type clears the L2 Table
+ */
+message L2ForwardCommandClearArg {
+}
+
+/**
  * The Measure module measures and collects latency/jitter data for packets
  * annotated by a Timestamp module. Note that Timestamp and Measure module must reside
  * on the server for accurate measurement (as a result, the most typical use case is


### PR DESCRIPTION
Fixes #920 for L2Forward and Replicate, demonstrates a pattern applicable as a fix to most other modules.

Introduces a very common check for "port hopping" into the L2Forward module and defines it as an option

Adds the clear command to the L2Forward module so it is functionally similar to the IPForward module.