### PR TITLE
Add metadata with attribute to the Timestamp module.

### DIFF
--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -47,6 +47,7 @@ class Measure final : public Module {
         jitter_sample_prob_(),
         last_rtt_ns_(),
         offset_(),
+        attr_id_(-1),
         pkt_cnt_(),
         bytes_cnt_() {
     max_allowed_workers_ = Worker::kMaxWorkers;
@@ -77,6 +78,7 @@ class Measure final : public Module {
   uint64_t last_rtt_ns_;
 
   size_t offset_;  // in bytes
+  int attr_id_;
 
   uint64_t pkt_cnt_;
   uint64_t bytes_cnt_;

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -39,7 +39,7 @@ class Timestamp final : public Module {
   using MarkerType = uint32_t;
   static const MarkerType kMarker = 0x54C5BE55;
 
-  Timestamp() : Module() { max_allowed_workers_ = Worker::kMaxWorkers; }
+  Timestamp() : Module(), offset_(), attr_id_(-1) { max_allowed_workers_ = Worker::kMaxWorkers; }
 
   CommandResponse Init(const bess::pb::TimestampArg &arg);
 
@@ -47,6 +47,7 @@ class Timestamp final : public Module {
 
  private:
   size_t offset_;
+  int attr_id_;
 };
 
 #endif  // BESS_MODULES_TIMESTAMP_H_

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -652,7 +652,10 @@ message MACSwapArg {
  */
 message MeasureArg {
   // int64 warmup = 1; /// removed: instead of warmup delay, user should Clear()
-  uint64 offset = 2; /// Where to store the current time within the packet, offset in bytes.
+  oneof type {
+    uint64 offset = 2; /// Where to store the current time within the packet, offset in bytes.
+    string attr_name = 6; /// Where to store the current time as attribute
+  }
   double jitter_sample_prob = 3; /// How often the module should sample packets for inter-packet arrival measurements (to measure jitter).
   uint64 latency_ns_max = 4; /// maximum latency expected, in ns (default 0.1 s)
   uint32 latency_ns_resolution = 5; /// resolution, in ns (default 100)
@@ -1034,7 +1037,10 @@ message SplitArg {
  * __Output Gates__: 1
  */
 message TimestampArg {
-  uint64 offset = 1;
+  oneof type {
+    uint64 offset = 1;
+    string attr_name = 2;
+  }
 }
 
 /**


### PR DESCRIPTION
This patch is useful when Timestamp and Measure modules are used
in tandem. In current version, the default location to store the
metadata in Timestamp module is at Eth/IP4/Udp offset. This may
lead to bugs if the pipeline uses encap/decap operations (header
sizes are changed, and timestamp value can get corrupted).

We propose using attribute option to store timestamp value as
default. Refer to #975 for background.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>