### PR TITLE
BPF module: `get_initial_args()` is a thread safe function

### DIFF
--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -54,7 +54,7 @@ const Commands BPF::cmds = {
     {"clear", "EmptyArg", MODULE_CMD_FUNC(&BPF::CommandClear),
      Command::THREAD_UNSAFE},
     {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&BPF::GetInitialArg),
-     Command::THREAD_UNSAFE}};
+     Command::THREAD_SAFE}};
 
 CommandResponse BPF::Init(const bess::pb::BPFArg &arg) {
   return CommandAdd(arg);


### PR DESCRIPTION
While the function is thread-safe, we marked the function differently.