### PR TITLE
Build *.so files for plugin modules

### DIFF
--- a/build.py
+++ b/build.py
@@ -397,7 +397,7 @@ def build_bess():
     sys.stdout.flush()
     cmd('bin/bessctl daemon stop 2> /dev/null || true', shell=True)
     cmd('rm -f core/bessd')  # force relink as DPDK might have been rebuilt
-    cmd('make -C core bessd all_test %s' % makeflags())
+    cmd('make -C core bessd modules all_test %s' % makeflags())
 
 
 def build_kmod():


### PR DESCRIPTION
Modules in plugins are built as *.so dynamic loadable library, ratherthan being embedded in the bessd executable. Commit 0928eccf accidentally broke this, not building *.so files.