### PR TITLE
Bumping up queue size to support higher-end adapters

### DIFF
--- a/core/port.h
+++ b/core/port.h
@@ -50,7 +50,7 @@
 
 typedef uint8_t queue_t;
 
-#define MAX_QUEUES_PER_DIR 32 /* [0, 31] (for each RX/TX) */
+#define MAX_QUEUES_PER_DIR 128 /* [0, 31] (for each RX/TX) */
 
 #define DRIVER_FLAG_SELF_INC_STATS 0x0001
 #define DRIVER_FLAG_SELF_OUT_STATS 0x0002


### PR DESCRIPTION
Some high-end machines might have DPDK adapters with larger queues, typically 128 for the x552 in TX. As well, some servers are equipped with dual 28-core xeon, which results into 56 cores available, so more than 32 cores could be used to process traffic. Therefore, we should bump up the current 32 limit.