### PR TITLE
Fix compilation issue on Ubuntu 20.04

### DIFF
--- a/core/kmod/llring.h
+++ b/core/kmod/llring.h
@@ -97,7 +97,11 @@
 #define _LLRING_H_
 
 #if !defined(__cplusplus) // C
+#ifdef fallthrough
+#define FALLTHROUGH __attribute__((__fallthrough__))
+#else
 #define FALLTHROUGH __attribute__((fallthrough))
+#endif
 #elif __cplusplus <= 201402L && defined(__clang__) // C++14 or older, Clang
 #define FALLTHROUGH [[clang::fallthrough]]
 #elif __cplusplus <= 201402L && __GNUC__ < 7 // C++14 or older, pre-GCC 7


### PR DESCRIPTION
Ubuntu 20.04 ships with a recent kernel >= 5.4 by default.
Unfortunately, BESS fails to compile on the system, due to the `fallthrough` pseudo keyword added on recent versions of the kernel.
https://github.com/torvalds/linux/commit/294f69e662d1570703e9b56e95be37a9fd3afba5 shows the change on the kernel, which is applied since kernel >= 5.4. 

For the successful compilation on Ubuntu 20.04, it seems that `core/kmod/llring.h` should use `__attribute__((__fallthrough__))`  instead of `__attribute__((fallthrough))` as a definition of `FALLTHROUGH`, along with removing fPIC options as suggested by shinae-woo@e39efb7.