### PR TITLE
Apply a hotfix for flakey DPDK parallel build

### DIFF
--- a/build.py
+++ b/build.py
@@ -337,9 +337,9 @@ def build_dpdk():
     if not os.path.exists('%s/build' % DPDK_DIR):
         configure_dpdk()
 
-    # patch bpf_validate as it conflicts with libpcap
-    cmd('patch -d %s -N -p1 < %s/bpf_validate.patch || true' % (DPDK_DIR, DEPS_DIR),
-        shell=True)
+    for f in glob.glob('%s/*.patch' % DEPS_DIR):
+        print('Applying patch %s' % f)
+        cmd('patch -d %s -N -p1 < %s || true' % (DPDK_DIR, f), shell=True)
 
     print('Building DPDK...')
     nproc = int(cmd('nproc', quiet=True))

--- a/deps/ethdev_include.patch
+++ b/deps/ethdev_include.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/librte_ethdev/rte_ethdev.h b/lib/librte_ethdev/rte_ethdev.h
+index d1a593ad1..12a892339 100644
+--- a/lib/librte_ethdev/rte_ethdev.h
++++ b/lib/librte_ethdev/rte_ethdev.h
+@@ -4284,7 +4284,7 @@ __rte_experimental
+ int rte_eth_dev_hairpin_capability_get(uint16_t port_id,
+ 				       struct rte_eth_hairpin_cap *cap);
+ 
+-#include <rte_ethdev_core.h>
++#include "rte_ethdev_core.h"
+ 
+ /**
+  *
+diff --git a/lib/librte_ethdev/rte_ethdev_driver.h b/lib/librte_ethdev/rte_ethdev_driver.h
+index 99d4cd6cd..496c77fb5 100644
+--- a/lib/librte_ethdev/rte_ethdev_driver.h
++++ b/lib/librte_ethdev/rte_ethdev_driver.h
+@@ -15,7 +15,7 @@
+  *
+  */
+ 
+-#include <rte_ethdev.h>
++#include "rte_ethdev.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {


### PR DESCRIPTION
DPDK has a race between building C files and creating symbolic links (`lib/librte_ethdev/*.h` -> `build/include/*.h`) for their dependency headers. This race may cause a build failure on `make -j`. While it is fairly rare, it tends to happen more often on busy machines.

The easiest way to reproduce the bug is to add an artificial delay in the Makefile:

```
--- a/mk/internal/rte.install-post.mk
+++ b/mk/internal/rte.install-post.mk
@@ -31,6 +31,7 @@ define symlink_rule
 $(addprefix $(RTE_OUTPUT)/$(1)/,$(notdir $(2))): $(2)
        @echo "  SYMLINK-FILE $(addprefix $(1)/,$(notdir $(2)))"
        @[ -d $(RTE_OUTPUT)/$(1) ] || mkdir -p $(RTE_OUTPUT)/$(1)
+       sleep 10
        $(Q)ln -nsf `$(RTE_SDK)/buildtools/relpath.sh $$(<) $(RTE_OUTPUT)/$(1)` \
                $(RTE_OUTPUT)/$(1)
 endef
```

the the error looks like:
```
== Build lib/librte_ethdev
[2020-05-13T19:07:26.450Z]   SYMLINK-FILE include/rte_ethdev.h
[2020-05-13T19:07:26.450Z] gcc -Wp,-MD,./.ethdev_private.o.d.tmp  -m64 -pthread -I/var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/lib/librte_eal/linux/eal/include  -march=nehalem -DRTE_MACHINE_CPUFLAG_SSE -DRTE_MACHINE_CPUFLAG_SSE2 -DRTE_MACHINE_CPUFLAG_SSE3 -DRTE_MACHINE_CPUFLAG_SSSE3 -DRTE_MACHINE_CPUFLAG_SSE4_1 -DRTE_MACHINE_CPUFLAG_SSE4_2  -I/var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/build/include -DRTE_USE_FUNCTION_VERSIONING -include /var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/build/include/rte_config.h -D_GNU_SOURCE -DALLOW_EXPERIMENTAL_API -O3 -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wold-style-definition -Wpointer-arith -Wcast-align -Wnested-externs -Wcast-qual -Wformat-nonliteral -Wformat-security -Wundef -Wwrite-strings -Wdeprecated -Wimplicit-fallthrough=2 -Wno-format-truncation -Wno-address-of-packed-member   -g -w -fPIC -o ethdev_private.o -c /var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/lib/librte_ethdev/ethdev_private.c 

[2020-05-13T19:07:27.012Z] In file included from /var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/lib/librte_ethdev/ethdev_private.c:5:0:
[2020-05-13T19:07:27.012Z] /var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/lib/librte_ethdev/rte_ethdev.h:4287:10: fatal error: rte_ethdev_core.h: No such file or directory
[2020-05-13T19:07:27.012Z]  #include <rte_ethdev_core.h>
[2020-05-13T19:07:27.012Z]           ^~~~~~~~~~~~~~~~~~~
[2020-05-13T19:07:27.012Z] compilation terminated.
[2020-05-13T19:07:27.012Z] /var/lib/docker/volumes/jenkins_home/_data/workspace/Deploy/bess-internal/bess/deps/dpdk-19.11.1/mk/internal/rte.compile-pre.mk:114: recipe for target 'ethdev_private.o' failed
```
I am going to send a patch to the DPDK upstream, after figurng out what the root cause of the race is. Until then, we work around the problem with a patch.