### PR TITLE
Add pybess API to configure port

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1031,6 +1031,17 @@ def command_gatehook(cli, name, module, direction, gate, cmd, arg_type, args):
         cli.bess.resume_all()
 
 
+# Please do not rely on this API. This API may be replaced with `command port PORT`
+# in the same way with gatehook and module
+@cmd('configure port PORT [PORT_ARGS...]', '[Experimental] Update a port configuration')
+def conigure_port(cli, name, args):
+    cli.bess.pause_all()
+    try:
+        cli.bess.ser_port_config(name, args or {})
+    finally:
+        cli.bess.resume_all()
+
+
 @cmd('delete worker WORKER_ID...', 'Delete a worker')
 def delete_worker(cli, wids):
     wids = sorted(list(set(wids)))
@@ -1440,8 +1451,10 @@ def _show_port(cli, port):
     else:
         autoneg = 'OFF'
 
-    cli.fout.write('  %-12s Driver %-10s HWaddr %s\n' %
-                   (port.name, port.driver, port.mac_addr))
+    port_config = cli.bess.get_port_config(port.name)
+
+    cli.fout.write('  %-12s Driver %-10s HWaddr %-18s MTU %-6d\n' %
+                   (port.name, port.driver, port.mac_addr, port_config.conf.mtu))
     cli.fout.write('  %-12s Speed %-11s Link %-5s Duplex %-5s Autoneg %-5s\n' %
                    ('', speed, link, duplex, autoneg))
     stats = cli.bess.get_port_stats(port.name)

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1037,7 +1037,7 @@ class BESSControlImpl final : public BESSControl::Service {
   }
 
   Status SetPortConf(ServerContext*, const SetPortConfRequest* request,
-                     EmptyResponse* response) override {
+                     CommandResponse* response) override {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     if (!request->name().length()) {
@@ -1064,7 +1064,7 @@ class BESSControlImpl final : public BESSControl::Service {
     }
 
     WorkerPauser wp;
-    it->second->UpdateConf(conf);
+    *response = it->second->UpdateConf(conf);
     return Status::OK;
   }
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -324,16 +324,20 @@ CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
   return CommandSuccess();
 }
 
-int PMDPort::UpdateConf(const Conf &conf) {
+CommandResponse PMDPort::UpdateConf(const Conf &conf) {
   rte_eth_dev_stop(dpdk_port_id_);
 
   if (conf_.mtu != conf.mtu && conf.mtu != 0) {
+    if (conf.mtu > SNBUF_DATA || conf.mtu < ETHER_MIN_MTU) {
+      return CommandFailure(EINVAL, "mtu should be >= %d and <= %d",
+                            ETHER_MIN_MTU, SNBUF_DATA);
+    }
+
     int ret = rte_eth_dev_set_mtu(dpdk_port_id_, conf.mtu);
     if (ret == 0) {
       conf_.mtu = conf.mtu;
     } else {
-      LOG(WARNING) << "rte_eth_dev_set_mtu() failed: " << rte_strerror(-ret);
-      return ret;
+      return CommandFailure(-ret, "rte_eth_dev_set_mtu() failed");
     }
   }
 
@@ -345,9 +349,7 @@ int PMDPort::UpdateConf(const Conf &conf) {
     if (ret == 0) {
       conf_.mac_addr = conf.mac_addr;
     } else {
-      LOG(WARNING) << "rte_eth_dev_default_mac_addr_set() failed: "
-                   << rte_strerror(-ret);
-      return ret;
+      return CommandFailure(-ret, "rte_eth_dev_default_mac_addr_set() failed");
     }
   }
 
@@ -356,12 +358,11 @@ int PMDPort::UpdateConf(const Conf &conf) {
     if (ret == 0) {
       conf_.admin_up = true;
     } else {
-      LOG(WARNING) << "rte_eth_dev_start() failed: " << rte_strerror(-ret);
-      return ret;
+      return CommandFailure(-ret, "rte_eth_dev_start() failed");
     }
   }
 
-  return 0;
+  return CommandSuccess();
 }
 
 void PMDPort::DeInit() {

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -330,7 +330,7 @@ int PMDPort::UpdateConf(const Conf &conf) {
   if (conf_.mtu != conf.mtu && conf.mtu != 0) {
     int ret = rte_eth_dev_set_mtu(dpdk_port_id_, conf.mtu);
     if (ret == 0) {
-      conf_.mtu = conf_.mtu;
+      conf_.mtu = conf.mtu;
     } else {
       LOG(WARNING) << "rte_eth_dev_set_mtu() failed: " << rte_strerror(-ret);
       return ret;

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -127,7 +127,7 @@ class PMDPort final : public Port {
 
   LinkStatus GetLinkStatus() override;
 
-  int UpdateConf(const Conf &conf) override;
+  CommandResponse UpdateConf(const Conf &conf) override;
 
   /*!
    * Get any placement constraints that need to be met when receiving from this

--- a/core/port.h
+++ b/core/port.h
@@ -266,7 +266,9 @@ class Port {
     };
   }
 
-  virtual int UpdateConf(const Conf &) { return -ENOTSUP; }
+  virtual CommandResponse UpdateConf(const Conf &) {
+    return CommandFailure(ENOTSUP);
+  }
 
   CommandResponse InitWithGenericArg(const google::protobuf::Any &arg);
 

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -204,7 +204,7 @@ service BESSControl {
   rpc DestroyPort (DestroyPortRequest) returns (EmptyResponse) {}
 
   /// Runtime-updatable configuration
-  rpc SetPortConf (SetPortConfRequest) returns (EmptyResponse) {}
+  rpc SetPortConf (SetPortConfRequest) returns (CommandResponse) {}
   rpc GetPortConf (GetPortConfRequest) returns (GetPortConfResponse) {}
 
   /// Collect port statistics

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -393,6 +393,20 @@ class BESS(object):
         request.name = name
         return self._request('DestroyPort', request)
 
+    def set_port_config(self, name, arg):
+        request = bess_msg.SetPortConfRequest()
+        request.name = name
+        # no update is done if mac_addr or mtu is not specified
+        request.conf.mac_addr = arg.pop('mac_addr', '00:00:00:00:00:00')
+        request.conf.mtu = arg.pop('mtu', 0)
+        request.conf.admin_up = arg.pop('admin_up', True)
+        return self._request('SetPortConf', request)
+
+    def get_port_config(self, name):
+        request = bess_msg.GetPortConfRequest()
+        request.name = name
+        return self._request('GetPortConf', request)
+
     def get_port_stats(self, name):
         request = bess_msg.GetPortStatsRequest()
         request.name = name

--- a/pybess/port.py
+++ b/pybess/port.py
@@ -52,3 +52,10 @@ class Port(object):
 
     def get_link_status(self):
         return self.bess.get_link_status(self.name)
+
+    def set_port_config(self, **kwargs):
+        return self.bess.set_port_config(self.name,
+                                         self.choose_arg(None, kwargs))
+
+    def get_port_config(self):
+        return self.bess.get_port_config(self.name)


### PR DESCRIPTION
This commit 
1) verifies a MTU input ranges and add responses, and
2) adds a pybess API to call `SetPortConfRequest()` which configure a port by name for mac_address, MTU, and enable/disable the port.