### PR TITLE
Add CPU flag to customize the `-march` build option

### DIFF
--- a/build.py
+++ b/build.py
@@ -288,14 +288,14 @@ def download_dpdk(quiet=False):
 
 
 def configure_dpdk():
-    print('Configuring DPDK...')
+    arch = os.getenv('CPU', 'native')
+    print('Configuring DPDK... (CONFIG_RTE_MACHINE=%s)' % arch)
 
+    set_config('%s/config/defconfig_%s' % (DPDK_DIR, DPDK_TARGET),
+               "CONFIG_RTE_MACHINE", arch)
     check_kernel_headers()
-
     check_mlx()
-
     generate_dpdk_extra_mk()
-
     cmd('make -C %s config T=%s' % (DPDK_DIR, DPDK_TARGET))
 
 

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ kernel_release = cmd('uname -r', quiet=True).strip()
 
 DPDK_DIR = '%s/%s' % (DEPS_DIR, DPDK_VER)
 DPDK_CFLAGS = '"-g -w -fPIC"'
-DPDK_ORIG_CONFIG = '%s/config/common_linux' % DPDK_DIR
+DPDK_CONFIG = '%s/build/.config' % DPDK_DIR
 
 extra_libs = set()
 cxx_flags = []
@@ -197,11 +197,16 @@ def set_config(filename, config, new_value):
     with open(filename) as fp:
         lines = fp.readlines()
 
+    found = False
     with open(filename, 'w') as fp:
         for line in lines:
             if line.startswith(config + '='):
+                found = True
                 line = '%s=%s\n' % (config, new_value)
             fp.write(line)
+
+    assert found, '"%s" is not found in %s' % (config, filename)
+    print('  %s: %s=%s' % (filename, config, new_value))
 
 
 def is_kernel_header_installed():
@@ -212,10 +217,10 @@ def check_kernel_headers():
     # If kernel header is not available, do not attempt to build
     # any components that require kernel.
     if not is_kernel_header_installed():
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_EAL_IGB_UIO', 'n')
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_KNI_KMOD', 'n')
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_LIBRTE_KNI', 'n')
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_LIBRTE_PMD_KNI', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_EAL_IGB_UIO', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_KNI_KMOD', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_LIBRTE_KNI', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_LIBRTE_PMD_KNI', 'n')
 
 
 def check_bnx():
@@ -223,7 +228,7 @@ def check_bnx():
         extra_libs.add('z')
     else:
         print(' - "zlib1g-dev" is not available. Disabling BNX2X PMD...')
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_LIBRTE_BNX2X_PMD', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_LIBRTE_BNX2X_PMD', 'n')
 
 
 def check_mlx():
@@ -239,14 +244,13 @@ def check_mlx():
             print('   NOTE: "libibverbs-dev" does exist, but it does not '
                   'work with MLX PMDs. Instead download OFED from '
                   'http://www.melloanox.com')
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_LIBRTE_MLX4_PMD', 'n')
-        set_config(DPDK_ORIG_CONFIG, 'CONFIG_RTE_LIBRTE_MLX5_PMD', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_LIBRTE_MLX4_PMD', 'n')
+        set_config(DPDK_CONFIG, 'CONFIG_RTE_LIBRTE_MLX5_PMD', 'n')
 
 
 def generate_dpdk_extra_mk():
     with open('core/extra.dpdk.mk', 'w') as fp:
-        fp.write(
-            'LIBS += %s\n' % ' '.join(map(lambda lib: '-l' + lib, extra_libs)))
+        fp.write('LIBS += %s\n' % ' '.join(['-l' + lib for lib in extra_libs]))
 
 
 def find_current_plugins():
@@ -288,15 +292,17 @@ def download_dpdk(quiet=False):
 
 
 def configure_dpdk():
-    arch = os.getenv('CPU', 'native')
-    print('Configuring DPDK... (CONFIG_RTE_MACHINE=%s)' % arch)
+    print('Configuring DPDK...')
+    cmd('make -C %s config T=%s' % (DPDK_DIR, DPDK_TARGET))
 
-    set_config('%s/config/defconfig_%s' % (DPDK_DIR, DPDK_TARGET),
-               "CONFIG_RTE_MACHINE", arch)
     check_kernel_headers()
     check_mlx()
     generate_dpdk_extra_mk()
-    cmd('make -C %s config T=%s' % (DPDK_DIR, DPDK_TARGET))
+
+    arch = os.getenv('CPU')
+    if arch:
+        print(' - Building DPDK with -march=%s' % arch)
+        set_config(DPDK_CONFIG, "CONFIG_RTE_MACHINE", arch)
 
 
 def makeflags():

--- a/core/Makefile
+++ b/core/Makefile
@@ -108,8 +108,8 @@ endif
 # these headers.  Should fix the warnings.  Using -isystem also disables
 # -MMD dependency recording (should we use -MD?).
 COREDIR := $(abspath .)
-CXXARCHFLAGS ?= -march=native
-CXXFLAGS += -std=c++17 -g3 -ggdb3 $(CXXARCHFLAGS) \
+CPU ?= native
+CXXFLAGS += -std=c++17 -g3 -ggdb3 -march=$(CPU) \
             -isystem $(DPDK_INC_DIR) -isystem $(COREDIR) \
             -isystem $(dir $<).. -isystem $(COREDIR)/modules \
             -D_GNU_SOURCE \


### PR DESCRIPTION
BESS versions with DPDK 17.11:
- DPDK was always built with `-march=nehalem`
- BESS was built with `CXXARCHFLAGS`

BESS versions with DPDK 19.11.1:
- DPDK was always built with `-march=native`
- BESS was built with `CXXARCHFLAGS` environment variable

After this PR:
- both DPDK and BESS are built with `CPU` environment variable (`native` if not specified)