### PR TITLE
Copy metadata when making a packet copy

### DIFF
--- a/core/packet.cc
+++ b/core/packet.cc
@@ -58,7 +58,9 @@ Packet *Packet::copy(const Packet *src) {
 
   bess::utils::CopyInlined(dst->append(src->total_len()), src->head_data(),
                            src->total_len(), true);
-
+  bess::utils::CopyInlined(&dst->metadata_, &src->metadata_,
+                           SNBUF_METADATA, true);
+  
   return dst;
 }
 


### PR DESCRIPTION
Copy was copying only data, losing all metadata in the process.

This resulted in very erratic behaviour of Replicate in a pipeline
which relies on metadata to identify packets.