### PR TITLE
Add ifIndex and RPF checks

### DIFF
--- a/core/modules/port_inc.h
+++ b/core/modules/port_inc.h
@@ -35,6 +35,27 @@
 #include "../pb/module_msg.pb.h"
 #include "../port.h"
 
+
+using bess::metadata::kMetadataAttrMaxSize;
+using bess::metadata::mt_offset_t;
+
+typedef struct {
+  uint8_t bytes[kMetadataAttrMaxSize];
+} value_t;
+typedef struct {
+  uint8_t bytes[kMetadataAttrMaxSize];
+} mask_t;
+
+struct Attr {
+  std::string name;
+  value_t value;
+  mask_t mask;
+  int offset;
+  size_t size;
+  bool do_mask;
+  int shift;  // in bytes for now
+};
+
 class PortInc final : public Module {
  public:
   static const gate_idx_t kNumIGates = 0;
@@ -63,6 +84,7 @@ class PortInc final : public Module {
   Port *port_;
   int prefetch_;
   int burst_;
+  std::vector<struct Attr> attrs_;
 };
 
 #endif  // BESS_MODULES_PORTINC_H_

--- a/core/modules/port_out.h
+++ b/core/modules/port_out.h
@@ -62,6 +62,8 @@ class PortOut final : public Module {
 
  private:
   Port *port_;
+  int attr_id_;
+  bool rpfcheck_;
 
   int worker_queues_[Worker::kMaxWorkers];
 
@@ -69,6 +71,8 @@ class PortOut final : public Module {
   int queue_users_[MAX_QUEUES_PER_DIR];
 
   mcslock_t queue_locks_[MAX_QUEUES_PER_DIR];
+
+  int SendBatch(bess::PacketBatch *batch, queue_t qid);
 };
 
 #endif  // BESS_MODULES_PORTOUT_H_

--- a/core/packet.cc
+++ b/core/packet.cc
@@ -58,7 +58,9 @@ Packet *Packet::copy(const Packet *src) {
 
   bess::utils::CopyInlined(dst->append(src->total_len()), src->head_data(),
                            src->total_len(), true);
-
+  bess::utils::CopyInlined(&dst->metadata_, &src->metadata_,
+                           SNBUF_METADATA, true);
+  
   return dst;
 }
 

--- a/core/port.cc
+++ b/core/port.cc
@@ -45,9 +45,31 @@
 
 std::map<std::string, Port *> PortBuilder::all_ports_;
 
+static uint64_t cur_ifIndex = 1;
+static bool rolled_over = false;
+
 Port *PortBuilder::CreatePort(const std::string &name) const {
   Port *p = port_generator_();
   p->set_name(name);
+  if (rolled_over) {
+    for (p->ifIndex = 1; p->ifIndex < UINT64_MAX; p->ifIndex++) {
+      bool found = false;
+      for (auto const &pi : all_ports_) {
+        if (pi.second->ifIndex == p->ifIndex) {
+            found = true;
+            break;
+        }              
+      }
+      if (!found) {
+            break;
+      }
+    }
+  } else { 
+    p->ifIndex = ++cur_ifIndex;
+    if (cur_ifIndex == UINT64_MAX) {
+        rolled_over = true;
+    }
+  }
   p->set_port_builder(this);
   return p;
 }

--- a/core/port.h
+++ b/core/port.h
@@ -293,6 +293,8 @@ class Port {
 
   const PortBuilder *port_builder() const { return port_builder_; }
 
+  uint64_t get_ifIndex() const { return ifIndex; }
+
  protected:
   friend class PortBuilder;
 
@@ -301,6 +303,7 @@ class Port {
 
   // Current configuration
   Conf conf_;
+  uint64_t ifIndex;
 
  private:
   static const size_t kDefaultIncQueueSize = 1024;

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -770,6 +770,7 @@ message PortIncArg {
  */
 message PortOutArg {
   string port = 1; /// The portname to connect to.
+  bool rpfcheck = 2; /// Allow reflection of packets to source port
 }
 
 /**


### PR DESCRIPTION
This is a basic requirement for most switching/routing algorithms. 

Example - most trivial possible "hub" - two ports wired to a replicator and two Linux instances off them: 

UnixSocketPort(name='u0', path="/var/tmp/uml-test-0")
UnixSocketPort(name='u1', path="/var/tmp/uml-test-1")
PortInc(port="u0") -> repl::Replicate(gates=[0,1])
PortInc(port="u1") -> repl 
repl:0 -> PortOut(port="u0")
repl:1 -> PortOut(port="u1")

This behaves pretty badly with BESS as is because the packets sent out of port 0 are also received on port 0 and vice versa.

Adding this change and enabling it results in the correct expected behaviour and correct high throughput.

UnixSocketPort(name='u0', path="/var/tmp/uml-test-0")
UnixSocketPort(name='u1', path="/var/tmp/uml-test-1")
PortInc(port="u0") -> repl::Replicate(gates=[0,1])
PortInc(port="u1") -> repl 
repl:0 -> PortOut(port="u0", rpfcheck=1)
repl:1 -> PortOut(port="u1", rpfcheck=1)

I have tried to preserve packet batching to the extent possible for packets being sent. As a result of the "drops" the batches may now be a bit smaller, but it will still batch.
 
A.