### PR TITLE
port.h: bump kDefault*QueueSize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,4 +63,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Alireza Sanaee
 * Brent Stephens
 * M. Asim Jamshed
-
+* Yan Grunenberger

--- a/core/port.h
+++ b/core/port.h
@@ -303,8 +303,8 @@ class Port {
   Conf conf_;
 
  private:
-  static const size_t kDefaultIncQueueSize = 256;
-  static const size_t kDefaultOutQueueSize = 256;
+  static const size_t kDefaultIncQueueSize = 1024;
+  static const size_t kDefaultOutQueueSize = 1024;
 
   static const uint32_t kDefaultMtu = 1500;
 


### PR DESCRIPTION
The current value of kDefaultOutQueueSize is too small for some
paravirtualized adapters such as vmxnet3, and as a result those PMDports
fail during attachment. Bumping up the default value.