### PR TITLE
Makefile: fix missing protobuf dependency

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -385,7 +385,7 @@ $(eval $(call BUILD, \
 $(eval $(call BUILD, \
         CXX, \
         pb/%.pb.o, \
-        pb/%.pb.cc, \
+        pb/%.pb.cc $(PROTO_HEADERS), \
         $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $(PERMISSIVE) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \
@@ -403,7 +403,7 @@ $(eval $(call BUILD, \
 $(eval $(call BUILD, \
         UTILS_CXX, \
         utils/%.o, \
-        utils/%.cc, \
+        utils/%.cc $(PROTO_HEADERS), \
         $(CXX) -o $$@ -c $$< $$(CXXFLAGS) $$(DEPFLAGS)))
 
 $(eval $(call BUILD, \


### PR DESCRIPTION
Two dependencies are added:

1. Since protobuf files can reference each other, their corresponding
   C++ header files should reflect that dependency

2. Files in utils/ do not (and should not) include protobuf headers.
   However this rule may not apply to utils/ files in plugins, so we
   need to generate pb.h/.cc files before compiling utils/