### PR TITLE
Fix missing column header in 'monitor tc' csv output

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -1948,7 +1948,7 @@ def _monitor_tcs(cli, *tcs):
         csv_path = os.getenv('CSV', None)
         with open(csv_path, 'w') if csv_path is not None else noop() as csv_f:
             if csv_f is not None:
-                csv_f.write('{}\n'.format(','.join(('Timestamp',) + FIELDS)))
+                csv_f.write('{}\n'.format(','.join(('Timestamp','traffic class',) + FIELDS)))
             print_loop(csv_f)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
I have just started to use the CSV output of `monitor tc`. That is a really cool feature, thanks!
Unfortunately, the headers are skewed due to a missing TC column header. 
The PR fixes this issue.

----
**Demo:**
```
$ CSV=/tmp/bess.csv ./bessctl run samples/update -- monitor tc
```

Before:
*csv file*
```
Timestamp,CPU MHz,scheduled,Mpps,Mbps,pkts/sched,cycles/p
08:50:57,W0 !leaf_source0:0,2400.050,2491609.000,79.732,53579.580,32.000,30.102
08:50:58,W0 !leaf_source0:0,2400.048,2490410.000,79.693,53553.796,32.000,30.116
```
*as org table*
```
| Timestamp | CPU MHz            | scheduled |        Mpps |   Mbps | pkts/sched | cycles/p |        |
|  08:50:57 | W0 !leaf_source0:0 |  2400.050 | 2491609.000 | 79.732 |  53579.580 |   32.000 | 30.102 |
|  08:50:58 | W0 !leaf_source0:0 |  2400.048 | 2490410.000 | 79.693 |  53553.796 |   32.000 | 30.116 |
```

After:

```
Timestamp,traffic class,CPU MHz,scheduled,Mpps,Mbps,pkts/sched,cycles/p
08:51:41,W0 !leaf_source0:0,2400.064,2491320.000,79.722,53573.349,32.000,30.105
08:51:42,W0 !leaf_source0:0,2400.049,2493994.000,79.808,53630.849,32.000,30.073
```
```
| Timestamp | traffic class      |  CPU MHz |   scheduled |   Mpps |      Mbps | pkts/sched | cycles/p |
|  08:51:41 | W0 !leaf_source0:0 | 2400.064 | 2491320.000 | 79.722 | 53573.349 |     32.000 |   30.105 |
|  08:51:42 | W0 !leaf_source0:0 | 2400.049 | 2493994.000 | 79.808 | 53630.849 |     32.000 |   30.073 |
```
