### PR TITLE
Allows specifying socket/numa node for BESS

### DIFF
--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -567,6 +567,12 @@ class BESSControlImpl final : public BESSControl::Service {
     if (!is_cpu_present(core)) {
       return return_with_error(response, EINVAL, "Invalid core %d", core);
     }
+   
+    if (rte_lcore_to_socket_id(core) != (unsigned int) FLAGS_n) {
+      return return_with_error(response, EINVAL, "Invalid core %d not on socket %d",
+      core, FLAGS_n);
+    }
+
     if (is_worker_active(wid)) {
       return return_with_error(response, EEXIST, "worker:%d is already active",
                                wid);

--- a/core/dpdk.h
+++ b/core/dpdk.h
@@ -37,7 +37,7 @@ bool IsDpdkInitialized();
 
 // Initialize DPDK, with the specified amount of hugepage memory.
 // Safe to call multiple times.
-void InitDpdk(int dpdk_mb_per_socket = 0);
+void InitDpdk(int dpdk_mb_per_socket = 0, int socket = 0);
 
 }  // namespace bess
 

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -35,6 +35,7 @@
 
 #include "bessd.h"
 #include "worker.h"
+#include "memory.h"
 
 // Port this BESS instance listens on.
 // Panda came up with this default number
@@ -105,6 +106,18 @@ DEFINE_int32(m, 1024,
              "If set to 0, no hugepage is used");
 static const bool _m_dummy[[maybe_unused]] =
     google::RegisterFlagValidator(&FLAGS_m, &ValidateMegabytesPerSocket);
+
+static bool ValidateNumaNode(const char *, int32_t value) {
+  if (value < 0 || value >= bess::NumNumaNodes()) {
+    LOG(ERROR) << "Invalid Numa node: " << value;
+    return false;
+  }
+  return true;
+}
+DEFINE_int32(n, 0,
+    "Specifies which numa node to run BESS on");
+static const bool _n_dummy[[maybe_unused]] =
+    google::RegisterFlagValidator(&FLAGS_n, &ValidateNumaNode);
 
 static bool ValidateBuffersPerSocket(const char *, int32_t value) {
   if (value <= 0) {

--- a/core/opts.h
+++ b/core/opts.h
@@ -44,6 +44,7 @@ DECLARE_string(b);
 DECLARE_int32(p);
 DECLARE_string(grpc_url);
 DECLARE_int32(m);
+DECLARE_int32(n);
 DECLARE_bool(skip_root_check);
 DECLARE_string(modules);
 DECLARE_bool(core_dump);

--- a/core/packet_pool.cc
+++ b/core/packet_pool.cc
@@ -36,27 +36,25 @@ void DoMunmap(rte_mempool_memhdr *memhdr, void *) {
 PacketPool *PacketPool::default_pools_[RTE_MAX_NUMA_NODES];
 
 void PacketPool::CreateDefaultPools(size_t capacity) {
-  InitDpdk(FLAGS_dpdk ? FLAGS_m : 0);
+  InitDpdk(FLAGS_dpdk ? FLAGS_m : 0, FLAGS_n);
 
   rte_dump_physmem_layout(stdout);
 
-  for (int sid = 0; sid < NumNumaNodes(); sid++) {
-    if (FLAGS_m == 0) {
-      LOG(WARNING) << "Hugepage is disabled! Creating PlainPacketPool for "
-                   << capacity << " packets on node " << sid;
-      default_pools_[sid] = new PlainPacketPool(capacity, sid);
-    } else if (FLAGS_dpdk) {
-      LOG(INFO) << "Creating DpdkPacketPool for " << capacity
-                << " packets on node " << sid;
-      default_pools_[sid] = new DpdkPacketPool(capacity, sid);
-    } else {
-      LOG(INFO) << "Creating BessPacketPool for " << capacity
-                << " packets on node " << sid;
-      default_pools_[sid] = new BessPacketPool(capacity, sid);
-    }
-    CHECK(default_pools_[sid])
-        << "Packet pool allocation on node " << sid << " failed!";
+  if (FLAGS_m == 0) {
+    LOG(WARNING) << "Hugepage is disabled! Creating PlainPacketPool for "
+                 << capacity << " packets on node " << FLAGS_n;
+    default_pools_[FLAGS_n] = new PlainPacketPool(capacity, FLAGS_n);
+  } else if (FLAGS_dpdk) {
+    LOG(INFO) << "Creating DpdkPacketPool for " << capacity
+              << " packets on node " << FLAGS_n;
+    default_pools_[FLAGS_n] = new DpdkPacketPool(capacity, FLAGS_n);
+  } else {
+    LOG(INFO) << "Creating BessPacketPool for " << capacity
+              << " packets on node " << FLAGS_n;
+    default_pools_[FLAGS_n] = new BessPacketPool(capacity, FLAGS_n);
   }
+  CHECK(default_pools_[FLAGS_n])
+      << "Packet pool allocation on node " << FLAGS_n << " failed!";
 }
 
 PacketPool::PacketPool(size_t capacity, int socket_id) {


### PR DESCRIPTION
Using "-n" flag a user may now specify the desired socket to allocate
huge pages from when using BESS.

Also includes a check for worker core existing on the correct socket
before trying to launch a worker. If worker is launched on a core on an
unused socket GetDefaultPool will crash bessd.

Signed-off-by: Tim Rozet <trozet@redhat.com>