### PR TITLE
Resolving the invalid RSS configuration problem for vhost PMD ports.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,3 +61,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Ryan Standt
 * Tim Rozet
 * Alireza Sanaee
+* Brent Stephens

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Anton Ivanov
 * Ryan Standt
 * Tim Rozet
+* Alireza Sanaee

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -43,14 +43,14 @@
 #define SN_HW_RXCSUM 0
 #define SN_HW_TXCSUM 0
 
-static const struct rte_eth_conf default_eth_conf(struct rte_eth_dev_info dev_info, int num_rxq) {
+static const struct rte_eth_conf default_eth_conf(struct rte_eth_dev_info dev_info) {
   struct rte_eth_conf ret = rte_eth_conf();
   uint64_t rss_hf = ETH_RSS_IP | ETH_RSS_UDP | ETH_RSS_TCP | ETH_RSS_SCTP;
 
-  if (num_rxq <= 1) {
-    rss_hf = 0;
-  } else if (dev_info.flow_type_rss_offloads) {
+  if (dev_info.flow_type_rss_offloads) {
     rss_hf = dev_info.flow_type_rss_offloads;
+  } else {
+    rss_hf = 0;
   }
 
   ret.link_speeds = ETH_LINK_SPEED_AUTONEG;
@@ -266,7 +266,7 @@ CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
    * with minor tweaks */
   rte_eth_dev_info_get(ret_port_id, &dev_info);
 
-  eth_conf = default_eth_conf(dev_info, num_rxq);
+  eth_conf = default_eth_conf(dev_info);
   if (arg.loopback()) {
     eth_conf.lpbk_mode = 1;
   }


### PR DESCRIPTION
There is a flow_type_rss_offloads condition added to the PMD port driver
which makes issues for vhost ports requiring more than one queue. Given
that there is no RSS support for vhost ports yet, it should be considered
in that condition.

Before this commit, we weren't able to have a vhost PMD port with more
than one queue, and even the example bess script in `conf/port/vhost/vhost.bess`
with more than one queue --which isn't the default config-- used to have errors.

Signed-off-by: Alireza Sanaee <sarsanaee@gmail.com>