### PR TITLE
WeightedFairScheduler: double or nothing

### DIFF
--- a/bessctl/conf/samples/tc/wfs_double.bess
+++ b/bessctl/conf/samples/tc/wfs_double.bess
@@ -1,0 +1,54 @@
+# Test WeightedFairscheduler's accuracy on a simple tree pipeline
+# Works correctly, if internal variables of WFS are represented as
+# doubles. Details: https://github.com/NetSys/bess/pull/955
+
+import time
+
+
+def do_measure(shares):
+    # setup pipeline
+    src = Source()
+    rr = RandomSplit(gates=[0, 1], drop_rate=0.0)
+    q1 = Queue()
+    q2 = Queue()
+    m1 = Measure()
+    m2 = Measure()
+
+    src -> Timestamp() -> rr
+    rr:0 -> q1 -> m1 -> Sink()
+    rr:1 -> q2 -> m2 -> Sink()
+
+    # configure TCs
+    bess.add_tc('root', policy='weighted_fair', resource='count')
+    src.attach_task(parent='root', share=shares['root'])
+    q1.attach_task(parent='root', share=shares['leaf'])
+    q2.attach_task(parent='root', share=shares['leaf'])
+
+    # run pipeline
+    bess.resume_all()
+    time.sleep(2)
+    bess.pause_all()
+
+    # query and print measurement results
+    for i, m in enumerate((m1, m2)):
+        percentiles = [90, 95, 99]
+        res = m.get_summary(latency_percentiles=percentiles)
+        print('FLOW%d:' % i)
+        print('  avg_ns: %.3f' % res.latency.avg_ns)
+        for i, p in enumerate(percentiles):
+            print_args = (p, res.latency.percentile_values_ns[i])
+            print(' %dth_ns: %.3f' % print_args)
+        print()
+    print()
+
+
+# We expect to see a small difference in measured latency when the
+# root share is 170 and 171 (leaf share is 100).
+root_shares = (170, 171)
+
+for root_share in root_shares:
+    print('=' * 20)
+    print('TC SHARES: %d:100' % root_share)
+    print('=' * 20)
+    do_measure({'leaf': 100, 'root': root_share})
+    bess.reset_all()

--- a/core/traffic_class.cc
+++ b/core/traffic_class.cc
@@ -192,7 +192,7 @@ bool WeightedFairTrafficClass::AddChild(TrafficClass *child,
   }
 
   child->parent_ = this;
