### PR TITLE
Do not build dpdk with fPIC options

### DIFF
--- a/build.py
+++ b/build.py
@@ -95,7 +95,7 @@ DPDK_TARGET = 'x86_64-native-linuxapp-gcc'
 kernel_release = cmd('uname -r', quiet=True).strip()
 
 DPDK_DIR = '%s/%s' % (DEPS_DIR, DPDK_VER)
-DPDK_CFLAGS = '"-g -w -fPIC"'
+DPDK_CFLAGS = '"-g -w"'
 DPDK_CONFIG = '%s/build/.config' % DPDK_DIR
 
 extra_libs = set()


### PR DESCRIPTION
- This option added before to resolve the issues from older version of
  gcc (gcc-5, gcc-6), which defaultly enable pie mode. This bug had been
  fixed on the newer version of gcc.

- If stack protector option enabled on kernel (CC_STACKPROTECTOR_STRONG,
  or STACKPROTECTOR_STRONG), pie is not allowed. This is defaultly
  enabled on many of recent Debian-family distros, so The option `-fPIC`
  triggers an build error for some driver modules (e.g., kmoe, igb_uio)

- To support default kernel option for stack protector, and as a fact
  that PIE is not default for recent version of gcc anymore, we can
  remove fPIC from the option.

- Still build with old gcc versions on newer kernel have a chance to
  failure, in that case, multiple options may available
  (though, I didn't test those options by myself)

  1) upgrade gcc to newer version
  2) override DPDK_CFLAGS to set -fPIC
  3) disable STACKPROTECTOR_STRONG from kernel config
  4) disable PIE option on KBUILD_CFLAGS (--no-pie)