### PR TITLE
Make `interval' argument optional as documented.

### DIFF
--- a/core/modules/dump.cc
+++ b/core/modules/dump.cc
@@ -48,7 +48,9 @@ CommandResponse Dump::Init(const bess::pb::DumpArg &arg) {
   // cannot get a context-based current nanoseconds
   min_interval_ns_ = DEFAULT_INTERVAL_NS;
   next_ns_ = tsc_to_ns(rdtsc());
-  return CommandSetInterval(arg);
+  if (arg.interval())
+    return CommandSetInterval(arg);
+  return CommandSuccess();
 }
 
 void Dump::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {


### PR DESCRIPTION
The wiki page (https://github.com/NetSys/bess/wiki/Built-In-Modules-and-Ports)
mentions that the argument is optional. However the module fails to get
instantiated without adding this argument. This patch fixes this.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>