### PR TITLE
There are more than 64 Core/Thread CPUs nowdays

### DIFF
--- a/core/kmod/sn_common.h
+++ b/core/kmod/sn_common.h
@@ -52,7 +52,7 @@ typedef uint64_t phys_addr_t;
 #define __LLRING_USE_PHYS_ADDR__
 #include "llring.h"
 
-#define SN_MAX_CPU 64
+#define SN_MAX_CPU 128
 
 #define SN_MAX_TXQ 32
 #define SN_MAX_RXQ 32


### PR DESCRIPTION
Rather obvious one. Without it bess crashes on a two socket Xeon which claims to have 36 Cores/72 threads.

Signed-off-by: Anton Ivanov <anton.ivanov@cambridgegreys.com>