### PR TITLE
Set IOVA mode explicitly

### DIFF
--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -91,6 +91,16 @@ class CmdLineOpts {
 
   int Argc() const { return args_.size(); }
 
+  std::string Dump() {
+    std::ostringstream os;
+    os << "[";
+    for (size_t i = 0; i < args_.size(); i++) {
+      os << (i == 0 ? "" : ", ") << '"' << args_[i].data() << '"';
+    }
+    os << "]";
+    return os.str();
+  }
+
  private:
   // Contains a copy of each argument.
   std::vector<std::vector<char>> args_;
@@ -148,6 +158,7 @@ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
   stdout = fopencookie(nullptr, "w", dpdk_log_init_funcs);
 
   disable_syslog();
+  LOG(INFO) << "Initializing DPDK EAL with options: " << rte_args.Dump();
   int ret = rte_eal_init(rte_args.Argc(), rte_args.Argv());
   if (ret < 0) {
     LOG(FATAL) << "rte_eal_init() failed: ret = " << ret
@@ -218,7 +229,6 @@ void InitDpdk(int dpdk_mb_per_socket) {
 
   if (!is_initialized) {
     is_initialized = true;
-    LOG(INFO) << "Initializing DPDK";
     init_eal(dpdk_mb_per_socket, GetNonWorkerCoreList());
   }
 }

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -118,9 +118,12 @@ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
       // Do not bother with /var/run/.rte_config and .rte_hugepage_info,
       // since we don't want to interfere with other DPDK applications.
       "--no-shconf",
+      // TODO(sangjin) switch to dynamic memory mode
+      "--legacy-mem",
   };
 
   if (dpdk_mb_per_socket <= 0) {
+    rte_args.Append({"--iova", "va"});
     rte_args.Append({"--no-huge"});
 
     // even if we opt out of using hugepages, many DPDK libraries still rely on
@@ -128,6 +131,8 @@ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
     // memory in advance. We allocate 512MB (this is shared among nodes).
     rte_args.Append({"-m", "512"});
   } else {
+    rte_args.Append({"--iova", "pa"});
+
     std::string opt_socket_mem = std::to_string(dpdk_mb_per_socket);
     for (int i = 1; i < NumNumaNodes(); i++) {
       opt_socket_mem += "," + std::to_string(dpdk_mb_per_socket);

--- a/core/dpdk.cc
+++ b/core/dpdk.cc
@@ -46,6 +46,7 @@
 #include <string>
 
 #include "memory.h"
+#include "opts.h"
 #include "worker.h"
 
 namespace bess {
@@ -123,7 +124,7 @@ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
   };
 
   if (dpdk_mb_per_socket <= 0) {
-    rte_args.Append({"--iova", "va"});
+    rte_args.Append({"--iova", (FLAGS_iova != "") ? FLAGS_iova : "va"});
     rte_args.Append({"--no-huge"});
 
     // even if we opt out of using hugepages, many DPDK libraries still rely on
@@ -131,7 +132,7 @@ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
     // memory in advance. We allocate 512MB (this is shared among nodes).
     rte_args.Append({"-m", "512"});
   } else {
-    rte_args.Append({"--iova", "pa"});
+    rte_args.Append({"--iova", (FLAGS_iova != "") ? FLAGS_iova : "pa"});
 
     std::string opt_socket_mem = std::to_string(dpdk_mb_per_socket);
     for (int i = 1; i < NumNumaNodes(); i++) {

--- a/core/opts.cc
+++ b/core/opts.cc
@@ -58,6 +58,13 @@ DEFINE_bool(no_crashlog, false, "Disable the generation of a crash log file");
 //       so DPDK is default for now.
 DEFINE_bool(dpdk, true, "Let DPDK manage hugepages");
 
+static bool ValidateIovaMode(const char *, const std::string &value) {
+  return (value == "") || (value == "pa") || (value == "va");
+}
+DEFINE_string(iova, "", "DPDK IOVA mode: pa or va. Set auto if not specified");
+static bool _iova_dummy[[maybe_unused]] =
+    google::RegisterFlagValidator(&FLAGS_iova, &ValidateIovaMode);
+
 static bool ValidateCoreID(const char *, int32_t value) {
   if (!is_cpu_present(value)) {
     LOG(ERROR) << "Invalid core ID: " << value;

--- a/core/opts.h
+++ b/core/opts.h
@@ -50,5 +50,6 @@ DECLARE_bool(core_dump);
 DECLARE_bool(no_crashlog);
 DECLARE_int32(buffers);
 DECLARE_bool(dpdk);
+DECLARE_string(iova);
 
 #endif  // BESS_OPTS_H_


### PR DESCRIPTION
... to PA or VA, based on whether hugepages are being used or not.
Otherwise, what mode is used heuristically depends on the current
current configuration of the system, sometimes ends up with not
what we want (e.g., PA mode is used even when run by non-root users)

https://software.intel.com/en-us/articles/memory-in-dpdk-part-2-deep-dive-into-iova

---

Without this patch, bessd (or unit tests) may crash if
* some NICs are bound to `vfio-pci`,
* `/sys/module/vfio/parameters/enable_unsafe_noiommu_mode` is set,
* bessd is run by non-privileged user without hugepages.