-  ChildData child_data{STRIDE1 / share, {NextPass()}, child};
+  ChildData child_data{STRIDE1 / (double)share, {NextPass()}, child};
   if (child->blocked_) {
     blocked_children_.push_back(child_data);
   } else {
@@ -275,7 +275,7 @@ void WeightedFairTrafficClass::FinishAndAccountTowardsRoot(
 
   auto &item = runnable_children_.mutable_top();
   uint64_t consumed = usage[resource_];
-  uint64_t pass_delta = item.stride * consumed / QUANTUM;
+  double pass_delta = item.stride * consumed / QUANTUM;
 
   // DCHECK_EQ(item.c, child) << "Child that we picked should be at the front
   // of priority queue.";

--- a/core/traffic_class.h
+++ b/core/traffic_class.h
@@ -335,15 +335,15 @@ class WeightedFairTrafficClass final : public TrafficClass {
       return right.pass < pass;
     }
 
-    int64_t stride;
+    double stride;
 
     // NOTE: while in the code example in the original Stride Scheduler
     // [Waldspurgger95] maintains "pass" and "remain" (penalty) separately,
     // we can safely multiplex these variables in a union since they are never
     // used at the same time.
     union {
-      int64_t pass;
-      int64_t remain;
+      double pass;
+      double remain;
     };
 
     TrafficClass *c;
@@ -395,7 +395,7 @@ class WeightedFairTrafficClass final : public TrafficClass {
  private:
   // Returns the pass value of the first child to be scheduled next,
   // or 0 if there is no runnable child (i.e., the priority queue is empty)
-  int64_t NextPass() const {
+  double NextPass() const {
     if (runnable_children_.empty()) {
       return 0;
     } else {


### PR DESCRIPTION
WeightedFairScheduler is not able to keep up with shares set in 'count' aka batch domain. 

_tl;dr: The wf scheduler is inaccurate with non-extreme shares. Representing internal values as doubles solves this inaccuracy._ 

As an example, take a simple tree pipeline with a single 'root' node and two 'leaf' nodes. These are  connected by a RandomSplit. Root and leaf modules are put into separate tasks (see config at the bottom). Suppose, we want to schedule in batch domain ('count') and share ratios (leaf:root) are set as 1:1.71 and 1:1.7. To achieve that, shares are set to 100 (leaf), and 171 or 170 (root).

We expect to see a small difference in measured latency in the two scenarios. Actually, we see a large performance gap:
```
$ ./bessctl run local/wfq-test root_share=1.7
FLOW0:
   avg_ns: 1064.000
  90th_ns: 1600.000
  95th_ns: 2200.000
  99th_ns: 3200.000

FLOW1:
   avg_ns: 1063.000
  90th_ns: 1600.000
  95th_ns: 2200.000
  99th_ns: 3200.000

$ ./bessctl run local/wfq-test root_share=1.71
FLOW0:
   avg_ns: 42947.000
  90th_ns: 71700.000
  95th_ns: 74500.000
  99th_ns: 100700.000

FLOW1:
   avg_ns: 35842.000
  90th_ns: 69900.000
  95th_ns: 73200.000
  99th_ns: 96200.000
```

To solve this issue, the important code section is in [WeightedFairTrafficClass::FinishAndAccountTowardsRoot()](https://github.com/NetSys/bess/blob/master/core/traffic_class.cc#L278); where pass_delta is calculated. The pass_delta is important for the underlying stride scheduling, since the scheduler takes the task with the smallest pass value at each iteration.

If we calculate pass_delta values by hand, we see a small difference between pass_delta values corresponding to share 170 and 171:

```
| share | pass_delta |
|-------+------------+
|   100 |    10.2400 |
|   170 |     6.0235 |
|   171 |     5.9883 |
```

But, pass_delta is represented as an integer and BESS is writen in C++, so pass_delta will be 6 for share 170 and 5 for 171. That is a game changing difference in this situation, the ratio of pass_delta values in the later case is not 1.71:1, but 2:1!

Floating-point representation of weighted-fair scheduler internal values solved the performance issue:
```
$ ./bessctl run local/wfq-test root_share=1.7
FLOW0:
   avg_ns: 1060.000
  90th_ns: 1600.000
  95th_ns: 2300.000
  99th_ns: 3100.000

FLOW1:
   avg_ns: 1063.000
  90th_ns: 1600.000
  95th_ns: 2300.000
  99th_ns: 3100.000

$ ./bessctl run local/wfq-test root_share=1.71
FLOW0:
   avg_ns: 1086.000
  90th_ns: 1600.000
  95th_ns: 2300.000
  99th_ns: 3100.000

FLOW1:
   avg_ns: 1087.000
  90th_ns: 1600.000
  95th_ns: 2400.000
  99th_ns: 3100.000
```

WDYT?

---

A BESS script to reproduce results:
```python
import time

root_share  = float($root_share!'1.7')

shares = {'leaf': 100,
          'root': int(root_share * 100)}

src = Source()
rr = RandomSplit(gates=[0,1], drop_rate=0.0)
q1 = Queue()
q2 = Queue()
m1 = Measure()
m2 = Measure()

src -> Timestamp() -> rr
rr:0 -> q1 -> m1 -> Sink()
rr:1 -> q2 -> m2 -> Sink()

bess.add_tc('root', policy='weighted_fair', resource='count')
src.attach_task(parent='root', share=shares['root'])
q1.attach_task(parent='root', share=shares['leaf'])
q2.attach_task(parent='root', share=shares['leaf'])

bess.resume_all()

time.sleep(2)

bess.pause_all()

for i,m in enumerate((m1,m2)):
    percentiles = [90, 95, 99]
    res = m.get_summary(latency_percentiles=percentiles)
    print('FLOW%d:' % i)
    print('   avg_ns: %.3f' % res.latency.avg_ns)
    for i,p in enumerate(percentiles):
        print('  %dth_ns: %.3f' % (
            p,
            res.latency.percentile_values_ns[i]))
    print()
```