### PR TITLE
Bypass l4/ip4 csum compute/validate for !tcp/!udp

### DIFF
--- a/core/modules/l4_checksum.cc
+++ b/core/modules/l4_checksum.cc
@@ -76,8 +76,12 @@ void L4Checksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       if (verify_)
 	EmitPacket(ctx, batch->pkts()[i],
 		   (VerifyIpv4TcpChecksum(*ip, *tcp)) ? FORWARD_GATE : FAIL_GATE);
-      else
+      else {
 	tcp->checksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+	EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
+      }
+    } else { /* fail-safe condition. */
+	EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
     }
   }
 }


### PR DESCRIPTION
This patch ensures that ping messages goes through the dataplane pipeline which includes verify checksum module.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
Signed-off-by: Hyunsun Moon <hyunsun@opennetworking.org>