### PR TITLE
Add support for IP/L4 checksum verification.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,5 @@ Please add your name to the end of this file and include this file to the PR, un
 * Tim Rozet
 * Alireza Sanaee
 * Brent Stephens
+* M. Asim Jamshed
+

--- a/bessctl/conf/samples/rxipchecksum.bess
+++ b/bessctl/conf/samples/rxipchecksum.bess
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright(c) 2019 Intel Corporation
+#
+#
+# Copyright (c) 2014-2016, The Regents of the University of California.
+# Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the names of the copyright holders nor the names of their
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import scapy.all as scapy
+
+# 'show module' command shows detailed stats/parameters
+
+pkt_size = int($BESS_PKT_SIZE!'60')
+assert(60 <= pkt_size <= 1522)
+
+eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
+ip = scapy.IP(src='10.0.0.1', dst='10.0.0.2')   # dst IP is overwritten
+tcp = scapy.TCP(sport=10001, dport=10002)
+udp = scapy.UDP(sport=10001, dport=10002)
+payload_tcp = ('hello' + '0123456789' * 200)[:pkt_size-len(eth/ip/tcp)]
+payload_udp = ('hello' + '0123456789' * 200)[:pkt_size-len(eth/ip/udp)]
+pkt_tcp = eth/ip/tcp/payload_tcp
+pkt_udp = eth/ip/udp/payload_udp
+pkt_data_tcp = bytes(pkt_tcp)
+pkt_data_udp = bytes(pkt_udp)
+
+# NOTE: without quick_rampup=1, it takes a while to converge to
+# the desired load level, especially when flow duration is pareto distribution
+
+FlowGen(template=pkt_data_tcp, pps=1e6, flow_rate = 1e4, flow_duration = 10.0, \
+        arrival='exponential', duration='pareto', quick_rampup=True) \
+        -> TcpIPRxChecksum::IPChecksum(verify=True) \
+        -> Sink()
+
+FlowGen(template=pkt_data_udp, pps=1e6, flow_rate = 1e4, flow_duration = 10.0, \
+        arrival='exponential', duration='pareto', quick_rampup=True) \
+        -> UdpIPRxChecksum::IPChecksum(verify=True) \
+        -> Sink()
+
+# Redirect all csum errors packets to sink2 + sink3
+TcpIPRxChecksum:1 -> Sink()
+UdpIPRxChecksum:1 -> Sink()

--- a/bessctl/conf/samples/rxl4checksum.bess
+++ b/bessctl/conf/samples/rxl4checksum.bess
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright(c) 2019 Intel Corporation
+#
+#
+# Copyright (c) 2014-2016, The Regents of the University of California.
+# Copyright (c) 2016-2017, Nefeli Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the names of the copyright holders nor the names of their
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import scapy.all as scapy
+
+# 'show module' command shows detailed stats/parameters
+
+pkt_size = int($BESS_PKT_SIZE!'60')
+assert(60 <= pkt_size <= 1522)
+
+eth = scapy.Ether(src='02:1e:67:9f:4d:ae', dst='06:16:3e:1b:72:32')
+ip = scapy.IP(src='10.0.0.1', dst='10.0.0.2')   # dst IP is overwritten
+tcp = scapy.TCP(sport=10001, dport=10002)
+udp = scapy.UDP(sport=10001, dport=10002)
+payload_tcp = ('hello' + '0123456789' * 200)[:pkt_size-len(eth/ip/tcp)]
+payload_udp = ('hello' + '0123456789' * 200)[:pkt_size-len(eth/ip/udp)]
+pkt_tcp = eth/ip/tcp/payload_tcp
+pkt_udp = eth/ip/udp/payload_udp
+pkt_data_tcp = bytes(pkt_tcp)
+pkt_data_udp = bytes(pkt_udp)
+
+# NOTE: without quick_rampup=1, it takes a while to converge to
+# the desired load level, especially when flow duration is pareto distribution
+
+FlowGen(template=pkt_data_tcp, pps=1e6, flow_rate = 1e4, flow_duration = 10.0, \
+        arrival='exponential', duration='pareto', quick_rampup=True) \
+        -> TcpIPRxChecksum::IPChecksum(verify=True) \
+        -> TcpL4RxChecksum::L4Checksum(verify=True) \
+        -> Sink()
+
+FlowGen(template=pkt_data_udp, pps=1e6, flow_rate = 1e4, flow_duration = 10.0, \
+        arrival='exponential', duration='pareto', quick_rampup=True) \
+        -> UdpIPRxChecksum::IPChecksum(verify=True) \
+        -> UdpL4RxChecksum::L4Checksum(verify=True) \
+        -> Sink()
+
+# Redirect all csum errors packets to sinks2-5
+TcpIPRxChecksum:1 -> Sink()
+TcpL4RxChecksum:1 -> Sink()
+UdpIPRxChecksum:1 -> Sink()
+UdpL4RxChecksum:1 -> Sink()

