### PR TITLE
do not crash even if rte_socket_id() fails

### DIFF
--- a/core/worker.cc
+++ b/core/worker.cc
@@ -291,7 +291,14 @@ void *Worker::Run(void *_arg) {
   wid_ = arg->wid;
   core_ = arg->core;
   socket_ = rte_socket_id();
-  CHECK_GE(socket_, 0);  // shouldn't be SOCKET_ID_ANY (-1)
+
+  // For some reason, rte_socket_id() does not return a correct NUMA ID.
+  // Nevertheless, BESS should not crash.
+  if (socket_ == SOCKET_ID_ANY) {
+    LOG(WARNING) << "rte_socket_id() returned -1 for " << arg->core;
+    socket_ = 0;
+  }
+
   fd_event_ = eventfd(0, 0);
   CHECK_GE(fd_event_, 0);
 


### PR DESCRIPTION
In some container scenario, it was observed that rte_socket_id() may return -1 (SOCKET_ID_ANY)