### PR TITLE
improve PortOut thread safety

### DIFF
--- a/bessctl/conf/port/s2p.bess
+++ b/bessctl/conf/port/s2p.bess
@@ -29,8 +29,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 dpdk_ports = int($BESS_PORTS!'1')
+num_queues = int($BESS_QUEUES!'1')
+num_workers = int($BESS_WORKERS!'1')
 print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
 
+for i in range(num_workers):
+	bess.add_worker(wid=i, core=i)
+
+sources = [Source() for _ in range(num_workers)]
+
 for i in range(dpdk_ports):
-    p = PMDPort(port_id=i)
-    Source() -> PortOut(port=p.name)
+    p = PMDPort(port_id=i, num_inc_q=num_queues, num_out_q=num_queues)
+    pout = PortOut(port=p.name)
+    for src in sources:
+        src -> pout

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -34,6 +34,7 @@
 #include "../module.h"
 #include "../pb/module_msg.pb.h"
 #include "../port.h"
+#include "../utils/mcslock.h"
 #include "../worker.h"
 
 class PortOut final : public Module {
@@ -41,7 +42,10 @@ class PortOut final : public Module {
   static const gate_idx_t kNumIGates = MAX_GATES;
   static const gate_idx_t kNumOGates = 0;
 
-  PortOut() : Module(), port_(), available_queues_(), worker_queues_() {}
+  PortOut()
+      : Module(), port_(), worker_queues_(), queue_users_(), queue_locks_() {
+    max_allowed_workers_ = Worker::kMaxWorkers;
+  }
 
   CommandResponse Init(const bess::pb::PortOutArg &arg);
 
@@ -56,9 +60,12 @@ class PortOut final : public Module {
  private:
   Port *port_;
 
-  std::vector<queue_t> available_queues_;
-
   int worker_queues_[Worker::kMaxWorkers];
+
+  // Number of workers mapped to a given queue. Indexed by queue number
+  int queue_users_[MAX_QUEUES_PER_DIR];
+
+  mcslock_t queue_locks_[MAX_QUEUES_PER_DIR];
 };
 
 #endif  // BESS_MODULES_PORTOUT_H_


### PR DESCRIPTION
This is kind of an RFC. The included commits replace the ResumeHook based thread saftey introduced by #661 with per-queue locks and minimal transmit load balancing (modular division seems fast enough for now since it only happens once per-batch).

Using the benchmark below on an XXV710 and a 2.1GHz E5-2620 v4. The overhead is fairly low when there's no contention.

```
dpdk_ports = int($BESS_PORTS!'1')
qsize = int($BESS_QSIZE!'128')
num_queues = int($BESS_QUEUES!'1')
num_workers = int($BESS_WORKERS!'1')

for i in range(num_workers):
        bess.add_worker(wid=i, core=i)

sources = [Source() for _ in range(num_workers)]

print('Using %d DPDK ports... (envvar "BESS_PORTS")' % dpdk_ports)
print('RX/TX queue size: %d packets per queue' % qsize)
print('NOTE: not all DPDK ports support lookback mode')

for i in range(dpdk_ports):
                p = PMDPort(port_id=i,
                                        loopback=1,
                                        size_inc_q=qsize,
                                        size_out_q=qsize,
                                        num_inc_q=num_queues,
                                        num_out_q=num_queues)
                pout = PortOut(port=p.name)
                for src in sources:
                        src -> pout
                PortInc(port=p.name) -> Sink()
```

## Before the change
```
localhost:10514 $ run port/loopback BESS_WORKERS=1
Environment variable "BESS_PORTS" is not set. Using default value "1"
Environment variable "BESS_QSIZE" is not set. Using default value "128"
Environment variable "BESS_QUEUES" is not set. Using default value "1"
Using 1 DPDK ports... (envvar "BESS_PORTS")
RX/TX queue size: 128 packets per queue
NOTE: not all DPDK ports support lookback mode
Done.
localhost:10514 $ monitor tc
Monitoring traffic classes: !leaf_source0:0, !leaf_port_inc0:0, !default_rr_0

23:40:57.602144            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1591.319     2916951      93.342   62726.114      32.000      17.048
W0 !leaf_port_inc0:0       508.692     2916953       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     5833900      93.342   62726.101      16.000      22.498
----------------------------------------------------------------------------------------------

23:40:58.603888            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1591.227     2917414      93.357   62736.085      32.000      17.044
W0 !leaf_port_inc0:0       508.782     2917415       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     5834832      93.357   62736.134      16.000      22.494
----------------------------------------------------------------------------------------------

23:40:59.605590            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1591.124     2917842      93.371   62745.284      32.000      17.041
W0 !leaf_port_inc0:0       508.888     2917839       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.012     5835684      93.371   62745.266      16.000      22.491
----------------------------------------------------------------------------------------------
```

## After the change (no contention)
```
localhost:10514 $ run port/loopback BESS_WORKERS=1
Environment variable "BESS_PORTS" is not set. Using default value "1"
Environment variable "BESS_QSIZE" is not set. Using default value "128"
Environment variable "BESS_QUEUES" is not set. Using default value "1"
Using 1 DPDK ports... (envvar "BESS_PORTS")
RX/TX queue size: 128 packets per queue
NOTE: not all DPDK ports support lookback mode
Done.
localhost:10514 $ monitor tc
Monitoring traffic classes: !leaf_source0:0, !leaf_port_inc0:0, !default_rr_0

11:25:40.671544            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1711.045     2787092      89.187   59933.630      32.000      19.185
W0 !leaf_port_inc0:0       388.966     2787089       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     5574184      89.187   59933.632      16.000      23.546
----------------------------------------------------------------------------------------------

11:25:41.673333            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1710.686     2787090      89.187   59933.589      32.000      19.181
W0 !leaf_port_inc0:0       389.323     2787091       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     5574181      89.187   59933.597      16.000      23.546
----------------------------------------------------------------------------------------------

11:25:42.675116            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1710.680     2786947      89.182   59930.517      32.000      19.182
W0 !leaf_port_inc0:0       389.332     2786949       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     5573882      89.182   59930.383      16.000      23.547
----------------------------------------------------------------------------------------------

11:25:43.676848            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1710.586     2787311      89.194   59938.350      32.000      19.178
W0 !leaf_port_inc0:0       389.425     2787308       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.012     5574638      89.194   59938.509      16.000      23.544
----------------------------------------------------------------------------------------------
```

```
localhost:10514 $ run port/loopback BESS_WORKERS=4, BESS_QUEUES=4
Environment variable "BESS_PORTS" is not set. Using default value "1"
Environment variable "BESS_QSIZE" is not set. Using default value "128"
Using 1 DPDK ports... (envvar "BESS_PORTS")
RX/TX queue size: 128 packets per queue
NOTE: not all DPDK ports support lookback mode
Done.
localhost:10514 $ monitor tc
Monitoring traffic classes: !leaf_source3:0, !leaf_port_inc0:3, !default_rr_3, !leaf_source0:0, !leaf_port_inc0:0, !default_rr_0, !leaf_source2:0, !leaf_port_inc0:2, !default_rr_2, !leaf_source1:0, !leaf_port_inc0:1, !default_rr_1

11:51:18.562539            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W3 !leaf_source3:0        1644.168     2246245      71.880   48303.264      32.000      22.874
W3 !leaf_port_inc0:3       455.840     2246246       0.000       0.000       0.000       0.000
W3 !default_rr_3          2100.010     4492483      71.880   48303.185      16.000      29.216
W0 !leaf_source0:0        1759.595     2421178      77.478   52065.008      32.000      22.711
W0 !leaf_port_inc0:0       340.417     2421177       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.012     4842355      77.478   52065.022      16.000      27.105
W2 !leaf_source2:0        1677.910     2049957      65.599   44082.291      32.000      25.578
W2 !leaf_port_inc0:2       422.102     2049957       0.000       0.000       0.000       0.000
W2 !default_rr_2          2100.009     4099907      65.599   44082.193      16.000      32.013
W1 !leaf_source1:0        1778.794     2299321      73.578   49444.605      32.000      24.176
W1 !leaf_port_inc0:1       321.217     2299321       0.000       0.000       0.000       0.000
W1 !default_rr_1          2100.010     4598638      73.578   49444.557      16.000      28.541
----------------------------------------------------------------------------------------------

11:51:19.566015            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W3 !leaf_source3:0        1644.678     2242692      71.766   48226.860      32.000      22.917
W3 !leaf_port_inc0:3       455.336     2242695       0.000       0.000       0.000       0.000
W3 !default_rr_3          2100.009     4485387      71.766   48226.883      16.000      29.262
W0 !leaf_source0:0        1758.153     2428862      77.724   52230.271      32.000      22.621
W0 !leaf_port_inc0:0       341.858     2428864       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.010     4857731      77.724   52230.322      16.000      27.019
W2 !leaf_source2:0        1677.433     2052020      65.665   44126.650      32.000      25.545
W2 !leaf_port_inc0:2       422.576     2052016       0.000       0.000       0.000       0.000
W2 !default_rr_2          2100.010     4104024      65.664   44126.467      16.000      31.981
W1 !leaf_source1:0        1778.937     2297444      73.518   49404.248      32.000      24.197
W1 !leaf_port_inc0:1       321.074     2297443       0.000       0.000       0.000       0.000
W1 !default_rr_1          2100.010     4594896      73.518   49404.328      16.000      28.564
----------------------------------------------------------------------------------------------

11:51:20.569463            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W3 !leaf_source3:0        1644.265     2246325      71.882   48304.983      32.000      22.874
W3 !leaf_port_inc0:3       455.745     2246321       0.000       0.000       0.000       0.000
W3 !default_rr_3          2100.011     4492637      71.882   48304.840      16.000      29.215
W0 !leaf_source0:0        1759.063     2423398      77.549   52112.759      32.000      22.683
W0 !leaf_port_inc0:0       340.947     2423397       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     4846797      77.549   52112.764      16.000      27.080
W2 !leaf_source2:0        1677.791     2050621      65.620   44096.571      32.000      25.568
W2 !leaf_port_inc0:2       422.221     2050627       0.000       0.000       0.000       0.000
W2 !default_rr_2          2100.012     4101267      65.620   44096.829      16.000      32.002
W1 !leaf_source1:0        1779.016     2297325      73.514   49401.694      32.000      24.200
W1 !leaf_port_inc0:1       320.994     2297325       0.000       0.000       0.000       0.000
W1 !default_rr_1          2100.010     4594649      73.514   49401.673      16.000      28.566
----------------------------------------------------------------------------------------------
```

## After the change (with contention)
```
localhost:10514 $ run port/loopback BESS_WORKERS=2, BESS_QUEUES=1
WARNING: The current pipeline will be reset. Are you sure? (type "yes") yes
Environment variable "BESS_PORTS" is not set. Using default value "1"
Environment variable "BESS_QSIZE" is not set. Using default value "128"
Using 1 DPDK ports... (envvar "BESS_PORTS")
RX/TX queue size: 128 packets per queue
NOTE: not all DPDK ports support lookback mode
Done.
localhost:10514 $ monitor tc
Monitoring traffic classes: !leaf_source0:0, !leaf_port_inc0:0, !default_rr_0, !leaf_source1:0

11:52:09.327137            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1801.301     1542957      49.375   33179.761      32.000      36.482
W0 !leaf_port_inc0:0       298.710     1542960       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.011     3085915      49.375   33179.761      16.000      42.532
W1 !leaf_source1:0        2100.010     1585577      50.738   34096.254      32.000      41.389
----------------------------------------------------------------------------------------------

11:52:10.329061            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1811.010     1512715      48.407   32529.433      32.000      37.412
W0 !leaf_port_inc0:0       289.008     1512731       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.012     3025478      48.408   32529.951      16.000      43.382
W1 !leaf_source1:0        2100.011     1557923      49.854   33501.597      32.000      42.124
----------------------------------------------------------------------------------------------

11:52:11.330955            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W0 !leaf_source0:0        1801.704     1539172      49.254   33098.357      32.000      36.580
W0 !leaf_port_inc0:0       298.299     1539155       0.000       0.000       0.000       0.000
W0 !default_rr_0          2100.010     3078307      49.253   33097.952      16.000      42.637
W1 !leaf_source1:0        2100.008     1582169      50.629   34022.970      32.000      41.478
----------------------------------------------------------------------------------------------
```

```
localhost:10514 $ run port/loopback BESS_WORKERS=4, BESS_QUEUES=1
WARNING: The current pipeline will be reset. Are you sure? (type "yes") yes
Environment variable "BESS_PORTS" is not set. Using default value "1"
Environment variable "BESS_QSIZE" is not set. Using default value "128"
Using 1 DPDK ports... (envvar "BESS_PORTS")
RX/TX queue size: 128 packets per queue
NOTE: not all DPDK ports support lookback mode
Done.
localhost:10514 $ monitor tc
Monitoring traffic classes: !leaf_source0:0, !leaf_port_inc0:0, !default_rr_1, !leaf_source3:0, !leaf_source2:0, !leaf_source1:0

11:52:31.857821            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W1 !leaf_source0:0        1926.620      756914      24.221   16276.694      32.000      79.543
W1 !leaf_port_inc0:0       173.395      756919       0.000       0.000       0.000       0.000
W1 !default_rr_1          2100.011     1513841      24.221   16276.836      16.000      86.700
W0 !leaf_source3:0        2100.009      756908      24.221   16276.569      32.000      86.702
W3 !leaf_source2:0        2100.013      756924      24.222   16276.910      32.000      86.700
W2 !leaf_source1:0        2100.009      756928      24.222   16276.996      32.000      86.699
----------------------------------------------------------------------------------------------

11:52:32.860110            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W1 !leaf_source0:0        1927.922      753979      24.127   16213.578      32.000      79.906
W1 !leaf_port_inc0:0       172.086      753979       0.000       0.000       0.000       0.000
W1 !default_rr_1          2100.009     1507961      24.127   16213.589      16.000      87.038
W0 !leaf_source3:0        2100.011      753979      24.127   16213.586      32.000      87.039
W3 !leaf_source2:0        2100.009      753974      24.127   16213.473      32.000      87.039
W2 !leaf_source1:0        2100.014      753961      24.127   16213.180      32.000      87.041
----------------------------------------------------------------------------------------------

11:52:33.862335            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W1 !leaf_source0:0        1926.752      756427      24.206   16266.217      32.000      79.599
W1 !leaf_port_inc0:0       173.257      756428       0.000       0.000       0.000       0.000
W1 !default_rr_1          2100.011     1512853      24.206   16266.199      16.000      86.757
W0 !leaf_source3:0        2100.010      756436      24.206   16266.401      32.000      86.756
W3 !leaf_source2:0        2100.011      756427      24.206   16266.214      32.000      86.757
W2 !leaf_source1:0        2100.010      756434      24.206   16266.378      32.000      86.756
----------------------------------------------------------------------------------------------
```

```
localhost:10514 $ run port/loopback BESS_WORKERS=4, BESS_QUEUES=2
WARNING: The current pipeline will be reset. Are you sure? (type "yes") yes
Environment variable "BESS_PORTS" is not set. Using default value "1"
Environment variable "BESS_QSIZE" is not set. Using default value "128"
Using 1 DPDK ports... (envvar "BESS_PORTS")
RX/TX queue size: 128 packets per queue
NOTE: not all DPDK ports support lookback mode
Done.
localhost:10514 $ monitor tc
Monitoring traffic classes: !leaf_source1:0, !leaf_port_inc0:1, !default_rr_3, !leaf_source3:0, !leaf_source0:0, !leaf_port_inc0:0, !default_rr_2, !leaf_source2:0

11:52:49.475850            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W3 !leaf_source1:0        1815.817     1727556      55.282   37149.383      32.000      32.847
W3 !leaf_port_inc0:1       284.195     1727568       0.000       0.000       0.000       0.000
W3 !default_rr_3          2100.010     3455127      55.282   37149.524      16.000      37.987
W1 !leaf_source3:0        2100.010     1737003      55.584   37352.520      32.000      37.781
W2 !leaf_source0:0        1807.784     1748746      55.960   37605.045      32.000      32.305
W2 !leaf_port_inc0:0       292.228     1748752       0.000       0.000       0.000       0.000
W2 !default_rr_2          2100.011     3497535      55.961   37605.499      16.000      37.527
W0 !leaf_source2:0        2100.009     1761224      56.359   37873.381      32.000      37.261
----------------------------------------------------------------------------------------------

11:52:50.478539            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W3 !leaf_source1:0        1816.976     1722015      55.105   37030.231      32.000      32.973
W3 !leaf_port_inc0:1       283.036     1722009       0.000       0.000       0.000       0.000
W3 !default_rr_3          2100.012     3444034      55.105   37030.262      16.000      38.110
W1 !leaf_source3:0        2100.012     1731360      55.404   37231.185      32.000      37.904
W2 !leaf_source0:0        1807.551     1750589      56.019   37644.668      32.000      32.267
W2 !leaf_port_inc0:0       292.456     1750575       0.000       0.000       0.000       0.000
W2 !default_rr_2          2100.012     3501133      56.018   37644.189      16.000      37.488
W0 !leaf_source2:0        2100.012     1762233      56.391   37895.077      32.000      37.240
----------------------------------------------------------------------------------------------

11:52:51.481211            CPU MHz   scheduled        Mpps        Mbps  pkts/sched    cycles/p
----------------------------------------------------------------------------------------------
W3 !leaf_source1:0        1816.926     1725320      55.210   37101.286      32.000      32.909
W3 !leaf_port_inc0:1       283.085     1725327       0.000       0.000       0.000       0.000
W3 !default_rr_3          2100.010     3450656      55.211   37101.460      16.000      38.036
W1 !leaf_source3:0        2100.010     1734715      55.511   37303.323      32.000      37.831
W2 !leaf_source0:0        1807.861     1748639      55.956   37602.743      32.000      32.308
W2 !leaf_port_inc0:0       292.152     1748649       0.000       0.000       0.000       0.000
W2 !default_rr_2          2100.010     3497296      55.957   37602.929      16.000      37.529
W0 !leaf_source2:0        2100.010     1760004      56.320   37847.133      32.000      37.287
----------------------------------------------------------------------------------------------
```