### PR TITLE
Fix relative imports

### DIFF
--- a/bessctl/bessctl
+++ b/bessctl/bessctl
@@ -46,7 +46,7 @@ import logging
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 try:
-    this_dir = os.path.dirname(os.path.realpath(__file__))
+    this_dir = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(1, os.path.join(this_dir, '..'))
     from pybess.bess import *
 except ImportError:

--- a/bessctl/run_module_tests.py
+++ b/bessctl/run_module_tests.py
@@ -40,7 +40,7 @@ import subprocess
 import sys
 import unittest
 
-this_dir = os.path.dirname(os.path.realpath(__file__))
+this_dir = os.path.dirname(os.path.abspath(__file__))
 bessctl = os.path.join(this_dir, 'bessctl')
 default_test_dir = os.path.join(this_dir, 'module_tests')
 


### PR DESCRIPTION
1) allow module_tests and bessctl to use relative paths even when those files are in symlink'd directories
2) re-work how auto-generated protobuf files are imported so that they're treated as external modules

These commits together fix situations where the source tree for bess and the autogenerated protobuf files don't live in the same directory, but are instead symlinked into a third directory. Build systems like bazel do this sort of symlink madness.

tested by running the module test and having bessctl use python2 and python3