### PR TITLE
fix replicate first index gate issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Brent Stephens
 * M. Asim Jamshed
 * Yan Grunenberger
+* Farbod Shahinfar

--- a/core/modules/replicate.cc
+++ b/core/modules/replicate.cc
@@ -74,7 +74,7 @@ void Replicate::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
         EmitPacket(ctx, newpkt, gates_[j]);
       }
     }
-    EmitPacket(ctx, tocopy, 0);
+    EmitPacket(ctx, tocopy, gates_[0]);
   }
 }
 


### PR DESCRIPTION
when the first gate of the replicate gates array is not zero the
behavior of the code was unexpected. it was emiting packets on
gate zero instead of using the gate in the array with zero index.