### PR TITLE
Allow 'Debian' to use ansible dependency build script

### DIFF
--- a/env/build-dep.yml
+++ b/env/build-dep.yml
@@ -36,7 +36,7 @@
         - libgrpc++-dev
         - libprotobuf-dev
         - protobuf-compiler-grpc
-      when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 18
+      when: ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 18)
 
     # for Ubuntu < 18.04, grpc has to be installed manually
     - name: Install gRPC and its requirements (from source)


### PR DESCRIPTION
The ansible script assumes 'Ubuntu' only for the logic to check distro and it's version to add ppa source and build from source appropriately as needed. This PR allows 'Debian' to add build dependencies. 

(Tested on Debian10+)