--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -34,6 +34,8 @@
 #include "../utils/ether.h"
 #include "../utils/ip.h"
 
+enum { FORWARD_GATE = 0, FAIL_GATE };
+
 void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   using bess::utils::be16_t;
   using bess::utils::Ethernet;
@@ -54,7 +56,8 @@ void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       data = qinq + 1;
       ether_type = qinq->ether_type;
       if (ether_type != be16_t(Ethernet::Type::kVlan)) {
-        continue;
+	EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
+	continue;
       }
     }
 
@@ -67,13 +70,22 @@ void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     if (ether_type == be16_t(Ethernet::Type::kIpv4)) {
       ip = reinterpret_cast<Ipv4 *>(data);
     } else {
+      EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
       continue;
     }
 
-    ip->checksum = CalculateIpv4Checksum(*ip);
+    if (verify_) {
+      EmitPacket(ctx, batch->pkts()[i], (VerifyIpv4Checksum(*ip)) ? FORWARD_GATE : FAIL_GATE);
+    } else {
+      ip->checksum = CalculateIpv4Checksum(*ip);
+      EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
+    }
   }
+}
 
-  RunNextModule(ctx, batch);
+CommandResponse IPChecksum::Init(const bess::pb::IPChecksumArg &arg) {
+  verify_ = arg.verify();
+  return CommandSuccess();
 }
 
 ADD_MODULE(IPChecksum, "ip_checksum", "recomputes the IPv4 checksum")

--- a/core/modules/ip_checksum.h
+++ b/core/modules/ip_checksum.h
@@ -37,9 +37,16 @@
 // Compute IP checksum on packet
 class IPChecksum final : public Module {
  public:
-  IPChecksum() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
+  IPChecksum() : Module(), verify_(false) { max_allowed_workers_ = Worker::kMaxWorkers; }
 
+  /* Gates: (0) Default, (1) Drop */
+  static const gate_idx_t kNumOGates = 2;
+  CommandResponse Init(const bess::pb::IPChecksumArg &arg);
   void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
+
+ private:
+  /* enable checksum verification */
+  bool verify_;
 };
 
 #endif  // BESS_MODULES_IP_CHECKSUM_H_

--- a/core/modules/l4_checksum.h
+++ b/core/modules/l4_checksum.h
@@ -36,9 +36,16 @@
 // Compute L4 checksum on packet
 class L4Checksum final : public Module {
  public:
-  L4Checksum() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
+ L4Checksum() : Module(), verify_(false) { max_allowed_workers_ = Worker::kMaxWorkers; }
 
+  /* Gates: (0) Default, (1) Drop */
+  static const gate_idx_t kNumOGates = 2;
+  static const gate_idx_t kNumIGates = MAX_GATES;
+  CommandResponse Init(const bess::pb::L4ChecksumArg &arg);
   void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
+
+ private:
+  bool verify_;
 };
 
 #endif  // BESS_MODULES_L4_CHECKSUM_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -983,6 +983,32 @@ message SourceArg {
 }
 
 /**
+* The IPChecksum module calculates the IPv4 checksum of packets. If
+* verify is set to true, the module can be used to validate the checksum
+* of the IPv4 packet. All non-IPv4 packets are forwarded without
+* modification. Output gates: (0) Default, (1) Drop.
+*
+* __Input Gates__: 1
+* __Output Gates__: 2
+*/
+message IPChecksumArg {
+ bool verify = 1; /// check checksum
+}
+
+/**
+* The L4Checksum module calculates the UDP/IPv4 checksum of packets. If
+* verify is set to true, the module can be used to validate the checksum
+* of the UDP/IPv4 packet. All non-IPv4 packets are forwarded without
+* modification. Output gates: (0) Default, (1) Drop.
+*
+* __Input Gates__: MAX_GATES
+* __Output Gates__: 2
+*/
+message L4ChecksumArg {
+ bool verify = 1; /// check checksum
+}
+
+/**
  * The Split module is a basic classifier which directs packets out a gate
  * based on data in the packet (e.g., if the read in value is 3, the packet
  * is directed out output gate 3).


### PR DESCRIPTION
L4Checksum and IPCheckum verification support is enabled once the
argument 'verify=True' is passed during module initialization.
Default value is set to False. Gate 0 gets all packets that pass
the verification test. Gate 1 gets all the packets that have
incorrect checksums.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>