### PR TITLE
Fix Python 3.7/3.8 incompatibility

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1364,7 +1364,8 @@ def _draw_pipeline(cli, field, units, last_stats=None, graph_args=[]):
         f = subprocess.Popen('graph-easy ' + ' '.join(graph_args), shell=True,
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             universal_newlines=True)
 
         for m in modules:
             print('[%s]' % node_labels[m.name], file=f.stdin)
@@ -1789,8 +1790,8 @@ def _monitor_ports(cli, *ports):
         else:
             out_mbps = 0.
 
-        data = (inc_mbps, delta.inc_packets / 1e6, long(delta.inc_dropped), out_mbps, delta.out_packets / 1e6,
-                long(delta.out_dropped))
+        data = (inc_mbps, delta.inc_packets / 1e6, int(delta.inc_dropped), out_mbps, delta.out_packets / 1e6,
+                int(delta.out_dropped))
         cli.fout.write('{:<20}{:>14.1f}{:>10.3f}{:>10d}        {:>14.1f}{:>10.3f}{:>10d}\n'.format(port, *data))
         if csv_f is not None:
             csv_f.write('{},{},{}\n'.format(time.strftime('%X'), port, ','.join(map(lambda x: '{:.3f}'.format(x), data))))
@@ -1905,7 +1906,7 @@ def _monitor_tcs(cli, *tcs):
         else:
             cpp = 0.
 
-        data = (delta.cycles / 1e6, long(delta.count), delta.packets / 1e6, delta.bits / 1e6, ppb, cpp)
+        data = (delta.cycles / 1e6, int(delta.count), delta.packets / 1e6, delta.bits / 1e6, ppb, cpp)
         fmt = '{:<%d}{:>12.3f}{:>12d}{:>12.3f}{:>12.3f}{:>12.3f}{:>12.3f}\n' % (name_len,)
         cli.fout.write(fmt.format(tc, *data))
         if csv_f is not None:

--- a/bessctl/conf/port/vhost/launch_container.py
+++ b/bessctl/conf/port/vhost/launch_container.py
@@ -79,7 +79,7 @@ def launch(cid):
         '--txq={q} --rxq={q} --total-num-mbufs=65536'.format(
             qsize=QSIZE, q=NUM_QUEUES)
 
-    if subprocess.check_output(['numactl', '-H']).find(' 1 nodes') >= 0:
+    if subprocess.check_output(['numactl', '-H'], universal_newlines=True).find(' 1 nodes') >= 0:
         cmd = ''
     else:
         cmd = 'numactl -m %d ' % VM_MEM_SOCKET
@@ -99,10 +99,11 @@ def launch(cid):
         out = subprocess.PIPE
 
     proc = subprocess.Popen(shlex.split(cmd), stdin=subprocess.PIPE,
-                            stdout=out, stderr=subprocess.STDOUT)
-    proc.stdin.write('set fwd {}\n'.format(FWD_MODE))
-    proc.stdin.write('set txpkts {}\n'.format(PKT_SIZE))
-    proc.stdin.write('start tx_first {}\n'.format(QSIZE))
+                            stdout=out, stderr=subprocess.STDOUT,
+                            universal_newlines=True)
+    print('set fwd {}'.format(FWD_MODE), file=proc.stdin)
+    print('set txpkts {}'.format(PKT_SIZE), file=proc.stdin)
+    print('start tx_first {}'.format(QSIZE), file=proc.stdin, flush=True)
     return proc
 
 

--- a/bessctl/conf/port/vhost/launch_vm.py
+++ b/bessctl/conf/port/vhost/launch_vm.py
@@ -119,7 +119,7 @@ def launch(vm_id, num_nics, vhost_opts):
     assert(vm_id < 10)
     assert(num_nics < 10)
 
-    if subprocess.check_output(shlex.split('numactl -H')).find(' 1 nodes') >= 0:
+    if subprocess.check_output(['numactl', '-H'], universal_newlines=True).find(' 1 nodes') >= 0:
         cmd = ''
     else:
         cmd = 'numactl -m %d ' % VM_MEM_SOCKET
@@ -189,8 +189,8 @@ def run_forward(vm_id, num_nics):
         '--total-num-mbufs=65536' \
         .format(qsize=QSIZE, q=NUM_QUEUES, fwdcores=NUM_VCPUS - 1)
     testpmd_cmd = 'sudo ./testpmd {} -- {}'.format(eal_opt, testpmd_opt)
-    cmd = ssh_cmd(vm_id, '(echo -e "set fwd %s\nstart tx_first %d" && cat) | %s'
-                  % (FWD_MODE, QSIZE, testpmd_cmd))
+    cmd = ssh_cmd(vm_id, '(echo -e "set fwd %s\nset txpkts %d\nstart tx_first %d" && cat) | %s'
+                  % (FWD_MODE, PKT_SIZE, QSIZE, testpmd_cmd))
     if VERBOSE:
         print(cmd)
     subprocess.Popen(shlex.split(cmd))

--- a/bessctl/conf/samples/exactmatch.bess
+++ b/bessctl/conf/samples/exactmatch.bess
@@ -68,7 +68,7 @@ em.add(fields=[{'value_int':6}, {'value_bin':aton('172.12.55.99')}, {'value_bin'
 em.add(fields=[{'value_int':17}, {'value_bin':aton('172.12.55.99')}, {'value_bin':aton('12.34.56.78')}], gate=2)
 
 # delete test
-em.add(fields=[{'value_bin':chr(17)}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
-em.delete(fields=[{'value_bin':chr(17)}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
+em.add(fields=[{'value_bin':b'\x11'}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}], gate=3)
+em.delete(fields=[{'value_bin':b'\x11'}, {'value_bin':aton('192.168.1.123')}, {'value_bin':aton('12.34.56.78')}])
 
 em.set_default_gate(gate=5)


### PR DESCRIPTION
This patch fixes miscellaneous compatibility issues of bessctl and its sample scripts for Python 3.7 & Python 3.8.

See #917. 