### PR TITLE
ARM support for BESS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/sse2neon"]
+	path = deps/sse2neon
+	url = https://github.com/DLTcollab/sse2neon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,4 @@ Please add your name to the end of this file and include this file to the PR, un
 * Brent Stephens
 * M. Asim Jamshed
 * Yan Grunenberger
+* Md Ashfaqur Rahaman

--- a/build.py
+++ b/build.py
@@ -41,6 +41,7 @@ import shlex
 import subprocess
 import textwrap
 import argparse
+import platform
 
 
 def cmd(cmd, quiet=False, shell=False):
@@ -90,7 +91,14 @@ DEPS_DIR = '%s/deps' % BESS_DIR
 
 DPDK_URL = 'https://fast.dpdk.org/rel'
 DPDK_VER = 'dpdk-19.11.4'
-DPDK_TARGET = 'x86_64-native-linuxapp-gcc'
+
+if platform.uname().machine == 'x86_64':
+    DPDK_TARGET = 'x86_64-native-linuxapp-gcc'
+elif platform.uname().machine == 'aarch64':
+    DPDK_TARGET = 'arm64-armv8a-linux-gcc'
+else:
+    print("Unsupported platform")
+    sys.exit(1)
 
 kernel_release = cmd('uname -r', quiet=True).strip()
 
@@ -299,10 +307,10 @@ def configure_dpdk():
     check_mlx()
     generate_dpdk_extra_mk()
 
-    arch = os.getenv('CPU')
-    if arch:
-        print(' - Building DPDK with -march=%s' % arch)
-        set_config(DPDK_CONFIG, "CONFIG_RTE_MACHINE", arch)
+    arch = platform.uname().machine
+    if arch == 'aarch64':
+        print(' - Building DPDK with -march=%s' % 'armv8-a')
+        set_config(DPDK_CONFIG, "CONFIG_RTE_MACHINE", 'armv8-a')
 
 
 def makeflags():

--- a/core/Makefile
+++ b/core/Makefile
@@ -60,9 +60,18 @@ ifeq "$(CXXCOMPILER)" "g++"
 endif
 
 HAS_PKG_CONFIG := $(shell command -v $(PKG_CONFIG) 2>&1 >/dev/null && echo yes || echo no)
+ARCH := $(shell uname -m)
 
 RTE_SDK ?= $(abspath ../deps/dpdk-19.11.4)
