### PR TITLE
Ensure that kMaxBurst is explicitly defined

### DIFF
--- a/core/pktbatch.h
+++ b/core/pktbatch.h
@@ -67,7 +67,7 @@ class PacketBatch {
     bess::utils::CopyInlined(pkts_, src->pkts_, cnt_ * sizeof(Packet *));
   }
 
-  static const size_t kMaxBurst = 32;
+  inline static const size_t kMaxBurst = 32;
 
  private:
   int cnt_;


### PR DESCRIPTION
kMaxBurst was declared and assigned a value, but not explicitly defined. This can cause issues when linking in cases where a reference
may be taken of kMaxBurst (say, passing it to std::min()) and the constant can't be fully optimized out.

This was actually fixed years ago in #522 but ended up being reverted accidentally during a refactor in #820.

With C++17 now, we don't have to put the definition in a source file, we can just add inline and that takes care of it.