### PR TITLE
Add per-queue stats to bessctl

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1445,8 +1445,10 @@ def _show_port(cli, port):
 
     port_config = cli.bess.get_port_config(port.name)
 
-    cli.fout.write('  %-12s Driver %-10s HWaddr %-18s MTU %-6d\n' %
-                   (port.name, port.driver, port.mac_addr, port_config.conf.mtu))
+    cli.fout.write('  %-12s Driver %-10s HWaddr %-18s MTU %-5d %s\n' %
+                   (port.name, port.driver,
+                    port_config.conf.mac_addr, port_config.conf.mtu,
+                    'Enabled' if port_config.conf.admin_up else 'Disabled'))
     cli.fout.write('  %-12s Speed %-11s Link %-5s Duplex %-5s Autoneg %-5s\n' %
                    ('', speed, link, duplex, autoneg))
     stats = cli.bess.get_port_stats(port.name)

--- a/core/bessctl.cc
+++ b/core/bessctl.cc
@@ -1133,22 +1133,10 @@ class BESSControlImpl final : public BESSControl::Service {
     response->mutable_inc()->set_packets(stats.inc.packets);
     response->mutable_inc()->set_dropped(stats.inc.dropped);
     response->mutable_inc()->set_bytes(stats.inc.bytes);
-    *response->mutable_inc()->mutable_requested_hist() = {
-        stats.inc.requested_hist.begin(), stats.inc.requested_hist.end()};
-    *response->mutable_inc()->mutable_actual_hist() = {
-        stats.inc.actual_hist.begin(), stats.inc.actual_hist.end()};
-    *response->mutable_inc()->mutable_diff_hist() = {
-        stats.inc.diff_hist.begin(), stats.inc.diff_hist.end()};
 
     response->mutable_out()->set_packets(stats.out.packets);
     response->mutable_out()->set_dropped(stats.out.dropped);
     response->mutable_out()->set_bytes(stats.out.bytes);
-    *response->mutable_out()->mutable_requested_hist() = {
-        stats.out.requested_hist.begin(), stats.out.requested_hist.end()};
-    *response->mutable_out()->mutable_actual_hist() = {
-        stats.out.actual_hist.begin(), stats.out.actual_hist.end()};
-    *response->mutable_out()->mutable_diff_hist() = {
-        stats.out.diff_hist.begin(), stats.out.diff_hist.end()};
 
     response->set_timestamp(get_epoch_time());
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -434,7 +434,7 @@ void PMDPort::CollectStats(bool reset) {
     return;
   }
 
-  VLOG(1) << bess::utils::Format(
+  VLOG(2) << bess::utils::Format(
       "PMD port %d: ipackets %" PRIu64 " opackets %" PRIu64 " ibytes %" PRIu64
       " obytes %" PRIu64 " imissed %" PRIu64 " ierrors %" PRIu64
       " oerrors %" PRIu64 " rx_nombuf %" PRIu64,

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -189,7 +189,7 @@ static CommandResponse find_dpdk_vdev(const std::string &vdev,
 
   rte_dev_iterator iterator;
   RTE_ETH_FOREACH_MATCHING_DEV(port_id, vdev.c_str(), &iterator) {
-    LOG(INFO) << "port id: " << port_id << "matches vdev: " << vdev;
+    LOG(INFO) << "port id " << port_id << " matches vdev '" << vdev << "'";
     rte_eth_iterator_cleanup(&iterator);
     break;
   }

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -458,15 +458,15 @@ void PMDPort::CollectStats(bool reset) {
   } else {
     dir = PACKET_DIR_INC;
     for (qid = 0; qid < num_queues[dir]; qid++) {
-      queue_stats[dir][qid].packets = stats.q_ipackets[qid];
-      queue_stats[dir][qid].bytes = stats.q_ibytes[qid];
-      queue_stats[dir][qid].dropped = stats.q_errors[qid];
+      queue_stats_[dir][qid].packets = stats.q_ipackets[qid];
+      queue_stats_[dir][qid].bytes = stats.q_ibytes[qid];
+      queue_stats_[dir][qid].dropped = stats.q_errors[qid];
     }
 
     dir = PACKET_DIR_OUT;
     for (qid = 0; qid < num_queues[dir]; qid++) {
-      queue_stats[dir][qid].packets = stats.q_opackets[qid];
-      queue_stats[dir][qid].bytes = stats.q_obytes[qid];
+      queue_stats_[dir][qid].packets = stats.q_opackets[qid];
+      queue_stats_[dir][qid].bytes = stats.q_obytes[qid];
     }
   }
 }
@@ -479,7 +479,7 @@ int PMDPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
 int PMDPort::SendPackets(queue_t qid, bess::Packet **pkts, int cnt) {
   int sent = rte_eth_tx_burst(dpdk_port_id_, qid,
                               reinterpret_cast<rte_mbuf **>(pkts), cnt);
-  auto &stats = queue_stats[PACKET_DIR_OUT][qid];
+  auto &stats = queue_stats_[PACKET_DIR_OUT][qid];
   int dropped = cnt - sent;
   stats.dropped += dropped;
   stats.requested_hist[cnt]++;

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -479,12 +479,7 @@ int PMDPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
 int PMDPort::SendPackets(queue_t qid, bess::Packet **pkts, int cnt) {
   int sent = rte_eth_tx_burst(dpdk_port_id_, qid,
                               reinterpret_cast<rte_mbuf **>(pkts), cnt);
-  auto &stats = queue_stats_[PACKET_DIR_OUT][qid];
-  int dropped = cnt - sent;
-  stats.dropped += dropped;
-  stats.requested_hist[cnt]++;
-  stats.actual_hist[sent]++;
-  stats.diff_hist[dropped]++;
+  queue_stats_[PACKET_DIR_OUT][qid].dropped += cnt - sent;
   return sent;
 }
 

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -418,9 +418,6 @@ void PMDPort::DeInit() {
 }
 
 void PMDPort::CollectStats(bool reset) {
-  packet_dir_t dir;
-  queue_t qid;
-
   if (reset) {
     rte_eth_stats_reset(dpdk_port_id_);
     return;
@@ -443,31 +440,35 @@ void PMDPort::CollectStats(bool reset) {
 
   port_stats_.inc.dropped = stats.imissed;
 
-  // i40e/net_e1000_igb PMD drivers, ixgbevf and net_bonding vdevs don't support
-  // per-queue stats
-  if (driver_ == "net_i40e" || driver_ == "net_i40e_vf" ||
-      driver_ == "net_ixgbe_vf" || driver_ == "net_bonding" ||
-      driver_ == "net_e1000_igb") {
-    // NOTE:
-    // - if link is down, tx bytes won't increase
-    // - if destination MAC address is incorrect, rx pkts won't increase
+  // NOTE: depending on DPDK PMD drivers,
+  // - if link is down, tx bytes may not increase
+  // - if destination is zero MAC address, rx pkts may not increase
+
+  uint64_t any = 0;
+
+  for (queue_t qid = 0; qid < num_queues[PACKET_DIR_INC]; qid++) {
+    auto &qstats = queue_stats_[PACKET_DIR_INC][qid];
+    any |= (qstats.packets = stats.q_ipackets[qid]);
+    any |= (qstats.bytes = stats.q_ibytes[qid]);
+    any |= (qstats.dropped = stats.q_errors[qid]);
+  }
+
+  for (queue_t qid = 0; qid < num_queues[PACKET_DIR_OUT]; qid++) {
+    auto &qstats = queue_stats_[PACKET_DIR_OUT][qid];
+    any |= (qstats.packets = stats.q_opackets[qid]);
+    any |= (qstats.bytes = stats.q_obytes[qid]);
+  }
+
+  // Some PMD drivers, such as i40e, ixgbevf and net_bonding, do not support
+  // per-queue stats. There doesn't seem to be a reliable way to detect whether
+  // the driver really supports per-queue stats or not. Instead, if all queue
+  // stats counters are 0, we assume that it only supports per-port stats
+  // Note that this heuristic is safe from potential double counting.
+  if (!any) {
     port_stats_.inc.packets = stats.ipackets;
     port_stats_.inc.bytes = stats.ibytes;
     port_stats_.out.packets = stats.opackets;
     port_stats_.out.bytes = stats.obytes;
-  } else {
-    dir = PACKET_DIR_INC;
-    for (qid = 0; qid < num_queues[dir]; qid++) {
-      queue_stats_[dir][qid].packets = stats.q_ipackets[qid];
-      queue_stats_[dir][qid].bytes = stats.q_ibytes[qid];
-      queue_stats_[dir][qid].dropped = stats.q_errors[qid];
-    }
-
-    dir = PACKET_DIR_OUT;
-    for (qid = 0; qid < num_queues[dir]; qid++) {
-      queue_stats_[dir][qid].packets = stats.q_opackets[qid];
-      queue_stats_[dir][qid].bytes = stats.q_obytes[qid];
-    }
   }
 }
 

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -79,7 +79,7 @@ class PMDPort final : public Port {
   void DeInit() override;
 
   /*!
-   * Copies rte port statistics into queue_stats datastructure (see port.h).
+   * Copies rte port statistics into queue_stats_ datastructure (see port.h).
    *
    * PARAMETERS:
    * * bool reset : if true, reset DPDK local statistics and return (do not

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -121,8 +121,8 @@ class PMDPort final : public Port {
    */
   int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
-  uint64_t GetFlags() const override {
-    return DRIVER_FLAG_SELF_INC_STATS | DRIVER_FLAG_SELF_OUT_STATS;
+  DriverFeatures GetFeatures() const override {
+    return {.offloadIncStats = true, .offloadOutStats = true};
   }
 
   LinkStatus GetLinkStatus() override;

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -144,7 +144,7 @@ struct task_result PortInc::RunTask(Context *ctx, bess::PacketBatch *batch,
     }
   }
 
-  if (!(port_->GetFlags() & DRIVER_FLAG_SELF_INC_STATS)) {
+  if (!(port_->GetFeatures().offloadIncStats)) {
     qstats.packets += cnt;
     qstats.bytes += received_bytes;
   }

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -123,14 +123,11 @@ struct task_result PortInc::RunTask(Context *ctx, bess::PacketBatch *batch,
   const int pkt_overhead = 24;
 
   uint32_t cnt = port_->RecvPackets(qid, batch->pkts(), burst);
-  batch->set_cnt(cnt);
-  qstats.requested_hist[burst]++;
-  qstats.actual_hist[cnt]++;
-  qstats.diff_hist[burst - cnt]++;
-
   if (cnt == 0) {
     return {.block = true, .packets = 0, .bits = 0};
   }
+
+  batch->set_cnt(cnt);
 
   // NOTE: we cannot skip this step since it might be used by scheduler.
   if (prefetch_) {

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -97,7 +97,7 @@ static inline int SendBatch(bess::PacketBatch *batch, Port *p, queue_t qid) {
 
   int sent_pkts = p->SendPackets(qid, batch->pkts(), batch->cnt());
 
-  if (!(p->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
+  if (!(p->GetFeatures().offloadOutStats)) {
     uint64_t sent_bytes = 0;
     for (int i = 0; i < sent_pkts; i++) {
       sent_bytes += batch->pkts()[i]->total_len();

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -103,10 +103,8 @@ static inline int SendBatch(bess::PacketBatch *batch, Port *p, queue_t qid) {
       sent_bytes += batch->pkts()[i]->total_len();
     }
 
-    auto &qstats = p->queue_stats_[PACKET_DIR_OUT][qid];
-    qstats.packets += sent_pkts;
-    qstats.dropped += (batch->cnt() - sent_pkts);
-    qstats.bytes += sent_bytes;
+    p->IncreaseOutQueueCounters(qid, sent_pkts, batch->cnt() - sent_pkts,
+                                sent_bytes);
   }
 
   return sent_pkts;

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -91,41 +91,38 @@ std::string PortOut::GetDesc() const {
 }
 
 static inline int SendBatch(bess::PacketBatch *batch, Port *p, queue_t qid) {
-  uint64_t sent_bytes = 0;
-  int sent_pkts = 0;
-
-  if (p->conf().admin_up) {
-    sent_pkts = p->SendPackets(qid, batch->pkts(), batch->cnt());
+  if (!p->conf().admin_up) {
+    return 0;
   }
 
-  if (!(p->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
-    const packet_dir_t dir = PACKET_DIR_OUT;
+  int sent_pkts = p->SendPackets(qid, batch->pkts(), batch->cnt());
 
+  if (!(p->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
+    uint64_t sent_bytes = 0;
     for (int i = 0; i < sent_pkts; i++) {
       sent_bytes += batch->pkts()[i]->total_len();
     }
 
-    p->queue_stats[dir][qid].packets += sent_pkts;
-    p->queue_stats[dir][qid].dropped += (batch->cnt() - sent_pkts);
-    p->queue_stats[dir][qid].bytes += sent_bytes;
+    auto &qstats = p->queue_stats_[PACKET_DIR_OUT][qid];
+    qstats.packets += sent_pkts;
+    qstats.dropped += (batch->cnt() - sent_pkts);
+    qstats.bytes += sent_bytes;
   }
 
   return sent_pkts;
 }
 
 void PortOut::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  Port *p = port_;
-
   CHECK(worker_queues_[ctx->wid] >= 0);
   queue_t qid = worker_queues_[ctx->wid];
   int sent_pkts = 0;
 
   if (queue_users_[qid] == 1) {
-    sent_pkts = SendBatch(batch, p, qid);
+    sent_pkts = SendBatch(batch, port_, qid);
   } else {
     mcslock_node_t me;
     mcs_lock(&queue_locks_[qid], &me);
-    sent_pkts = SendBatch(batch, p, qid);
+    sent_pkts = SendBatch(batch, port_, qid);
     mcs_unlock(&queue_locks_[qid], &me);
   }
 

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -86,29 +86,28 @@ std::string QueueInc::GetDesc() const {
 
 struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
                                      void *arg) {
-  Port *p = port_;
-
-  if (!p->conf().admin_up) {
+  if (!port_->conf().admin_up) {
     return {.block = true, .packets = 0, .bits = 0};
   }
 
   const queue_t qid = (queue_t)(uintptr_t)arg;
-
-  uint64_t received_bytes = 0;
+  auto &qstats = port_->queue_stats_[PACKET_DIR_INC][qid];
 
   const int burst = ACCESS_ONCE(burst_);
   const int pkt_overhead = 24;
 
-  batch->set_cnt(p->RecvPackets(qid, batch->pkts(), burst));
-  uint32_t cnt = batch->cnt();
-  p->queue_stats[PACKET_DIR_INC][qid].requested_hist[burst]++;
-  p->queue_stats[PACKET_DIR_INC][qid].actual_hist[cnt]++;
-  p->queue_stats[PACKET_DIR_INC][qid].diff_hist[burst - cnt]++;
+  uint32_t cnt = port_->RecvPackets(qid, batch->pkts(), burst);
+  batch->set_cnt(cnt);
+  qstats.requested_hist[burst]++;
+  qstats.actual_hist[cnt]++;
+  qstats.diff_hist[burst - cnt]++;
+
   if (cnt == 0) {
     return {.block = true, .packets = 0, .bits = 0};
   }
 
   // NOTE: we cannot skip this step since it might be used by scheduler.
+  uint64_t received_bytes = 0;
   if (prefetch_) {
     for (uint32_t i = 0; i < cnt; i++) {
       received_bytes += batch->pkts()[i]->total_len();
@@ -120,9 +119,9 @@ struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
     }
   }
 
-  if (!(p->GetFlags() & DRIVER_FLAG_SELF_INC_STATS)) {
-    p->queue_stats[PACKET_DIR_INC][qid].packets += cnt;
-    p->queue_stats[PACKET_DIR_INC][qid].bytes += received_bytes;
+  if (!(port_->GetFlags() & DRIVER_FLAG_SELF_INC_STATS)) {
+    qstats.packets += cnt;
+    qstats.bytes += received_bytes;
   }
 
   RunNextModule(ctx, batch);

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -91,8 +91,6 @@ struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
   }
 
   const queue_t qid = (queue_t)(uintptr_t)arg;
-  auto &qstats = port_->queue_stats_[PACKET_DIR_INC][qid];
-
   const int burst = ACCESS_ONCE(burst_);
   const int pkt_overhead = 24;
 
@@ -117,8 +115,7 @@ struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
   }
 
   if (!(port_->GetFeatures().offloadIncStats)) {
-    qstats.packets += cnt;
-    qstats.bytes += received_bytes;
+    port_->IncreaseIncQueueCounters(qid, cnt, 0, received_bytes);
   }
 
   RunNextModule(ctx, batch);

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -97,14 +97,11 @@ struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
   const int pkt_overhead = 24;
 
   uint32_t cnt = port_->RecvPackets(qid, batch->pkts(), burst);
-  batch->set_cnt(cnt);
-  qstats.requested_hist[burst]++;
-  qstats.actual_hist[cnt]++;
-  qstats.diff_hist[burst - cnt]++;
-
   if (cnt == 0) {
     return {.block = true, .packets = 0, .bits = 0};
   }
+
+  batch->set_cnt(cnt);
 
   // NOTE: we cannot skip this step since it might be used by scheduler.
   uint64_t received_bytes = 0;

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -119,7 +119,7 @@ struct task_result QueueInc::RunTask(Context *ctx, bess::PacketBatch *batch,
     }
   }
 
-  if (!(port_->GetFlags() & DRIVER_FLAG_SELF_INC_STATS)) {
+  if (!(port_->GetFeatures().offloadIncStats)) {
     qstats.packets += cnt;
     qstats.bytes += received_bytes;
   }

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -74,27 +74,22 @@ std::string QueueOut::GetDesc() const {
 }
 
 void QueueOut::ProcessBatch(Context *, bess::PacketBatch *batch) {
-  Port *p = port_;
-
-  const queue_t qid = qid_;
-
-  uint64_t sent_bytes = 0;
   int sent_pkts = 0;
 
-  if (p->conf().admin_up) {
-    sent_pkts = p->SendPackets(qid, batch->pkts(), batch->cnt());
+  if (port_->conf().admin_up) {
+    sent_pkts = port_->SendPackets(qid_, batch->pkts(), batch->cnt());
   }
 
-  if (!(p->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
-    const packet_dir_t dir = PACKET_DIR_OUT;
-
+  if (!(port_->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
+    uint64_t sent_bytes = 0;
     for (int i = 0; i < sent_pkts; i++) {
       sent_bytes += batch->pkts()[i]->total_len();
     }
 
-    p->queue_stats[dir][qid].packets += sent_pkts;
-    p->queue_stats[dir][qid].dropped += (batch->cnt() - sent_pkts);
-    p->queue_stats[dir][qid].bytes += sent_bytes;
+    auto &qstats = port_->queue_stats_[PACKET_DIR_OUT][qid_];
+    qstats.packets += sent_pkts;
+    qstats.dropped += (batch->cnt() - sent_pkts);
+    qstats.bytes += sent_bytes;
   }
 
   if (sent_pkts < batch->cnt()) {

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -86,10 +86,8 @@ void QueueOut::ProcessBatch(Context *, bess::PacketBatch *batch) {
       sent_bytes += batch->pkts()[i]->total_len();
     }
 
-    auto &qstats = port_->queue_stats_[PACKET_DIR_OUT][qid_];
-    qstats.packets += sent_pkts;
-    qstats.dropped += (batch->cnt() - sent_pkts);
-    qstats.bytes += sent_bytes;
+    port_->IncreaseOutQueueCounters(qid_, sent_pkts, batch->cnt() - sent_pkts,
+                                    sent_bytes);
   }
 
   if (sent_pkts < batch->cnt()) {

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -80,7 +80,7 @@ void QueueOut::ProcessBatch(Context *, bess::PacketBatch *batch) {
     sent_pkts = port_->SendPackets(qid_, batch->pkts(), batch->cnt());
   }
 
-  if (!(port_->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
+  if (!(port_->GetFeatures().offloadOutStats)) {
     uint64_t sent_bytes = 0;
     for (int i = 0; i < sent_pkts; i++) {
       sent_bytes += batch->pkts()[i]->total_len();

--- a/core/port.cc
+++ b/core/port.cc
@@ -172,19 +172,22 @@ Port::PortStats Port::GetPortStats() {
 
   PortStats ret = port_stats_;
 
+  ret.inc_queues[-1] = port_stats_.inc;
   for (queue_t qid = 0; qid < num_queues[PACKET_DIR_INC]; qid++) {
     const QueueStats &inc = queue_stats_[PACKET_DIR_INC][qid];
-
     ret.inc.packets += inc.packets;
     ret.inc.dropped += inc.dropped;
     ret.inc.bytes += inc.bytes;
+    ret.inc_queues[qid] = inc;
   }
 
+  ret.out_queues[-1] = port_stats_.out;
   for (queue_t qid = 0; qid < num_queues[PACKET_DIR_OUT]; qid++) {
     const QueueStats &out = queue_stats_[PACKET_DIR_OUT][qid];
     ret.out.packets += out.packets;
     ret.out.dropped += out.dropped;
     ret.out.bytes += out.bytes;
+    ret.out_queues[qid] = out;
   }
 
   return ret;

--- a/core/port.cc
+++ b/core/port.cc
@@ -173,7 +173,7 @@ Port::PortStats Port::GetPortStats() {
   PortStats ret = port_stats_;
 
   for (queue_t qid = 0; qid < num_queues[PACKET_DIR_INC]; qid++) {
-    const QueueStats &inc = queue_stats[PACKET_DIR_INC][qid];
+    const QueueStats &inc = queue_stats_[PACKET_DIR_INC][qid];
 
     ret.inc.packets += inc.packets;
     ret.inc.dropped += inc.dropped;
@@ -184,7 +184,7 @@ Port::PortStats Port::GetPortStats() {
   }
 
   for (queue_t qid = 0; qid < num_queues[PACKET_DIR_OUT]; qid++) {
-    const QueueStats &out = queue_stats[PACKET_DIR_OUT][qid];
+    const QueueStats &out = queue_stats_[PACKET_DIR_OUT][qid];
     ret.out.packets += out.packets;
     ret.out.dropped += out.dropped;
     ret.out.bytes += out.bytes;

--- a/core/port.cc
+++ b/core/port.cc
@@ -178,9 +178,6 @@ Port::PortStats Port::GetPortStats() {
     ret.inc.packets += inc.packets;
     ret.inc.dropped += inc.dropped;
     ret.inc.bytes += inc.bytes;
-    ret.inc.requested_hist += inc.requested_hist;
-    ret.inc.actual_hist += inc.actual_hist;
-    ret.inc.diff_hist += inc.diff_hist;
   }
 
   for (queue_t qid = 0; qid < num_queues[PACKET_DIR_OUT]; qid++) {
@@ -188,9 +185,6 @@ Port::PortStats Port::GetPortStats() {
     ret.out.packets += out.packets;
     ret.out.dropped += out.dropped;
     ret.out.bytes += out.bytes;
-    ret.out.requested_hist += out.requested_hist;
-    ret.out.actual_hist += out.actual_hist;
-    ret.out.diff_hist += out.diff_hist;
   }
 
   return ret;

--- a/core/port.h
+++ b/core/port.h
@@ -177,23 +177,10 @@ class PortBuilder {
                       // InitPortClass()?
 };
 
-struct BatchHistogram
-    : public std::array<uint64_t, bess::PacketBatch::kMaxBurst + 1> {
-  BatchHistogram &operator+=(const BatchHistogram &rhs) {
-    for (size_t i = 0; i < size(); i++) {
-      (*this)[i] += rhs[i];
-    }
-    return *this;
-  }
-};
-
 struct QueueStats {
   uint64_t packets;
   uint64_t dropped;  // Not all drivers support this for INC direction
   uint64_t bytes;    // It doesn't include Ethernet overhead
-  BatchHistogram requested_hist;
-  BatchHistogram actual_hist;
-  BatchHistogram diff_hist;
 };
 
 class Port {

--- a/core/port.h
+++ b/core/port.h
@@ -177,12 +177,6 @@ class PortBuilder {
                       // InitPortClass()?
 };
 
-struct QueueStats {
-  uint64_t packets;
-  uint64_t dropped;  // Not all drivers support this for INC direction
-  uint64_t bytes;    // It doesn't include Ethernet overhead
-};
-
 class Port {
  public:
   struct LinkStatus {
@@ -198,9 +192,20 @@ class Port {
     bool admin_up;
   };
 
+  struct QueueStats {
+    uint64_t packets;
+    uint64_t dropped;  // Not all drivers support this for INC direction
+    uint64_t bytes;    // It doesn't include Ethernet overhead
+  };
+
   struct PortStats {
     QueueStats inc;
     QueueStats out;
+
+    // Per-queue stat counters. The sum of all queues should match the above `inc`.
+    // Key -1 is used when exact queues are unknown.
+    std::map<int, Port::QueueStats> inc_queues;
+    std::map<int, Port::QueueStats> out_queues;
   };
 
   struct DriverFeatures {
@@ -266,6 +271,7 @@ class Port {
   CommandResponse InitWithGenericArg(const google::protobuf::Any &arg);
 
   PortStats GetPortStats();
+  std::map<int, QueueStats> GetQueueStats();
 
   /* queues == nullptr if _all_ queues are being acquired/released */
   int AcquireQueues(const struct module *m, packet_dir_t dir,

--- a/core/port.h
+++ b/core/port.h
@@ -49,9 +49,9 @@
 #include "utils/common.h"
 #include "utils/ether.h"
 
-typedef uint8_t queue_t;
+using queue_t = uint8_t;
 
-#define MAX_QUEUES_PER_DIR 128 /* [0, 31] (for each RX/TX) */
+#define MAX_QUEUES_PER_DIR 128 /* [0, 127] (for each RX/TX) */
 
 #define DRIVER_FLAG_SELF_INC_STATS 0x0001
 #define DRIVER_FLAG_SELF_OUT_STATS 0x0002
@@ -217,15 +217,15 @@ class Port {
 
   // overide this section to create a new driver -----------------------------
   Port()
-      : port_stats_(),
+      : queue_stats_(),
+        port_stats_(),
         conf_(),
         name_(),
         driver_arg_(),
         port_builder_(),
         num_queues(),
         queue_size(),
-        users(),
-        queue_stats() {
+        users() {
     conf_.mac_addr.Randomize();
     conf_.mtu = kDefaultMtu;
     conf_.admin_up = true;
@@ -293,6 +293,9 @@ class Port {
 
   const PortBuilder *port_builder() const { return port_builder_; }
 
+  // per-queue stat counters
+  QueueStats queue_stats_[PACKET_DIRS][MAX_QUEUES_PER_DIR];
+
  protected:
   friend class PortBuilder;
 
@@ -330,8 +333,6 @@ class Port {
   /* which modules are using this port?
    * TODO: more robust gate keeping */
   const struct module *users[PACKET_DIRS][MAX_QUEUES_PER_DIR];
-
-  struct QueueStats queue_stats[PACKET_DIRS][MAX_QUEUES_PER_DIR];
 };
 
 #define ADD_DRIVER(_DRIVER, _NAME_TEMPLATE, _HELP)                       \

--- a/core/port.h
+++ b/core/port.h
@@ -210,8 +210,8 @@ class Port {
 
   // overide this section to create a new driver -----------------------------
   Port()
-      : queue_stats_(),
-        port_stats_(),
+      : port_stats_(),
+        queue_stats_(),
         conf_(),
         name_(),
         driver_arg_(),
@@ -286,14 +286,30 @@ class Port {
 
   const PortBuilder *port_builder() const { return port_builder_; }
 
-  // per-queue stat counters
-  QueueStats queue_stats_[PACKET_DIRS][MAX_QUEUES_PER_DIR];
+  void IncreaseIncQueueCounters(queue_t qid, uint64_t received,
+                                uint64_t dropped, uint64_t received_bytes) {
+    auto &qstats = queue_stats_[PACKET_DIR_INC][qid];
+    qstats.packets += received;
+    qstats.dropped += dropped;
+    qstats.bytes += received_bytes;
+  }
+
+  void IncreaseOutQueueCounters(queue_t qid, uint64_t sent, uint64_t dropped,
+                                uint64_t sent_bytes) {
+    auto &qstats = queue_stats_[PACKET_DIR_OUT][qid];
+    qstats.packets += sent;
+    qstats.dropped += dropped;
+    qstats.bytes += sent_bytes;
+  }
 
  protected:
   friend class PortBuilder;
 
-  // for stats that do NOT belong to any queues
+  // for stats that do NOT counted for any per-queue stats below
   PortStats port_stats_;
+
+  // per-queue stat counters
+  QueueStats queue_stats_[PACKET_DIRS][MAX_QUEUES_PER_DIR];
 
   // Current configuration
   Conf conf_;

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -321,15 +321,15 @@ message GetPortStatsResponse {
 
     // Histogram of how many times a given number of packets in a batch was
     // requested.
-    repeated uint64 requested_hist = 4;
+    reserved 4;  // repeated uint64 requested_hist = 4;
 
     // Histogram of how many times a given number of packets in a batch were
     // actually processed.
-    repeated uint64 actual_hist = 5;
+    reserved 5;  // repeated uint64 actual_hist = 5;
 
     // Histogram of the difference between the requested batch size and the
     // actual number of packets processed in that batch.
-    repeated uint64 diff_hist = 6;
+    reserved 6;  //repeated uint64 diff_hist = 6;
   }
   Error error = 1;
   Stat inc = 2;          /// Port stats for incoming (Ext -> BESS) direction.

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -332,9 +332,15 @@ message GetPortStatsResponse {
     reserved 6;  //repeated uint64 diff_hist = 6;
   }
   Error error = 1;
+
   Stat inc = 2;          /// Port stats for incoming (Ext -> BESS) direction.
   Stat out = 3;          /// Port stats for outgoing (BESS -> Ext) direction.
+
   double timestamp = 4;  /// Time that stat counters were read.
+
+  /// qid -> Stat. qid -1 for "counters with unknown queue ID"
+  map<int32, Stat> inc_queues = 5;   /// per-queue stats for RX direction
+  map<int32, Stat> out_queues = 6;   /// per-queue stats for TX direction
 }
 
 message GetLinkStatusRequest {
@@ -348,10 +354,6 @@ message GetLinkStatusResponse {
   bool autoneg = 4;      /// auto-negotiated speed and duplex?
   bool link_up = 5;      /// link up?
 }
-
-
-
-
 
 message ListMclassResponse {
   Error error = 1;


### PR DESCRIPTION
... w/ some code polishing around it. From bessctl:

* `show port` command now shows counters for each queue, rather than aggregated ones only.
* a new command `monitor queue` has been added.