-RTE_TARGET ?= $(shell uname -m)-native-linuxapp-gcc
+
+ifeq ($(ARCH),x86_64)
+  RTE_TARGET ?= $(shell uname -m)-native-linuxapp-gcc
+else ifeq ($(ARCH),aarch64)
+  RTE_TARGET ?= arm64-armv8a-linux-gcc
+else
+  $(error Unsupported architecture)
+endif
+
 DPDK_LIB ?= dpdk
 
 ifneq ($(wildcard $(RTE_SDK)/$(RTE_TARGET)/*),)
@@ -75,6 +84,10 @@ else ifneq ($(wildcard $(RTE_SDK)/build/*),)
 else ifneq ($(MAKECMDGOALS),clean)
   $(error DPDK is not available. Make sure $(abspath $(RTE_SDK)) is available and built)
 endif
+
+# Library for translating Intel SSE intrinsics
+# to ARM64 NEON
+SSE2NEON_DIR ?= $(abspath ../deps/sse2neon)
 
 # We always want these libraries to be dynamically linked even when the
 # user requests a static build.
@@ -108,9 +121,16 @@ endif
 # these headers.  Should fix the warnings.  Using -isystem also disables
 # -MMD dependency recording (should we use -MD?).
 COREDIR := $(abspath .)
-CPU ?= native
+ifeq ($(ARCH),x86_64)
+  CPU ?= native
+else ifeq ($(ARCH),aarch64)
+  CPU ?= armv8-a+fp+simd
+else
+  $(error Unsupported architecture)
+endif
 CXXFLAGS += -std=c++17 -g3 -ggdb3 -march=$(CPU) \
             -isystem $(DPDK_INC_DIR) -isystem $(COREDIR) \
+            -isystem $(SSE2NEON_DIR) \
             -isystem $(dir $<).. -isystem $(COREDIR)/modules \
             -D_GNU_SOURCE \
             -Werror -Wall -Wextra -Wcast-align -Wno-error=deprecated-declarations \
@@ -131,6 +151,10 @@ endif
 # Disable GNU_UNIQUE symbol for g++
 ifeq "$(shell expr $(CXXCOMPILER) = g++)" "1"
   CXXFLAGS += -fno-gnu-unique
+endif
+
+ifeq ($(ARCH),aarch64)
+  CXXFLAGS += -DRTE_FORCE_INTRINSICS
 endif
 
 LDFLAGS += -rdynamic -L$(DPDK_LIB_DIR) -Wl,-rpath=$(DPDK_LIB_DIR) -pthread

--- a/core/gate_hooks/pcapng.cc
+++ b/core/gate_hooks/pcapng.cc
@@ -62,7 +62,7 @@ T PadSize(T a, T b) {
 
 // Return the single hex digit representing `nibble`.  If it cannot be
 // represented, return the char 'X'.
-char NibbleToHD(char nibble) {
+char NibbleToHD(signed char nibble) {
   if (nibble >= 0 && nibble <= 9) {
     return nibble + '0';
   } else if (nibble >= 10 && nibble <= 15) {

--- a/core/kmod/llring.h
+++ b/core/kmod/llring.h
@@ -149,7 +149,13 @@ typedef uint64_t phys_addr_t;
 #define llring_likely(x) __builtin_expect(!!(x), 1)
 #define llring_unlikely(x) __builtin_expect(!!(x), 0)
 
+#if __x86_64
 #include <emmintrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
 
 static inline void llring_pause(void) { _mm_pause(); }
 

--- a/core/modules/ip_lookup.cc
+++ b/core/modules/ip_lookup.cc
@@ -39,7 +39,13 @@
 #include "../utils/format.h"
 #include "../utils/ip.h"
 
+#if __x86_64
 #define VECTOR_OPTIMIZATION 1
+#elif __aarch64__
+#define VECTOR_OPTIMIZATION 0
+#else
+#error Unsupported architecture
+#endif
 
 static inline int is_valid_gate(gate_idx_t gate) {
   return (gate < MAX_GATES || gate == DROP_GATE);
@@ -84,7 +90,7 @@ void IPLookup::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
   gate_idx_t default_gate = default_gate_;
 
   int cnt = batch->cnt();
-  int i;
+  int i = 0;
 
 #if VECTOR_OPTIMIZATION
   // Convert endianness for four addresses at the same time

--- a/core/modules/set_metadata.cc
+++ b/core/modules/set_metadata.cc
@@ -28,7 +28,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#if __x86_64
 #include <x86intrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
 
 #include <cmath>
 

--- a/core/utils/bits.h
+++ b/core/utils/bits.h
@@ -31,7 +31,13 @@
 #define BESS_UTILS_BITS_H_
 
 #include <glog/logging.h>
+#if __x86_64
 #include <x86intrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
 
 #include <algorithm>
 

--- a/core/utils/common.h
+++ b/core/utils/common.h
@@ -91,7 +91,13 @@ static inline uint64_t align_ceil_pow2(uint64_t v) {
 #define INST_BARRIER() asm volatile("" ::: "memory")
 #define LOAD_BARRIER() INST_BARRIER()
 #define STORE_BARRIER() INST_BARRIER()
+#if (__i368 || __x86_64)
 #define FULL_BARRIER() asm volatile("mfence" ::: "memory")
+#elif __aarch64__
+#define FULL_BARRIER() asm volatile("dmb " "ish" ::: "memory")
+#else
+#error Unsupported architecture
+#endif
 
 // Put this in the declarations for a class to be uncopyable.
 #define DISALLOW_COPY(TypeName) TypeName(const TypeName &) = delete

--- a/core/utils/copy.h
+++ b/core/utils/copy.h
@@ -31,7 +31,13 @@
 #define BESS_UTILS_COPY_H_
 
 #include <glog/logging.h>
+#if __x86_64
 #include <x86intrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
 
 #include <cstring>
 

--- a/core/utils/http_parser.cc
+++ b/core/utils/http_parser.cc
@@ -32,7 +32,51 @@
 #ifdef _MSC_VER
 #include <nmmintrin.h>
 #else
+#if (__i386 || __x86_64)
 #include <x86intrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
+#endif
+
+#ifdef __aarch64__
+
+#define _SIDD_UBYTE_OPS 0x00
+#define _SIDD_CMP_RANGES 0x04
+#define _SIDD_LEAST_SIGNIFICANT 0x00
+
+typedef union __attribute__((aligned(16))) __oword {
+   int64x2_t m128i;
+   uint8_t m128i_u8[16];
+} __oword;
+
+static inline int _mm_cmpestri(int64x2_t str1, int len1, int64x2_t str2, int len2, int mode) {
+  __oword a, b;
+  a.m128i = str1;
+  b.m128i = str2;
+
+  // mode is unused
+  (void)mode;
+
+  int i,j, result;
+
+  for (i = 0; i < len2; i++) {
+    for (j = 0; j < len1; j+=2) {
+      if (b.m128i_u8[i] >= a.m128i_u8[j] && b.m128i_u8[i] <= a.m128i_u8[j+1]) 
+        break;
+    } 
+  }
+
+  result = i;
+
+  if (result == len2)
+    result = 16;
+
+  return result;
+}
+
 #endif
 
 /* $Id$ */

--- a/core/utils/simd.h
+++ b/core/utils/simd.h
@@ -33,7 +33,13 @@
 
 #include <string>
 
+#if __x86_64
 #include <x86intrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
 
 #include <glog/logging.h>
 
@@ -41,8 +47,10 @@
 #define __ymm_aligned __attribute__((aligned(32)))
 #define __zmm_aligned __attribute__((aligned(64)))
 
+#if __x86_64
 #if !__SSE4_2__
 #error CPU must be at least Intel Nehalem equivalent (SSE4.2 required)
+#endif
 #endif
 
 std::string m128i_to_str(__m128i a);

--- a/core/utils/syscallthread.h
+++ b/core/utils/syscallthread.h
@@ -35,7 +35,13 @@
 #include <cerrno>
 #include <thread>
 
+#if __x86_64
 #include <nmmintrin.h>
+#elif __aarch64__
+#include <sse2neon.h>
+#else
+#error Unsupported architecture
+#endif
 #include <signal.h>
 
 namespace bess {

--- a/core/utils/time.h
+++ b/core/utils/time.h
@@ -40,9 +40,19 @@
 extern uint64_t tsc_hz;
 
 static inline uint64_t rdtsc(void) {
+  uint64_t val;
+
+#if (__i386 || __x86_64)
   uint32_t hi, lo;
   __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
-  return (uint64_t)lo | ((uint64_t)hi << 32);
+  val = (uint64_t)lo | ((uint64_t)hi << 32);
+#elif __aarch64__
+  __asm__ __volatile__("mrs %0, cntvct_el0" : "=r" (val));
+#else
+#error Unsupported architecture
+#endif
+  
+  return val;
 }
 
 static inline uint64_t tsc_to_ns(uint64_t cycles) {


### PR DESCRIPTION
* Added build flags for compiling DPDK on ARM
* Added [sse2neon](https://github.com/DLTcollab/sse2neon) as a submodule for translating Intel SSE intrinsics to
  Arm/Aarch64 NEON implementation.
* Implemented SSE4.2 _mm_cmpstri as not supported by sse2neon. Adapted
  from: https://github.com/apache/impala/blob/master/be/src/util/sse-util.h
* Added equivalent arm64 asm for x86_64 asm.
* Vector optimization turned off for Arm64 in IPLookup module.

All tests passed except `TscToUs.Frequency` as on ARM reported tsc_hz is 50MHz (cross checked with `mrs x0, cntfrq_el0` instruction which returns [Timer Counter Frequency register](https://developer.arm.com/documentation/ddi0488/c/ch09s03s01)). This is failing as the test requires frequency >= 500MHz.

Closes #1028