### PR TITLE
Update DPDK version to 19.11.4

### DIFF
--- a/bessctl/conf/port/vhost/launch_vm.py
+++ b/bessctl/conf/port/vhost/launch_vm.py
@@ -175,7 +175,7 @@ def run_forward(vm_id, num_nics):
         nics += ' 00:1{nic}.0'.format(nic=i)
 
     scp(vm_id, os.path.join(bess_dir, 'bin/dpdk-devbind.py'), '')
-    scp(vm_id, os.path.join(bess_dir, 'deps/dpdk-19.11.3/build/app/testpmd'), '')
+    scp(vm_id, os.path.join(bess_dir, 'deps/dpdk-19.11.4/build/app/testpmd'), '')
 
     # virtio-pci devices should not be bound to any driver
     cmd = ssh_cmd(vm_id, 'sudo ./dpdk-devbind.py -u %s' % nics)

--- a/build.py
+++ b/build.py
@@ -89,7 +89,7 @@ BESS_DIR = os.path.dirname(os.path.abspath(__file__))
 DEPS_DIR = '%s/deps' % BESS_DIR
 
 DPDK_URL = 'https://fast.dpdk.org/rel'
-DPDK_VER = 'dpdk-19.11.3'
+DPDK_VER = 'dpdk-19.11.4'
 DPDK_TARGET = 'x86_64-native-linuxapp-gcc'
 
 kernel_release = cmd('uname -r', quiet=True).strip()

--- a/core/Makefile
+++ b/core/Makefile
@@ -61,7 +61,7 @@ endif
 
 HAS_PKG_CONFIG := $(shell command -v $(PKG_CONFIG) 2>&1 >/dev/null && echo yes || echo no)
 
-RTE_SDK ?= $(abspath ../deps/dpdk-19.11.3)
+RTE_SDK ?= $(abspath ../deps/dpdk-19.11.4)
 RTE_TARGET ?= $(shell uname -m)-native-linuxapp-gcc
 DPDK_LIB ?= dpdk
 

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -29,7 +29,7 @@ ARG BESS_DPDK_BRANCH=master
 RUN cd /build/bess && \
 	curl -s -L https://github.com/NetSys/bess/archive/${BESS_DPDK_BRANCH}.tar.gz | tar zx --strip-components=1 && \
 	./build.py dpdk && \
-	cp /build/bess/deps/dpdk-19.11.3/build/app/testpmd /usr/local/bin/ && \
+	cp /build/bess/deps/dpdk-19.11.4/build/app/testpmd /usr/local/bin/ && \
 	rm -rf /build/bess
 
 ENV CCACHE_DIR=/tmp/ccache


### PR DESCRIPTION
This release has vfio related fixes required to run on the latest
LTS kernel. Fixes #1016