### PR TITLE
bessctl: add init/cmd argument introspection

### DIFF
--- a/core/commands.h
+++ b/core/commands.h
@@ -31,7 +31,10 @@
 #ifndef BESS_COMMANDS_H_
 #define BESS_COMMANDS_H_
 
+#include <variant>
 #include <vector>
+
+#include <google/protobuf/descriptor.pb.h>
 
 #include "message.h"
 
@@ -50,6 +53,8 @@ using module_cmd_func_t =
     pb_func_t<CommandResponse, Module, google::protobuf::Any>;
 using gate_hook_cmd_func_t =
     pb_func_t<CommandResponse, bess::GateHook, google::protobuf::Any>;
+using CommandArgType =
+    std::variant<std::string, const google::protobuf::Descriptor *>;
 
 // Describes a single command that can be issued to a module
 // or gate hook (according to cmd_func_t).
@@ -58,7 +63,7 @@ struct GenericCommand {
   enum ThreadSafety { THREAD_UNSAFE = 0, THREAD_SAFE = 1 };
 
   std::string cmd;
-  std::string arg_type;
+  CommandArgType arg_type;
   cmd_func_t func;
 
   // If set to THREAD_SAFE, workers don't need to be paused in order to run

--- a/core/gate.h
+++ b/core/gate.h
@@ -164,10 +164,11 @@ class GateHookBuilder {
   const std::string &name_template() const { return name_template_; }
   const std::string &help_text() const { return help_text_; }
 
-  const std::vector<std::pair<std::string, std::string>> cmds() const {
-    std::vector<std::pair<std::string, std::string>> ret;
-    for (auto &cmd : cmds_)
+  const std::vector<std::pair<std::string, CommandArgType>> cmds() const {
+    std::vector<std::pair<std::string, CommandArgType>> ret;
+    for (auto &cmd : cmds_) {
       ret.push_back(std::make_pair(cmd.cmd, cmd.arg_type));
+    }
     return ret;
   }
 

--- a/core/module.cc
+++ b/core/module.cc
@@ -47,11 +47,12 @@ bool ModuleBuilder::RegisterModuleClass(
     std::function<Module *()> module_generator, const std::string &class_name,
     const std::string &name_template, const std::string &help_text,
     const gate_idx_t igates, const gate_idx_t ogates, const Commands &cmds,
-    module_init_func_t init_func) {
+    module_init_func_t init_func, const Descriptor *init_descriptor) {
   all_module_builders_holder().emplace(
       std::piecewise_construct, std::forward_as_tuple(class_name),
       std::forward_as_tuple(module_generator, class_name, name_template,
-                            help_text, igates, ogates, cmds, init_func));
+                            help_text, igates, ogates, cmds, init_func,
+                            init_descriptor));
   return true;
 }
 

--- a/core/modules/acl.cc
+++ b/core/modules/acl.cc
@@ -34,10 +34,10 @@
 #include "../utils/udp.h"
 
 const Commands ACL::cmds = {
-    {"add", "ACLArg", MODULE_CMD_FUNC(&ACL::CommandAdd),
+    {"add", bess::pb::ACLArg::descriptor(), MODULE_CMD_FUNC(&ACL::CommandAdd),
      Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&ACL::CommandClear),
-     Command::THREAD_UNSAFE}};
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&ACL::CommandClear), Command::THREAD_UNSAFE}};
 
 CommandResponse ACL::Init(const bess::pb::ACLArg &arg) {
   for (const auto &rule : arg.rules()) {

--- a/core/modules/arp_responder.cc
+++ b/core/modules/arp_responder.cc
@@ -36,8 +36,8 @@ using bess::utils::Arp;
 using bess::utils::be16_t;
 
 const Commands ArpResponder::cmds = {
-    {"add", "ArpResponderArg", MODULE_CMD_FUNC(&ArpResponder::CommandAdd),
-     Command::THREAD_UNSAFE}};
+    {"add", bess::pb::ArpResponderArg::descriptor(),
+     MODULE_CMD_FUNC(&ArpResponder::CommandAdd), Command::THREAD_UNSAFE}};
 
 CommandResponse ArpResponder::CommandAdd(const bess::pb::ArpResponderArg &arg) {
   be32_t ip_addr;

--- a/core/modules/bpf.cc
+++ b/core/modules/bpf.cc
@@ -49,14 +49,14 @@
 #define SNAPLEN 0xffff
 
 const Commands BPF::cmds = {
-    {"add", "BPFArg", MODULE_CMD_FUNC(&BPF::CommandAdd),
+    {"add", bess::pb::BPFArg::descriptor(), MODULE_CMD_FUNC(&BPF::CommandAdd),
      Command::THREAD_UNSAFE},
-    {"delete", "BPFArg", MODULE_CMD_FUNC(&BPF::CommandDelete),
-     Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&BPF::CommandClear),
-     Command::THREAD_UNSAFE},
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&BPF::GetInitialArg),
-     Command::THREAD_SAFE}};
+    {"delete", bess::pb::BPFArg::descriptor(),
+     MODULE_CMD_FUNC(&BPF::CommandDelete), Command::THREAD_UNSAFE},
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&BPF::CommandClear), Command::THREAD_UNSAFE},
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&BPF::GetInitialArg), Command::THREAD_SAFE}};
 
 CommandResponse BPF::Init(const bess::pb::BPFArg &arg) {
   return CommandAdd(arg);

--- a/core/modules/drr.cc
+++ b/core/modules/drr.cc
@@ -51,9 +51,9 @@ uint32_t RoundToPowerTwo(uint32_t v) {
 }
 
 const Commands DRR::cmds = {
-    {"set_quantum_size", "DRRQuantumArg",
+    {"set_quantum_size", bess::pb::DRRQuantumArg::descriptor(),
      MODULE_CMD_FUNC(&DRR::CommandQuantumSize), Command::THREAD_UNSAFE},
-    {"set_max_flow_queue_size", "DRRMaxFlowQueueSizeArg",
+    {"set_max_flow_queue_size", bess::pb::DRRMaxFlowQueueSizeArg::descriptor(),
      MODULE_CMD_FUNC(&DRR::CommandMaxFlowQueueSize), Command::THREAD_UNSAFE}};
 
 DRR::DRR()
@@ -152,7 +152,9 @@ struct task_result DRR::RunTask(Context *ctx, bess::PacketBatch *batch,
                                 void *) {
   if (children_overload_ > 0) {
     return {
-        .block = true, .packets = 0, .bits = 0,
+        .block = true,
+        .packets = 0,
+        .bits = 0,
     };
   }
 

--- a/core/modules/dump.cc
+++ b/core/modules/dump.cc
@@ -40,8 +40,8 @@
 static const uint64_t DEFAULT_INTERVAL_NS = 1 * NS_PER_SEC; /* 1 sec */
 
 const Commands Dump::cmds = {
-    {"set_interval", "DumpArg", MODULE_CMD_FUNC(&Dump::CommandSetInterval),
-     Command::THREAD_UNSAFE},
+    {"set_interval", bess::pb::DumpArg::descriptor(),
+     MODULE_CMD_FUNC(&Dump::CommandSetInterval), Command::THREAD_UNSAFE},
 };
 
 CommandResponse Dump::Init(const bess::pb::DumpArg &arg) {

--- a/core/modules/exact_match.cc
+++ b/core/modules/exact_match.cc
@@ -43,19 +43,20 @@ static inline int is_valid_gate(gate_idx_t gate) {
 }
 
 const Commands ExactMatch::cmds = {
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&ExactMatch::GetInitialArg),
-     Command::THREAD_SAFE},
-    {"get_runtime_config", "EmptyArg",
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&ExactMatch::GetInitialArg), Command::THREAD_SAFE},
+    {"get_runtime_config", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&ExactMatch::GetRuntimeConfig), Command::THREAD_SAFE},
-    {"set_runtime_config", "ExactMatchConfig",
+    {"set_runtime_config", bess::pb::ExactMatchConfig::descriptor(),
      MODULE_CMD_FUNC(&ExactMatch::SetRuntimeConfig), Command::THREAD_UNSAFE},
-    {"add", "ExactMatchCommandAddArg", MODULE_CMD_FUNC(&ExactMatch::CommandAdd),
-     Command::THREAD_UNSAFE},
-    {"delete", "ExactMatchCommandDeleteArg",
+    {"add", bess::pb::ExactMatchCommandAddArg::descriptor(),
+     MODULE_CMD_FUNC(&ExactMatch::CommandAdd), Command::THREAD_UNSAFE},
+    {"delete", bess::pb::ExactMatchCommandDeleteArg::descriptor(),
      MODULE_CMD_FUNC(&ExactMatch::CommandDelete), Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&ExactMatch::CommandClear),
-     Command::THREAD_UNSAFE},
-    {"set_default_gate", "ExactMatchCommandSetDefaultGateArg",
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&ExactMatch::CommandClear), Command::THREAD_UNSAFE},
+    {"set_default_gate",
+     bess::pb::ExactMatchCommandSetDefaultGateArg::descriptor(),
      MODULE_CMD_FUNC(&ExactMatch::CommandSetDefaultGate),
      Command::THREAD_SAFE}};
 

--- a/core/modules/flowgen.cc
+++ b/core/modules/flowgen.cc
@@ -39,8 +39,8 @@
 #include "../utils/ip.h"
 #include "../utils/simd.h"
 #include "../utils/tcp.h"
-#include "../utils/udp.h"
 #include "../utils/time.h"
+#include "../utils/udp.h"
 
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
@@ -53,9 +53,9 @@ using bess::utils::be32_t;
 const double PARETO_TAIL_LIMIT = 0.99;
 
 const Commands FlowGen::cmds = {
-    {"update", "FlowGenArg", MODULE_CMD_FUNC(&FlowGen::CommandUpdate),
-     Command::THREAD_UNSAFE},
-    {"set_burst", "FlowGenCommandSetBurstArg",
+    {"update", bess::pb::FlowGenArg::descriptor(),
+     MODULE_CMD_FUNC(&FlowGen::CommandUpdate), Command::THREAD_UNSAFE},
+    {"set_burst", bess::pb::FlowGenCommandSetBurstArg::descriptor(),
      MODULE_CMD_FUNC(&FlowGen::CommandSetBurst), Command::THREAD_SAFE}};
 
 /* find x from CDF of pareto distribution from given y in [0.0, 1.0) */
@@ -181,10 +181,11 @@ void FlowGen::PopulateInitialFlows() {
   }
 }
 
-CommandResponse FlowGen::ProcessUpdatableArguments(const bess::pb::FlowGenArg &arg) {
-
+CommandResponse FlowGen::ProcessUpdatableArguments(
+    const bess::pb::FlowGenArg &arg) {
   if (arg.template_().length() == 0) {
-    if (strnlen(reinterpret_cast<const char*>(tmpl_), MAX_TEMPLATE_SIZE) == 0) {
+    if (strnlen(reinterpret_cast<const char *>(tmpl_), MAX_TEMPLATE_SIZE) ==
+        0) {
       return CommandFailure(EINVAL, "must specify 'template'");
     }
   } else {
@@ -434,7 +435,6 @@ bess::Packet *FlowGen::FillUdpPacket(struct flow *f) {
   return pkt;
 }
 
-
 bess::Packet *FlowGen::FillTcpPacket(struct flow *f) {
   bess::Packet *pkt;
 
@@ -532,7 +532,9 @@ struct task_result FlowGen::RunTask(Context *ctx, bess::PacketBatch *batch,
                                     void *) {
   if (children_overload_ > 0) {
     return {
-        .block = true, .packets = 0, .bits = 0,
+        .block = true,
+        .packets = 0,
+        .bits = 0,
     };
   }
 

--- a/core/modules/hash_lb.cc
+++ b/core/modules/hash_lb.cc
@@ -73,9 +73,9 @@ static inline int is_valid_gate(gate_idx_t gate) {
 }
 
 const Commands HashLB::cmds = {
-    {"set_mode", "HashLBCommandSetModeArg",
+    {"set_mode", bess::pb::HashLBCommandSetModeArg::descriptor(),
      MODULE_CMD_FUNC(&HashLB::CommandSetMode), Command::THREAD_UNSAFE},
-    {"set_gates", "HashLBCommandSetGatesArg",
+    {"set_gates", bess::pb::HashLBCommandSetGatesArg::descriptor(),
      MODULE_CMD_FUNC(&HashLB::CommandSetGates), Command::THREAD_UNSAFE}};
 
 CommandResponse HashLB::CommandSetMode(

--- a/core/modules/ip_checksum.cc
+++ b/core/modules/ip_checksum.cc
@@ -37,10 +37,10 @@
 enum { FORWARD_GATE = 0, FAIL_GATE };
 
 void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  using bess::utils::be16_t;
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Vlan;
+  using bess::utils::be16_t;
 
   int cnt = batch->cnt();
 
@@ -56,8 +56,8 @@ void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       data = qinq + 1;
       ether_type = qinq->ether_type;
       if (ether_type != be16_t(Ethernet::Type::kVlan)) {
-	EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
-	continue;
+        EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
+        continue;
       }
     }
 
@@ -75,7 +75,8 @@ void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     }
 
     if (verify_) {
-      EmitPacket(ctx, batch->pkts()[i], (VerifyIpv4Checksum(*ip)) ? FORWARD_GATE : FAIL_GATE);
+      EmitPacket(ctx, batch->pkts()[i],
+                 (VerifyIpv4Checksum(*ip)) ? FORWARD_GATE : FAIL_GATE);
     } else {
       ip->checksum = CalculateIpv4Checksum(*ip);
       EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);

--- a/core/modules/l2_forward.cc
+++ b/core/modules/l2_forward.cc
@@ -69,7 +69,7 @@ static int l2_init(struct l2_table *l2tbl, int size, int bucket) {
     return -EINVAL;
   }
 
-  l2tbl->table = new(std::nothrow) l2_entry[size * bucket]{};
+  l2tbl->table = new (std::nothrow) l2_entry[size * bucket]{};
 
   if (l2tbl->table == nullptr) {
     return -ENOMEM;
@@ -360,8 +360,8 @@ static uint64_t l2_addr_to_u64(char *addr) {
   return a | (b << 32);
 }
 
-/******************************************************************************/
-// TODO(barath): Move this test code elsewhere.
+  /******************************************************************************/
+  // TODO(barath): Move this test code elsewhere.
 
 #include <limits.h>
 #include <stdint.h>
@@ -542,15 +542,16 @@ static int parse_mac_addr(const char *str, char *addr) {
 /******************************************************************************/
 
 const Commands L2Forward::cmds = {
-    {"add", "L2ForwardCommandAddArg", MODULE_CMD_FUNC(&L2Forward::CommandAdd),
-     Command::THREAD_UNSAFE},
-    {"delete", "L2ForwardCommandDeleteArg",
+    {"add", bess::pb::L2ForwardCommandAddArg::descriptor(),
+     MODULE_CMD_FUNC(&L2Forward::CommandAdd), Command::THREAD_UNSAFE},
+    {"delete", bess::pb::L2ForwardCommandDeleteArg::descriptor(),
      MODULE_CMD_FUNC(&L2Forward::CommandDelete), Command::THREAD_UNSAFE},
-    {"set_default_gate", "L2ForwardCommandSetDefaultGateArg",
+    {"set_default_gate",
+     bess::pb::L2ForwardCommandSetDefaultGateArg::descriptor(),
      MODULE_CMD_FUNC(&L2Forward::CommandSetDefaultGate), Command::THREAD_SAFE},
-    {"lookup", "L2ForwardCommandLookupArg",
+    {"lookup", bess::pb::L2ForwardCommandLookupArg::descriptor(),
      MODULE_CMD_FUNC(&L2Forward::CommandLookup), Command::THREAD_SAFE},
-    {"populate", "L2ForwardCommandPopulateArg",
+    {"populate", bess::pb::L2ForwardCommandPopulateArg::descriptor(),
      MODULE_CMD_FUNC(&L2Forward::CommandPopulate), Command::THREAD_UNSAFE},
 };
 

--- a/core/modules/l4_checksum.cc
+++ b/core/modules/l4_checksum.cc
@@ -39,11 +39,11 @@
 enum { FORWARD_GATE = 0, FAIL_GATE };
 
 void L4Checksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  using bess::utils::be16_t;
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Tcp;
   using bess::utils::Udp;
+  using bess::utils::be16_t;
 
   int cnt = batch->cnt();
 
@@ -63,21 +63,23 @@ void L4Checksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       Udp *udp =
           reinterpret_cast<Udp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
       if (verify_) {
-	EmitPacket(ctx, batch->pkts()[i],
-		   (VerifyIpv4UdpChecksum(*ip, *udp)) ? FORWARD_GATE : FAIL_GATE);
+        EmitPacket(
+            ctx, batch->pkts()[i],
+            (VerifyIpv4UdpChecksum(*ip, *udp)) ? FORWARD_GATE : FAIL_GATE);
       } else {
-	udp->checksum = CalculateIpv4UdpChecksum(*ip, *udp);
-	EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
+        udp->checksum = CalculateIpv4UdpChecksum(*ip, *udp);
+        EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
       }
     } else if (ip->protocol == Ipv4::Proto::kTcp) {
       size_t ip_bytes = (ip->header_length) << 2;
       Tcp *tcp =
           reinterpret_cast<Tcp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
       if (verify_)
-	EmitPacket(ctx, batch->pkts()[i],
-		   (VerifyIpv4TcpChecksum(*ip, *tcp)) ? FORWARD_GATE : FAIL_GATE);
+        EmitPacket(
+            ctx, batch->pkts()[i],
+            (VerifyIpv4TcpChecksum(*ip, *tcp)) ? FORWARD_GATE : FAIL_GATE);
       else
-	tcp->checksum = CalculateIpv4TcpChecksum(*ip, *tcp);
+        tcp->checksum = CalculateIpv4TcpChecksum(*ip, *tcp);
     }
   }
 }

--- a/core/modules/measure.cc
+++ b/core/modules/measure.cc
@@ -54,10 +54,10 @@ static bool IsTimestamped(bess::Packet *pkt, size_t offset, uint64_t *time) {
 }
 
 const Commands Measure::cmds = {
-    {"get_summary", "MeasureCommandGetSummaryArg",
+    {"get_summary", bess::pb::MeasureCommandGetSummaryArg::descriptor(),
      MODULE_CMD_FUNC(&Measure::CommandGetSummary), Command::THREAD_SAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&Measure::CommandClear),
-     Command::THREAD_SAFE},
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&Measure::CommandClear), Command::THREAD_SAFE},
 };
 
 CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {

--- a/core/modules/mpls_pop.cc
+++ b/core/modules/mpls_pop.cc
@@ -36,7 +36,7 @@
 using bess::utils::Ethernet;
 using bess::utils::Mpls;
 
-const Commands MPLSPop::cmds = {{"set", "MplsPopArg",
+const Commands MPLSPop::cmds = {{"set", bess::pb::MplsPopArg::descriptor(),
                                  MODULE_CMD_FUNC(&MPLSPop::CommandSet),
                                  Command::THREAD_UNSAFE}};
 

--- a/core/modules/nat.cc
+++ b/core/modules/nat.cc
@@ -45,21 +45,21 @@
 using bess::utils::Ethernet;
 using bess::utils::Ipv4;
 using IpProto = bess::utils::Ipv4::Proto;
-using bess::utils::Udp;
-using bess::utils::Tcp;
-using bess::utils::Icmp;
 using bess::utils::ChecksumIncrement16;
 using bess::utils::ChecksumIncrement32;
-using bess::utils::UpdateChecksumWithIncrement;
+using bess::utils::Icmp;
+using bess::utils::Tcp;
+using bess::utils::Udp;
 using bess::utils::UpdateChecksum16;
+using bess::utils::UpdateChecksumWithIncrement;
 
 const Commands NAT::cmds = {
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&NAT::GetInitialArg),
-     Command::THREAD_SAFE},
-    {"get_runtime_config", "EmptyArg", MODULE_CMD_FUNC(&NAT::GetRuntimeConfig),
-     Command::THREAD_SAFE},
-    {"set_runtime_config", "EmptyArg", MODULE_CMD_FUNC(&NAT::SetRuntimeConfig),
-     Command::THREAD_SAFE}};
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&NAT::GetInitialArg), Command::THREAD_SAFE},
+    {"get_runtime_config", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&NAT::GetRuntimeConfig), Command::THREAD_SAFE},
+    {"set_runtime_config", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&NAT::SetRuntimeConfig), Command::THREAD_SAFE}};
 
 // TODO(torek): move this to set/get runtime config
 CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
@@ -88,7 +88,9 @@ CommandResponse NAT::Init(const bess::pb::NATArg &arg) {
     std::vector<PortRange> port_list;
     if (address_range.port_ranges().size() == 0) {
       port_list.emplace_back(PortRange{
-          .begin = 0u, .end = 65535u, .suspended = false,
+          .begin = 0u,
+          .end = 65535u,
+          .suspended = false,
       });
     }
     for (const auto &range : address_range.port_ranges()) {

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -32,10 +32,10 @@
 #include "../utils/format.h"
 
 const Commands PortInc::cmds = {
-    {"set_burst", "PortIncCommandSetBurstArg",
+    {"set_burst", bess::pb::PortIncCommandSetBurstArg::descriptor(),
      MODULE_CMD_FUNC(&PortInc::CommandSetBurst), Command::THREAD_SAFE},
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&PortInc::GetInitialArg),
-     Command::THREAD_SAFE},
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&PortInc::GetInitialArg), Command::THREAD_SAFE},
 };
 
 CommandResponse PortInc::Init(const bess::pb::PortIncArg &arg) {

--- a/core/modules/port_out.cc
+++ b/core/modules/port_out.cc
@@ -32,8 +32,8 @@
 #include "../utils/format.h"
 
 const Commands PortOut::cmds = {
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&PortOut::GetInitialArg),
-     Command::THREAD_SAFE},
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&PortOut::GetInitialArg), Command::THREAD_SAFE},
 };
 
 CommandResponse PortOut::Init(const bess::pb::PortOutArg &arg) {

--- a/core/modules/queue.cc
+++ b/core/modules/queue.cc
@@ -37,17 +37,17 @@
 #define DEFAULT_QUEUE_SIZE 1024
 
 const Commands Queue::cmds = {
-    {"set_burst", "QueueCommandSetBurstArg",
+    {"set_burst", bess::pb::QueueCommandSetBurstArg::descriptor(),
      MODULE_CMD_FUNC(&Queue::CommandSetBurst), Command::THREAD_SAFE},
-    {"set_size", "QueueCommandSetSizeArg",
+    {"set_size", bess::pb::QueueCommandSetSizeArg::descriptor(),
      MODULE_CMD_FUNC(&Queue::CommandSetSize), Command::THREAD_UNSAFE},
-    {"get_status", "QueueCommandGetStatusArg",
+    {"get_status", bess::pb::QueueCommandGetStatusArg::descriptor(),
      MODULE_CMD_FUNC(&Queue::CommandGetStatus), Command::THREAD_SAFE},
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&Queue::GetInitialArg),
-     Command::THREAD_SAFE},
-    {"get_runtime_config", "EmptyArg",
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&Queue::GetInitialArg), Command::THREAD_SAFE},
+    {"get_runtime_config", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&Queue::GetRuntimeConfig), Command::THREAD_SAFE},
-    {"set_runtime_config", "QueueArg",
+    {"set_runtime_config", bess::pb::QueueArg::descriptor(),
      MODULE_CMD_FUNC(&Queue::SetRuntimeConfig), Command::THREAD_UNSAFE}};
 
 int Queue::Resize(int slots) {

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -33,9 +33,9 @@
 #include "../port.h"
 #include "../utils/format.h"
 
-const Commands QueueInc::cmds = {{"set_burst", "QueueIncCommandSetBurstArg",
-                                  MODULE_CMD_FUNC(&QueueInc::CommandSetBurst),
-                                  Command::THREAD_SAFE}};
+const Commands QueueInc::cmds = {
+    {"set_burst", bess::pb::QueueIncCommandSetBurstArg::descriptor(),
+     MODULE_CMD_FUNC(&QueueInc::CommandSetBurst), Command::THREAD_SAFE}};
 
 CommandResponse QueueInc::Init(const bess::pb::QueueIncArg &arg) {
   const char *port_name;

--- a/core/modules/random_split.cc
+++ b/core/modules/random_split.cc
@@ -38,9 +38,9 @@ static inline bool is_valid_gate(gate_idx_t gate) {
 }
 
 const Commands RandomSplit::cmds = {
-    {"set_droprate", "RandomSplitCommandSetDroprateArg",
+    {"set_droprate", bess::pb::RandomSplitCommandSetDroprateArg::descriptor(),
      MODULE_CMD_FUNC(&RandomSplit::CommandSetDroprate), Command::THREAD_UNSAFE},
-    {"set_gates", "RandomSplitCommandSetGatesArg",
+    {"set_gates", bess::pb::RandomSplitCommandSetGatesArg::descriptor(),
      MODULE_CMD_FUNC(&RandomSplit::CommandSetGates), Command::THREAD_UNSAFE}};
 
 CommandResponse RandomSplit::Init(const bess::pb::RandomSplitArg &arg) {

--- a/core/modules/random_update.cc
+++ b/core/modules/random_update.cc
@@ -33,10 +33,10 @@
 using bess::utils::be32_t;
 
 const Commands RandomUpdate::cmds = {
-    {"add", "RandomUpdateArg", MODULE_CMD_FUNC(&RandomUpdate::CommandAdd),
-     Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&RandomUpdate::CommandClear),
-     Command::THREAD_UNSAFE},
+    {"add", bess::pb::RandomUpdateArg::descriptor(),
+     MODULE_CMD_FUNC(&RandomUpdate::CommandAdd), Command::THREAD_UNSAFE},
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&RandomUpdate::CommandClear), Command::THREAD_UNSAFE},
 };
 
 CommandResponse RandomUpdate::Init(const bess::pb::RandomUpdateArg &arg) {

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -30,7 +30,7 @@
 #include "replicate.h"
 
 const Commands Replicate::cmds = {
-    {"set_gates", "ReplicateCommandSetGatesArg",
+    {"set_gates", bess::pb::ReplicateCommandSetGatesArg::descriptor(),
      MODULE_CMD_FUNC(&Replicate::CommandSetGates), Command::THREAD_UNSAFE},
 };
 

--- a/core/modules/rewrite.cc
+++ b/core/modules/rewrite.cc
@@ -35,10 +35,10 @@
 #include "../utils/copy.h"
 
 const Commands Rewrite::cmds = {
-    {"add", "RewriteArg", MODULE_CMD_FUNC(&Rewrite::CommandAdd),
-     Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&Rewrite::CommandClear),
-     Command::THREAD_UNSAFE},
+    {"add", bess::pb::RewriteArg::descriptor(),
+     MODULE_CMD_FUNC(&Rewrite::CommandAdd), Command::THREAD_UNSAFE},
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&Rewrite::CommandClear), Command::THREAD_UNSAFE},
 };
 
 CommandResponse Rewrite::Init(const bess::pb::RewriteArg &arg) {

--- a/core/modules/round_robin.cc
+++ b/core/modules/round_robin.cc
@@ -31,9 +31,9 @@
 #include "round_robin.h"
 
 const Commands RoundRobin::cmds = {
-    {"set_mode", "RoundRobinCommandSetModeArg",
+    {"set_mode", bess::pb::RoundRobinCommandSetModeArg::descriptor(),
      MODULE_CMD_FUNC(&RoundRobin::CommandSetMode), Command::THREAD_UNSAFE},
-    {"set_gates", "RoundRobinCommandSetGatesArg",
+    {"set_gates", bess::pb::RoundRobinCommandSetGatesArg::descriptor(),
      MODULE_CMD_FUNC(&RoundRobin::CommandSetGates), Command::THREAD_UNSAFE},
 };
 

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -40,7 +40,7 @@
 using bess::metadata::mt_offset_t;
 
 const Commands SetMetadata::cmds = {
-    {"get_initial_arg", "EmptyArg",
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&SetMetadata::GetInitialArg), Command::THREAD_SAFE},
 };
 

--- a/core/modules/source.cc
+++ b/core/modules/source.cc
@@ -31,9 +31,9 @@
 #include "source.h"
 
 const Commands Source::cmds = {
-    {"set_pkt_size", "SourceCommandSetPktSizeArg",
+    {"set_pkt_size", bess::pb::SourceCommandSetPktSizeArg::descriptor(),
      MODULE_CMD_FUNC(&Source::CommandSetPktSize), Command::THREAD_SAFE},
-    {"set_burst", "SourceCommandSetBurstArg",
+    {"set_burst", bess::pb::SourceCommandSetBurstArg::descriptor(),
      MODULE_CMD_FUNC(&Source::CommandSetBurst), Command::THREAD_SAFE},
 };
 

--- a/core/modules/static_nat.cc
+++ b/core/modules/static_nat.cc
@@ -36,11 +36,11 @@
 #include "../utils/udp.h"
 
 const Commands StaticNAT::cmds = {
-    {"get_initial_arg", "EmptyArg", MODULE_CMD_FUNC(&StaticNAT::GetInitialArg),
-     Command::THREAD_SAFE},
-    {"get_runtime_config", "EmptyArg",
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&StaticNAT::GetInitialArg), Command::THREAD_SAFE},
+    {"get_runtime_config", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&StaticNAT::GetRuntimeConfig), Command::THREAD_SAFE},
-    {"set_runtime_config", "EmptyArg",
+    {"set_runtime_config", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&StaticNAT::SetRuntimeConfig), Command::THREAD_SAFE}};
 
 CommandResponse StaticNAT::Init(const bess::pb::StaticNATArg &arg) {

--- a/core/modules/update.cc
+++ b/core/modules/update.cc
@@ -33,10 +33,10 @@
 #include "../utils/endian.h"
 
 const Commands Update::cmds = {
-    {"add", "UpdateArg", MODULE_CMD_FUNC(&Update::CommandAdd),
-     Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&Update::CommandClear),
-     Command::THREAD_UNSAFE},
+    {"add", bess::pb::UpdateArg::descriptor(),
+     MODULE_CMD_FUNC(&Update::CommandAdd), Command::THREAD_UNSAFE},
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&Update::CommandClear), Command::THREAD_UNSAFE},
 };
 
 CommandResponse Update::Init(const bess::pb::UpdateArg &arg) {

--- a/core/modules/vlan_pop.cc
+++ b/core/modules/vlan_pop.cc
@@ -33,8 +33,8 @@
 #include "../utils/ether.h"
 
 void VLANPop::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  using bess::utils::be16_t;
   using bess::utils::Ethernet;
+  using bess::utils::be16_t;
 
   int cnt = batch->cnt();
 

--- a/core/modules/vlan_push.cc
+++ b/core/modules/vlan_push.cc
@@ -36,13 +36,13 @@
 #include "../utils/format.h"
 #include "../utils/simd.h"
 
+using bess::utils::Ethernet;
 using bess::utils::be16_t;
 using bess::utils::be32_t;
-using bess::utils::Ethernet;
 
 const Commands VLANPush::cmds = {
-    {"set_tci", "VLANPushArg", MODULE_CMD_FUNC(&VLANPush::CommandSetTci),
-     Command::THREAD_UNSAFE},
+    {"set_tci", bess::pb::VLANPushArg::descriptor(),
+     MODULE_CMD_FUNC(&VLANPush::CommandSetTci), Command::THREAD_UNSAFE},
 };
 
 CommandResponse VLANPush::Init(const bess::pb::VLANPushArg &arg) {
@@ -74,9 +74,10 @@ void VLANPush::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       ethh = _mm_loadu_si128(reinterpret_cast<__m128i *>(new_head + 4));
       be16_t tpid(be16_t::swap(_mm_extract_epi16(ethh, 6)));
 
-      ethh = _mm_insert_epi32(ethh, (tpid.value() == Ethernet::Type::kVlan)
-                                        ? qinq_tag.raw_value()
-                                        : vlan_tag.raw_value(),
+      ethh = _mm_insert_epi32(ethh,
+                              (tpid.value() == Ethernet::Type::kVlan)
+                                  ? qinq_tag.raw_value()
+                                  : vlan_tag.raw_value(),
                               3);
 
       _mm_storeu_si128(reinterpret_cast<__m128i *>(new_head), ethh);

--- a/core/modules/vlan_split.cc
+++ b/core/modules/vlan_split.cc
@@ -33,8 +33,8 @@
 #include "../utils/ether.h"
 
 void VLANSplit::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  using bess::utils::be16_t;
   using bess::utils::Ethernet;
+  using bess::utils::be16_t;
 
   int cnt = batch->cnt();
 

--- a/core/modules/vxlan_decap.cc
+++ b/core/modules/vxlan_decap.cc
@@ -56,11 +56,11 @@ CommandResponse VXLANDecap::Init(
 }
 
 void VXLANDecap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  using bess::utils::be32_t;
   using bess::utils::Ethernet;
   using bess::utils::Ipv4;
   using bess::utils::Udp;
   using bess::utils::Vxlan;
+  using bess::utils::be32_t;
 
   int cnt = batch->cnt();
 

--- a/core/modules/wildcard_match.cc
+++ b/core/modules/wildcard_match.cc
@@ -56,19 +56,20 @@ static inline int is_valid_gate(gate_idx_t gate) {
 }
 
 const Commands WildcardMatch::cmds = {
-    {"get_initial_arg", "EmptyArg",
+    {"get_initial_arg", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&WildcardMatch::GetInitialArg), Command::THREAD_SAFE},
-    {"get_runtime_config", "EmptyArg",
+    {"get_runtime_config", bess::pb::EmptyArg::descriptor(),
      MODULE_CMD_FUNC(&WildcardMatch::GetRuntimeConfig), Command::THREAD_SAFE},
-    {"set_runtime_config", "WildcardMatchConfig",
+    {"set_runtime_config", bess::pb::WildcardMatchConfig::descriptor(),
      MODULE_CMD_FUNC(&WildcardMatch::SetRuntimeConfig), Command::THREAD_UNSAFE},
-    {"add", "WildcardMatchCommandAddArg",
+    {"add", bess::pb::WildcardMatchCommandAddArg::descriptor(),
      MODULE_CMD_FUNC(&WildcardMatch::CommandAdd), Command::THREAD_UNSAFE},
-    {"delete", "WildcardMatchCommandDeleteArg",
+    {"delete", bess::pb::WildcardMatchCommandDeleteArg::descriptor(),
      MODULE_CMD_FUNC(&WildcardMatch::CommandDelete), Command::THREAD_UNSAFE},
-    {"clear", "EmptyArg", MODULE_CMD_FUNC(&WildcardMatch::CommandClear),
-     Command::THREAD_UNSAFE},
-    {"set_default_gate", "WildcardMatchCommandSetDefaultGateArg",
+    {"clear", bess::pb::EmptyArg::descriptor(),
+     MODULE_CMD_FUNC(&WildcardMatch::CommandClear), Command::THREAD_UNSAFE},
+    {"set_default_gate",
+     bess::pb::WildcardMatchCommandSetDefaultGateArg::descriptor(),
      MODULE_CMD_FUNC(&WildcardMatch::CommandSetDefaultGate),
      Command::THREAD_SAFE}};
 
@@ -136,7 +137,8 @@ CommandResponse WildcardMatch::Init(const bess::pb::WildcardMatchArg &arg) {
 inline gate_idx_t WildcardMatch::LookupEntry(const wm_hkey_t &key,
                                              gate_idx_t def_gate) {
   struct WmData result = {
-      .priority = INT_MIN, .ogate = def_gate,
+      .priority = INT_MIN,
+      .ogate = def_gate,
   };
 
   for (auto &tuple : tuples_) {

--- a/core/modules/worker_split.cc
+++ b/core/modules/worker_split.cc
@@ -31,8 +31,8 @@
 #include "worker_split.h"
 
 const Commands WorkerSplit::cmds = {
-    {"reset", "WorkerSplitArg", MODULE_CMD_FUNC(&WorkerSplit::CommandReset),
-     Command::THREAD_UNSAFE}};
+    {"reset", bess::pb::WorkerSplitArg::descriptor(),
+     MODULE_CMD_FUNC(&WorkerSplit::CommandReset), Command::THREAD_UNSAFE}};
 
 CommandResponse WorkerSplit::Init(const bess::pb::WorkerSplitArg &arg) {
   return CommandReset(arg);

--- a/core/port.cc
+++ b/core/port.cc
@@ -128,11 +128,12 @@ bool PortBuilder::RegisterPortClass(
     std::function<Port *()> port_generator, const std::string &class_name,
     const std::string &name_template, const std::string &help_text,
     std::function<CommandResponse(Port *, const google::protobuf::Any &)>
-        init_func) {
+        init_func,
+    const Descriptor *init_descriptor) {
   all_port_builders_holder().emplace(
       std::piecewise_construct, std::forward_as_tuple(class_name),
       std::forward_as_tuple(port_generator, class_name, name_template,
-                            help_text, init_func));
+                            help_text, init_func, init_descriptor));
   return true;
 }
 

--- a/core/port_test.cc
+++ b/core/port_test.cc
@@ -286,9 +286,9 @@ TEST_F(PortTest, InitDrivers) {
 // Checks that when we register a portclass, the global table of PortBuilders
 // contains it.
 TEST_F(PortBuilderTest, RegisterPortClassDirectCall) {
-  PortBuilder::RegisterPortClass([]() { return new DummyPort(); }, "DummyPort",
-                                 "dummy_port", "dummy help",
-                                 PORT_INIT_FUNC(&DummyPort::Init));
+  PortBuilder::RegisterPortClass(
+      []() { return new DummyPort(); }, "DummyPort", "dummy_port", "dummy help",
+      PORT_INIT_FUNC(&DummyPort::Init), PORT_INIT_DESC(&DummyPort::Init));
 
   ASSERT_EQ(1, PortBuilder::all_port_builders().size());
   ASSERT_EQ(1, PortBuilder::all_port_builders().count("DummyPort"));

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -31,6 +31,7 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
 import "error.proto";
 
 /// - "timestamp" represents the current time in seconds since the Epoch.
@@ -620,4 +621,18 @@ message PauseWorkerRequest {
 
 message ResumeWorkerRequest {
   int64 wid = 1;    /// ID of the worker to be resumed
+}
+
+//  -------------------------------------------------------------------------
+//  Introspection commands
+//  -------------------------------------------------------------------------
+message DumpDescriptorsResponse {
+  message CommandDescriptors {
+    map<string, google.protobuf.DescriptorProto> commands = 1;
+  }
+
+  Error error = 1;
+	map<string, google.protobuf.DescriptorProto> modules = 2;
+	map<string, CommandDescriptors> module_commands = 3;
+	map<string, google.protobuf.DescriptorProto> ports = 4;
 }

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -312,4 +312,9 @@ service BESSControl {
 
   /// Enable/Disable a resume hook.
   rpc ConfigureResumeHook (ConfigureResumeHookRequest) returns (CommandResponse) {}
+
+  //  -------------------------------------------------------------------------
+  //  Introspection
+  //  -------------------------------------------------------------------------
+  rpc DumpDescriptors (EmptyRequest) returns (DumpDescriptorsResponse) {}
 }


### PR DESCRIPTION
This has been useful for a project I've been working on. Might be worth including a version upstream.

This change is backwards compatible with modules that elect to keep exposing their argument/init types as strings